### PR TITLE
refactor(renter): add Hosts method for direct usable host querying

### DIFF
--- a/core/renter.go
+++ b/core/renter.go
@@ -42,6 +42,7 @@ type RenterService interface {
 	GetAllowlistedHosts(ctx context.Context) ([]types.PublicKey, error)
 	SlabSize(ctx context.Context) (uint64, error)
 	ScanHost(ctx context.Context, host types.PublicKey, hostIP string) (api.RHPScanResponse, error)
+	Hosts(ctx context.Context) ([]api.Host, error)
 
 	Service
 }

--- a/service/internal/renter/host_scanner.go
+++ b/service/internal/renter/host_scanner.go
@@ -270,14 +270,14 @@ func (s *HostScanner) processHostBatches(ctx core.Context, cfg api.AutopilotConf
 		s.logPriceSettings(logger, currentSettings, priceTracking.validHostsCount)
 
 		// Test if we have enough hosts
-		evalResp, err := s.renter.TestAutoPilotConfig(ctx, cfg)
+		usableHosts, err := s.renter.Hosts(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to test autopilot config: %w", err)
 		}
 
-		if evalResp.Usable >= uint64(requiredHosts) {
+		if (len(usableHosts)) >= requiredHosts {
 			logger.Info("Found enough usable hosts, updating final gouging settings",
-				zap.Uint64("usable", evalResp.Usable),
+				zap.Int("usable", len(usableHosts)),
 				zap.Int("required", requiredHosts))
 
 			// Now that we have enough hosts, update the gouging settings
@@ -295,7 +295,7 @@ func (s *HostScanner) processHostBatches(ctx core.Context, cfg api.AutopilotConf
 		}
 
 		logger.Info("Need more hosts, continuing search",
-			zap.Uint64("usableHosts", evalResp.Usable),
+			zap.Int("usableHosts", len(usableHosts)),
 			zap.Int("required", requiredHosts))
 
 		page++

--- a/service/renter.go
+++ b/service/renter.go
@@ -398,6 +398,14 @@ func (r *RenterDefault) ScanHost(ctx context.Context, host types.PublicKey, host
 	return r.workerClient.RHPScan(ctx, host, hostIP, 30*time.Second)
 }
 
+func (r *RenterDefault) Hosts(ctx context.Context) ([]api.Host, error) {
+	return r.busClient.SearchHosts(ctx, api.SearchHostOptions{
+		Limit:         -1,
+		FilterMode:    "allowed",
+		UsabilityMode: "usable",
+	})
+}
+
 func (r *RenterDefault) SlabSize(ctx context.Context) (uint64, error) {
 	var settings api.RedundancySettings
 	err := r.GetSetting(ctx, api.SettingRedundancy, &settings)


### PR DESCRIPTION
- Add new Hosts() method to RenterDefault to directly query usable hosts
- Replace TestAutoPilotConfig usage in host scanner with direct Hosts call
- Update logging to reflect actual host count instead of evaluation response
- Adjust interface to include new Hosts method

This change simplifies the host scanning logic by directly querying usable hosts instead of using the autopilot config test evaluation.