### PR TITLE
refactor(core): need to copy BasicEvent to our Event struct so we don…

### DIFF
--- a/core/events.go
+++ b/core/events.go
@@ -14,10 +14,105 @@ var (
 
 type Eventer interface {
 	event.Event
+	SetName(name string) Eventer
 }
 
+var _ Eventer = (*Event)(nil)
+
 type Event struct {
-	event.BasicEvent
+	// event name
+	name string
+	// user data.
+	data map[string]any
+	// target
+	target any
+	// mark is aborted
+	aborted bool
+}
+
+// Abort event loop exec
+func (e *Event) Abort(abort bool) {
+	e.aborted = abort
+}
+
+// Fill event data
+func (e *Event) Fill(target any, data event.M) *Event {
+	if data != nil {
+		e.data = data
+	}
+
+	e.target = target
+	return e
+}
+
+// AttachTo add current event to the event manager.
+func (e *Event) AttachTo(em event.ManagerFace) {
+	em.AddEvent(e)
+}
+
+// Get data by index
+func (e *Event) Get(key string) any {
+	if v, ok := e.data[key]; ok {
+		return v
+	}
+
+	return nil
+}
+
+// Add value by key
+func (e *Event) Add(key string, val any) {
+	if _, ok := e.data[key]; !ok {
+		e.Set(key, val)
+	}
+}
+
+// Set value by key
+func (e *Event) Set(key string, val any) {
+	if e.data == nil {
+		e.data = make(map[string]any)
+	}
+
+	e.data[key] = val
+}
+
+// Name get event name
+func (e *Event) Name() string {
+	return e.name
+}
+
+// Data get all data
+func (e *Event) Data() map[string]any {
+	return e.data
+}
+
+// IsAborted check.
+func (e *Event) IsAborted() bool {
+	return e.aborted
+}
+
+// Target get target
+func (e *Event) Target() any {
+	return e.target
+}
+
+// SetName set event name
+func (e *Event) SetName(name string) Eventer {
+	e.name = name
+	return e
+}
+
+// SetData set data to the event
+func (e *Event) SetData(data event.M) event.Event {
+	if data != nil {
+		e.data = data
+	}
+	return e
+}
+
+// SetTarget set event target
+func (e *Event) SetTarget(target any) *Event {
+	e.target = target
+	return e
 }
 
 func RegisterEvent(id string, event Eventer) {
@@ -27,6 +122,8 @@ func RegisterEvent(id string, event Eventer) {
 	if _, ok := eventRegistry[id]; ok {
 		panic(fmt.Sprintf("event %s already registered", id))
 	}
+
+	event.SetName(id)
 
 	eventRegistry[id] = event
 }

--- a/core/storage.go
+++ b/core/storage.go
@@ -51,10 +51,6 @@ type StorageObjectUploadedEvent struct {
 	objectMetadata *UploadMetadata
 }
 
-func (e *StorageObjectUploadedEvent) Name() string {
-	return EVENT_STORAGE_OBJECT_UPLOADED
-}
-
 func (e *StorageObjectUploadedEvent) ObjectMetadata() *UploadMetadata {
 	return e.objectMetadata
 }

--- a/core/user.go
+++ b/core/user.go
@@ -60,10 +60,6 @@ type UserSubdomainSetEvent struct {
 	Event
 }
 
-func (e *UserSubdomainSetEvent) Name() string {
-	return EVENT_USER_SUBDOMAIN_SET
-}
-
 func (e *UserSubdomainSetEvent) Subdomain() string {
 	return e.Get("subdomain").(string)
 }


### PR DESCRIPTION
…'t have clone and can ensure the right name property instance is accessed.

Additionally defining Name() methods per event are no longer needed.