### PR TITLE
chore(ci): update release workflow concurrency and triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,11 @@ name: Release
 on:
   push:
     branches:
-      - "develop"
+      - "**"
     paths:
       - '.changeset/**'
+      - '.changeset-release/**'
+      - 'package.json'
     tags:
       - '**'
   pull_request:
@@ -15,8 +17,12 @@ on:
       - '**'
     paths:
       - '.changeset/**'
+      - '.changeset-release/**'
+      - 'package.json'
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   publish:


### PR DESCRIPTION
- Add package.json to workflow triggers
- Update concurrency settings with PR number/SHA
- Add .changeset-release to path triggers
- Extend branch trigger coverage to all branches
- Improve concurrent job handling with cancel-in-progress

This expands the workflow's scope while preventing redundant runs.