### PR TITLE
fix(config): enhance struct processing in fieldProcessorRecursive

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -56,6 +56,9 @@ func (d DatabaseConfig) Defaults() map[string]any {
 
 	if d.Type == "sqlite" || d.Type == "" {
 		def["file"] = "portal.db"
+		if d.Type == "" {
+			def["type"] = "sqlite"
+		}
 	}
 
 	if d.Type == "mysql" {


### PR DESCRIPTION
- Set default database type to sqlite when unspecified
- Refactor struct processing logic in fieldProcessorRecursive
- Add depth parameter to track recursion level
- Process top-level struct separately using depth check
- Extract processStruct function to determine struct eligibility