### PR TITLE
refactor(user): update UpdateAccountInfo to use map[string]any

### DIFF
--- a/core/user.go
+++ b/core/user.go
@@ -26,7 +26,7 @@ type UserService interface {
 	CreateAccount(email string, password string, verifyEmail bool) (*models.User, error)
 
 	// UpdateAccountInfo updates the account information of the user with the given ID.
-	UpdateAccountInfo(userId uint, info models.User) error
+	UpdateAccountInfo(userId uint, info map[string]any) error
 
 	// UpdateAccountName updates the first and last name of the user with the given ID.
 	UpdateAccountName(userId uint, firstName string, lastName string) error

--- a/service/auth.go
+++ b/service/auth.go
@@ -220,7 +220,7 @@ func (a AuthServiceDefault) doLogin(user *models.User, ip string, bypassSecurity
 
 	now := time.Now()
 
-	err := a.user.UpdateAccountInfo(user.ID, models.User{LastLoginIP: ip, LastLogin: &now})
+	err := a.user.UpdateAccountInfo(user.ID, map[string]any{"last_login_ip": ip, "last_login": &now})
 	if err != nil {
 		return "", err
 	}

--- a/service/otp.go
+++ b/service/otp.go
@@ -3,7 +3,6 @@ package service
 import (
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
-	"go.lumeweb.com/portal/db/models"
 	"gorm.io/gorm"
 )
 
@@ -58,7 +57,7 @@ func (o OTPServiceDefault) OTPGenerate(userId uint) (string, error) {
 		return "", core.NewAccountError(core.ErrKeyOTPGenerationFailed, otpErr)
 	}
 
-	err = o.user.UpdateAccountInfo(user.ID, models.User{OTPSecret: otp})
+	err = o.user.UpdateAccountInfo(user.ID, map[string]interface{}{"otp_secret": otp})
 
 	if err != nil {
 		return "", err
@@ -92,9 +91,9 @@ func (o OTPServiceDefault) OTPEnable(userId uint, code string) error {
 		return core.ErrInvalidOTPCode
 	}
 
-	return o.user.UpdateAccountInfo(userId, models.User{OTPEnabled: true})
+	return o.user.UpdateAccountInfo(userId, map[string]interface{}{"otp_enabled": true})
 }
 
 func (o OTPServiceDefault) OTPDisable(userId uint) error {
-	return o.user.UpdateAccountInfo(userId, models.User{OTPEnabled: false, OTPSecret: ""})
+	return o.user.UpdateAccountInfo(userId, map[string]interface{}{"otp_enabled": false, "otp_secret": ""})
 }

--- a/service/password.go
+++ b/service/password.go
@@ -110,7 +110,7 @@ func (p PasswordResetServiceDefault) ResetPassword(email string, token string, p
 		return err
 	}
 
-	err = p.user.UpdateAccountInfo(reset.UserID, models.User{PasswordHash: passwordHash})
+	err = p.user.UpdateAccountInfo(reset.UserID, map[string]interface{}{"password_hash": passwordHash})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Change UpdateAccountInfo method signature in core/user.go
- Modify BeforeUpdate hook in db/models/user.go to handle map input
- Update all service calls to use map[string]any instead of models.User
- Improve error handling and type checking in affected files