### PR TITLE
refactor: update cron system to use generics so that we don't need to…

### DIFF
--- a/service/cron.go
+++ b/service/cron.go
@@ -560,7 +560,7 @@ func (c *CronServiceDefault) RegisterEntity(service core.Cronable) {
 	c.entities = append(c.entities, service)
 }
 
-func (c *CronServiceDefault) RegisterTask(name string, taskFunc core.CronTaskFunction, taskDefFunc core.CronTaskDefArgsFactoryFunction, taskArgFunc core.CronTaskArgsFactoryFunction, recurring bool) {
+func (c *CronServiceDefault) RegisterTask(name string, taskFunc core.CronTaskFunction[core.CronTaskArgs], taskDefFunc core.CronTaskDefArgsFactoryFunction, taskArgFunc core.CronTaskArgsFactoryFunction, recurring bool) {
 	c.tasks.Store(name, taskFunc)
 	c.taskDefs.Store(name, taskDefFunc)
 	c.taskArgs.Store(name, taskArgFunc)

--- a/service/internal/renter/price_tracker.go
+++ b/service/internal/renter/price_tracker.go
@@ -40,9 +40,9 @@ type PriceTracker struct {
 }
 
 func (p PriceTracker) RegisterTasks(crn core.CronService) error {
-	crn.RegisterTask(cronTaskRecordSiaRateName, p.recordRate, cronTaskRecordSiaRateDefinition, nopArgsFactory, true)
-	crn.RegisterTask(cronTaskImportSiaPriceHistoryName, p.importPrices, core.CronTaskDefinitionOneTimeJob, nopArgsFactory, false)
-	crn.RegisterTask(cronTaskUpdateSiaRenterPriceName, p.updatePrices, core.CronTaskDefinitionOneTimeJob, nopArgsFactory, false)
+	crn.RegisterTask(cronTaskRecordSiaRateName, core.CronTaskFuncHandler(p.recordRate), cronTaskRecordSiaRateDefinition, nopArgsFactory, true)
+	crn.RegisterTask(cronTaskImportSiaPriceHistoryName, core.CronTaskFuncHandler(p.importPrices), core.CronTaskDefinitionOneTimeJob, nopArgsFactory, false)
+	crn.RegisterTask(cronTaskUpdateSiaRenterPriceName, core.CronTaskFuncHandler(p.updatePrices), core.CronTaskDefinitionOneTimeJob, nopArgsFactory, false)
 	return nil
 }
 
@@ -69,7 +69,7 @@ func (p PriceTracker) ScheduleJobs(crn core.CronService) error {
 	return nil
 }
 
-func (p PriceTracker) recordRate(_ any, _ core.Context) error {
+func (p PriceTracker) recordRate(_ core.CronTaskArgs, _ core.Context) error {
 	rate, _, err := p.api.GetExchangeRate()
 	if err != nil {
 		p.logger.Error("failed to get exchange rate", zap.Error(err))


### PR DESCRIPTION
… check the arguments type on every cron task function, and create a wrapper helper that is required by creating a dummy cron args interface to be satisfied, requiring a compile type check.