### PR TITLE
fix(middleware): correct access check and rename authz.go to access.go

### DIFF
--- a/middleware/access.go
+++ b/middleware/access.go
@@ -27,8 +27,9 @@ func AccessMiddleware(ctx core.Context) func(http.Handler) http.Handler {
 				return
 			}
 
-			ok, err := accessService.CheckAccess(m.ID, r.URL.Hostname(), r.URL.Path, r.Method)
+			ok, err := accessService.CheckAccess(m.ID, r.URL.Hostname(), r.Host, r.Method)
 			if err != nil {
+				deny()
 				return
 			}
 			if err != nil || !ok {


### PR DESCRIPTION
- Rename middleware/authz.go to middleware/access.go
- Update CheckAccess function to use r.Host instead of r.URL.Path
- Add deny() call on CheckAccess error