### PR TITLE
Refactor tus upload

### DIFF
--- a/api/s5/file.go
+++ b/api/s5/file.go
@@ -93,7 +93,7 @@ func NewFile(params FileParams) *S5File {
 
 func (f *S5File) Exists() bool {
 	ctx := context.Background()
-	exists, _ := f.tus.UploadExists(ctx, f.hash)
+	exists, _ := f.tus.UploadHashExists(ctx, f.hash)
 
 	if exists {
 		return true
@@ -181,7 +181,7 @@ func (f *S5File) init(offset int64) error {
 
 func (f *S5File) Record() (*metadata.UploadMetadata, error) {
 	if f.record == nil {
-		exists, tusRecord := f.tus.UploadExists(context.Background(), f.hash)
+		exists, tusRecord := f.tus.UploadHashExists(context.Background(), f.hash)
 
 		if exists {
 			size, err := f.tus.GetUploadSize(context.Background(), f.hash)

--- a/db/models/tus_upload.go
+++ b/db/models/tus_upload.go
@@ -9,7 +9,7 @@ func init() {
 
 type TusUpload struct {
 	gorm.Model
-	Hash       []byte `gorm:"type:binary(32);uniqueIndex:idx_hash_deleted"`
+	Hash       []byte `gorm:"type:binary(32);"`
 	MimeType   string
 	UploadID   string `gorm:"uniqueIndex"`
 	UploaderID uint
@@ -17,5 +17,4 @@ type TusUpload struct {
 	Uploader   User `gorm:"foreignKey:UploaderID"`
 	Protocol   string
 	Completed  bool
-	DeletedAt  gorm.DeletedAt `gorm:"uniqueIndex:idx_hash_deleted"`
 }

--- a/protocols/s5/s5.go
+++ b/protocols/s5/s5.go
@@ -245,7 +245,7 @@ func (s S5ProviderStore) CanProvide(hash *encoding.Multihash, kind []types.Stora
 		case types.StorageLocationTypeArchive, types.StorageLocationTypeFile, types.StorageLocationTypeFull:
 			rawHash := hash.HashBytes()
 
-			if exists, upload := s.tus.UploadExists(ctx, rawHash); exists {
+			if exists, upload := s.tus.UploadHashExists(ctx, rawHash); exists {
 				if upload.Completed {
 					return true
 				}

--- a/renter/renter.go
+++ b/renter/renter.go
@@ -145,6 +145,23 @@ func (r *RenterDefault) GetSetting(ctx context.Context, setting string, out any)
 	return nil
 }
 
+func (r *RenterDefault) UploadExists(ctx context.Context, bucket string, fileName string) (bool, error) {
+	var siaUpload models.SiaUpload
+
+	siaUpload.Bucket = bucket
+	siaUpload.Key = fileName
+
+	ret := r.db.WithContext(ctx).Model(&siaUpload).First(&siaUpload)
+	if ret.Error != nil {
+		if errors.Is(ret.Error, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, ret.Error
+	}
+
+	return true, nil
+}
+
 func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *MultiPartUploadParams) error {
 	size := params.Size
 	rf := params.ReaderFactory


### PR DESCRIPTION
* always allow to upload to s3 storage
* the cron tasks need to check for existing pins (which implicate checks upload records)
* check for existing uploads in progress
* run a poll function for now until the upload is done
* skipping the upload and calling the cleanup task if prior checks flip doUpload
* upload the file if doUpload isn't flipped

More context at a bugged PR https://github.com/LumeWeb/portal/pull/36