### PR TITLE
refactor(core): always wrap the ctx db getter in a withcontext to tie…

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -108,7 +108,7 @@ func (ctx *defaultContext) ExitFuncs() []func(Context) error {
 }
 
 func (ctx *defaultContext) DB() *gorm.DB {
-	return ctx.db
+	return ctx.db.WithContext(ctx)
 }
 
 func (ctx *defaultContext) Logger() *Logger {


### PR DESCRIPTION
… its lifetime to the app context