### PR TITLE
fix(middleware): correct parameters in CheckAccess function call

### DIFF
--- a/middleware/access.go
+++ b/middleware/access.go
@@ -27,7 +27,7 @@ func AccessMiddleware(ctx core.Context) func(http.Handler) http.Handler {
 				return
 			}
 
-			ok, err := accessService.CheckAccess(m.ID, r.URL.Hostname(), r.Host, r.Method)
+			ok, err := accessService.CheckAccess(m.ID, r.Host, r.URL.Path, r.Method)
 			if err != nil {
 				deny()
 				return


### PR DESCRIPTION
- Update CheckAccess function call to use r.Host and r.URL.Path
- Remove redundant r.URL.Hostname() parameter