### PR TITLE
feat(renter): add renterd cluster support

### DIFF
--- a/config/sia.go
+++ b/config/sia.go
@@ -27,9 +27,7 @@ func (s SiaConfig) Defaults() map[string]interface{} {
 }
 
 func (s SiaConfig) Validate() error {
-	if s.Key == "" {
-		return errors.New("core.storage.sia.key is required")
-	}
+
 	if s.URL == "" {
 		return errors.New("core.storage.sia.url is required")
 	}

--- a/service/internal/renter/client_manager.go
+++ b/service/internal/renter/client_manager.go
@@ -1,0 +1,205 @@
+package renter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"go.etcd.io/etcd/client/v3"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+	"sync"
+	"time"
+)
+
+type ClientType string
+
+const (
+	ClientTypeBus    ClientType = "bus"
+	ClientTypeWorker ClientType = "worker"
+	ClusterKey       string     = "/discovery/renterd"
+)
+
+const (
+	nodeTTL = 30 * time.Second // Time after which a node is considered dead if not updated
+)
+
+type NodeInfo struct {
+	URL       string     `json:"url"`
+	Type      ClientType `json:"type"`
+	LastSeen  time.Time  `json:"last_seen"`
+	Priority  int        `json:"priority"`
+	IsHealthy bool       `json:"is_healthy"`
+}
+
+type ClientManager struct {
+	ctx       core.Context
+	etcdKey   string
+	nodes     map[ClientType][]NodeInfo
+	nodesLock sync.RWMutex
+	logger    *core.Logger
+}
+
+func NewClientManager(ctx core.Context) *ClientManager {
+	return &ClientManager{
+		ctx:     ctx,
+		etcdKey: ClusterKey,
+		nodes:   make(map[ClientType][]NodeInfo),
+		logger:  ctx.Logger(),
+	}
+}
+
+func (cm *ClientManager) Start() error {
+	if !cm.ctx.Config().Config().Core.ClusterEnabled() {
+		return nil
+	}
+
+	client, err := cm.ctx.Config().Config().Core.Clustered.Etcd.Client()
+	if err != nil {
+		return fmt.Errorf("failed to create etcd client: %w", err)
+	}
+
+	// Initial load of nodes
+	if err := cm.loadNodes(client); err != nil {
+		return err
+	}
+
+	// Watch for changes
+	go cm.watchNodes(client)
+
+	return nil
+}
+
+func (cm *ClientManager) loadNodes(client *clientv3.Client) error {
+	resp, err := client.Get(context.Background(), cm.etcdKey, clientv3.WithPrefix())
+	if err != nil {
+		return fmt.Errorf("failed to get nodes from etcd: %w", err)
+	}
+
+	cm.nodesLock.Lock()
+	defer cm.nodesLock.Unlock()
+
+	for _, kv := range resp.Kvs {
+		var node NodeInfo
+		if err := json.Unmarshal(kv.Value, &node); err != nil {
+			cm.logger.Error("failed to unmarshal node info", zap.Error(err))
+			continue
+		}
+		cm.nodes[node.Type] = append(cm.nodes[node.Type], node)
+	}
+
+	return nil
+}
+
+func (cm *ClientManager) watchNodes(client *clientv3.Client) {
+	watchChan := client.Watch(context.Background(), cm.etcdKey, clientv3.WithPrefix())
+	for watchResp := range watchChan {
+		for _, event := range watchResp.Events {
+			var node NodeInfo
+			if err := json.Unmarshal(event.Kv.Value, &node); err != nil {
+				cm.logger.Error("failed to unmarshal node info from watch event", zap.Error(err))
+				continue
+			}
+
+			cm.nodesLock.Lock()
+			switch event.Type {
+			case clientv3.EventTypePut:
+				cm.updateNode(node)
+			case clientv3.EventTypeDelete:
+				cm.removeNode(node)
+			}
+			cm.nodesLock.Unlock()
+		}
+	}
+}
+
+func (cm *ClientManager) updateNode(node NodeInfo) {
+	nodes := cm.nodes[node.Type]
+	node.LastSeen = time.Now()
+	for i, existing := range nodes {
+		if existing.URL == node.URL {
+			nodes[i] = node
+			return
+		}
+	}
+	cm.nodes[node.Type] = append(cm.nodes[node.Type], node)
+}
+func (cm *ClientManager) updateNodeLastUsed(node *NodeInfo) {
+	if !cm.ctx.Config().Config().Core.ClusterEnabled() {
+		return
+	}
+
+	client, err := cm.ctx.Config().Config().Core.Clustered.Etcd.Client()
+	if err != nil {
+		cm.logger.Error("failed to get etcd client for updating node last used time", zap.Error(err))
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	nodeKey := fmt.Sprintf("%s/%s", cm.etcdKey, node.URL)
+	data, err := json.Marshal(node)
+	if err != nil {
+		cm.logger.Error("failed to marshal node info", zap.Error(err))
+		return
+	}
+
+	// Just use a short lease - we only need it for the update
+	lease, err := client.Grant(ctx, 1) // 1 second lease
+	if err != nil {
+		cm.logger.Error("failed to create lease", zap.Error(err))
+		return
+	}
+
+	_, err = client.Put(ctx, nodeKey, string(data), clientv3.WithLease(lease.ID))
+	if err != nil {
+		cm.logger.Error("failed to update node last used time in etcd", zap.Error(err))
+		// Revoke the lease to clean up
+		if _, revokeErr := client.Revoke(ctx, lease.ID); revokeErr != nil {
+			cm.logger.Error("failed to revoke lease after PUT failure", zap.Error(revokeErr))
+		}
+		return
+	}
+}
+
+func (cm *ClientManager) removeNode(node NodeInfo) {
+	nodes := cm.nodes[node.Type]
+	for i, existing := range nodes {
+		if existing.URL == node.URL {
+			cm.nodes[node.Type] = append(nodes[:i], nodes[i+1:]...)
+			return
+		}
+	}
+}
+
+func (cm *ClientManager) GetNextNode(clientType ClientType) (*NodeInfo, error) {
+	cm.nodesLock.Lock()
+	nodes := cm.nodes[clientType]
+	if len(nodes) == 0 {
+		cm.nodesLock.Unlock()
+		return nil, fmt.Errorf("no available %s nodes", clientType)
+	}
+
+	now := time.Now()
+	var selectedNode *NodeInfo
+
+	// Just find a healthy node - no need to track LastUsed locally
+	for i := range nodes {
+		if now.Sub(nodes[i].LastSeen) > nodeTTL {
+			nodes[i].IsHealthy = false
+			continue
+		}
+
+		if nodes[i].IsHealthy {
+			selectedNode = &nodes[i]
+			break
+		}
+	}
+	cm.nodesLock.Unlock()
+
+	if selectedNode == nil {
+		return nil, fmt.Errorf("no healthy %s nodes available", clientType)
+	}
+
+	return selectedNode, nil
+}

--- a/service/renter.go
+++ b/service/renter.go
@@ -44,6 +44,7 @@ type RenterDefault struct {
 	config          config.Manager
 	db              *gorm.DB
 	logger          *core.Logger
+	clientManager   *renterInternal.ClientManager
 }
 
 func NewRenterService() (*RenterDefault, []core.ContextBuilderOption, error) {
@@ -82,8 +83,12 @@ func (r *RenterDefault) ID() string {
 }
 
 func (r *RenterDefault) CreateBucketIfNotExists(bucket string) error {
-	_, err := r.busClient.Bucket(context.Background(), bucket)
+	client, err := r.getBusClient()
+	if err != nil {
+		return err
+	}
 
+	_, err = client.Bucket(context.Background(), bucket)
 	if err == nil {
 		return nil
 	}
@@ -92,7 +97,7 @@ func (r *RenterDefault) CreateBucketIfNotExists(bucket string) error {
 		return err
 	}
 
-	err = r.busClient.CreateBucket(context.Background(), bucket, api.CreateBucketOptions{
+	err = client.CreateBucket(context.Background(), bucket, api.CreateBucketOptions{
 		Policy: api.BucketPolicy{
 			PublicReadAccess: false,
 		},
@@ -105,8 +110,13 @@ func (r *RenterDefault) CreateBucketIfNotExists(bucket string) error {
 }
 
 func (r *RenterDefault) UploadObject(ctx context.Context, file io.Reader, bucket string, fileName string) error {
+	client, err := r.getWorkerClient()
+	if err != nil {
+		return err
+	}
+
 	fileName = "/" + strings.TrimLeft(fileName, "/")
-	_, err := r.workerClient.UploadObject(ctx, file, bucket, fileName, api.UploadObjectOptions{})
+	_, err = client.UploadObject(ctx, file, bucket, fileName, api.UploadObjectOptions{})
 
 	if err != nil {
 		return err
@@ -124,42 +134,91 @@ func (r *RenterDefault) ImportObjectMetadata(ctx context.Context, bucket string,
 }
 
 func (r *RenterDefault) init() error {
-	addr := r.config.Config().Core.Storage.Sia.URL
-	passwd := r.config.Config().Core.Storage.Sia.Key
-
-	addrURL, err := url.Parse(addr)
-
-	if err != nil {
-		return err
+	r.clientManager = renterInternal.NewClientManager(r.ctx)
+	if err := r.clientManager.Start(); err != nil {
+		return fmt.Errorf("failed to start client manager: %w", err)
 	}
 
-	addrURL.Path = "/api/worker"
+	if !r.ctx.Config().Config().Core.ClusterEnabled() {
+		addr := r.config.Config().Core.Storage.Sia.URL
+		passwd := r.config.Config().Core.Storage.Sia.Key
 
-	r.workerClient = workerClient.New(addrURL.String(), passwd)
+		if passwd == "" {
+			return errors.New("core.storage.sia.key is required")
+		}
 
-	addrURL.Path = "/api/bus"
+		addrURL, err := url.Parse(addr)
+		if err != nil {
+			return err
+		}
 
-	r.busClient = busClient.New(addrURL.String(), passwd)
+		addrURL.Path = "/api/worker"
+		r.workerClient = workerClient.New(addrURL.String(), passwd)
 
-	addrURL.Path = "/api/autopilot"
+		addrURL.Path = "/api/bus"
+		r.busClient = busClient.New(addrURL.String(), passwd)
 
-	r.autoPilotClient = autoPilotClient.NewClient(addrURL.String(), passwd)
+		addrURL.Path = "/api/autopilot"
+		r.autoPilotClient = autoPilotClient.NewClient(addrURL.String(), passwd)
 
-	_, stateErr := r.busClient.State()
-	if stateErr != nil {
-		return fmt.Errorf("renter status check: failed to get renter state: %w", stateErr)
+		_, stateErr := r.busClient.State()
+		if stateErr != nil {
+			return fmt.Errorf("renter status check: failed to get renter state: %w", stateErr)
+		}
 	}
 
 	return nil
 }
 
+func (r *RenterDefault) getBusClient() (*busClient.Client, error) {
+	if !r.ctx.Config().Config().Core.ClusterEnabled() {
+		if r.busClient == nil {
+			return nil, fmt.Errorf("bus client not initialized")
+		}
+		return r.busClient, nil
+	}
+
+	node, err := r.clientManager.GetNextNode(renterInternal.ClientTypeBus)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get bus node: %w", err)
+	}
+
+	client := busClient.New(node.URL, r.config.Config().Core.Storage.Sia.Key)
+	return client, nil
+}
+
+func (r *RenterDefault) getWorkerClient() (*workerClient.Client, error) {
+	if !r.ctx.Config().Config().Core.ClusterEnabled() {
+		if r.workerClient == nil {
+			return nil, fmt.Errorf("worker client not initialized")
+		}
+		return r.workerClient, nil
+	}
+
+	node, err := r.clientManager.GetNextNode(renterInternal.ClientTypeWorker)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get worker node: %w", err)
+	}
+
+	client := workerClient.New(node.URL, r.config.Config().Core.Storage.Sia.Key)
+	return client, nil
+}
+
 func (r *RenterDefault) GetObject(ctx context.Context, bucket string, fileName string, options api.DownloadObjectOptions) (*api.GetObjectResponse, error) {
+	client, err := r.getWorkerClient()
+	if err != nil {
+		return nil, err
+	}
 	fileName = "/" + strings.TrimLeft(fileName, "/")
-	return r.workerClient.GetObject(ctx, bucket, fileName, options)
+	return client.GetObject(ctx, bucket, fileName, options)
 }
 
 func (r *RenterDefault) GetObjectMetadata(ctx context.Context, bucket string, fileName string) (*api.Object, error) {
-	ret, err := r.busClient.Object(ctx, bucket, fileName, api.GetObjectOptions{})
+	client, err := r.getBusClient()
+	if err != nil {
+		return nil, err
+	}
+	ret, err := client.Object(ctx, bucket, fileName, api.GetObjectOptions{})
 
 	if err != nil {
 		return nil, err
@@ -169,11 +228,19 @@ func (r *RenterDefault) GetObjectMetadata(ctx context.Context, bucket string, fi
 }
 
 func (r *RenterDefault) DeleteObjectMetadata(ctx context.Context, bucket string, fileName string) error {
-	return r.busClient.DeleteObject(ctx, bucket, fileName, api.DeleteObjectOptions{})
+	client, err := r.getBusClient()
+	if err != nil {
+		return err
+	}
+	return client.DeleteObject(ctx, bucket, fileName, api.DeleteObjectOptions{})
 }
 
 func (r *RenterDefault) GetSetting(ctx context.Context, setting string, out any) error {
-	err := r.busClient.Setting(ctx, setting, out)
+	client, err := r.getBusClient()
+	if err != nil {
+		return err
+	}
+	err = client.Setting(ctx, setting, out)
 
 	if err != nil {
 		return err
@@ -236,7 +303,11 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 	}
 
 	if len(uploadId) == 0 {
-		upload, err := r.busClient.CreateMultipartUpload(ctx, bucket, fileName, api.CreateMultipartOptions{GenerateKey: true})
+		client, err := r.getBusClient()
+		if err != nil {
+			return err
+		}
+		upload, err := client.CreateMultipartUpload(ctx, bucket, fileName, api.CreateMultipartOptions{GenerateKey: true})
 		if err != nil {
 			return err
 		}
@@ -249,7 +320,11 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 			return err
 		}
 	} else {
-		existing, err := r.busClient.MultipartUploadParts(ctx, bucket, fileName, uploadId, 0, 0)
+		client, err := r.getBusClient()
+		if err != nil {
+			return err
+		}
+		existing, err := client.MultipartUploadParts(ctx, bucket, fileName, uploadId, 0, 0)
 
 		if err != nil {
 			uploadId = ""
@@ -291,7 +366,11 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 		opts := api.UploadMultipartUploadPartOptions{}
 		opts.EncryptionOffset = &offset
 
-		ret, err := r.workerClient.UploadMultipartUploadPart(ctx, lr, bucket, fileName, uploadId, partNumber, opts)
+		client, err := r.getWorkerClient()
+		if err != nil {
+			return err
+		}
+		ret, err := client.UploadMultipartUploadPart(ctx, lr, bucket, fileName, uploadId, partNumber, opts)
 		if err != nil {
 			return err
 		}
@@ -310,7 +389,11 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 		}
 	}
 
-	_, err = r.busClient.CompleteMultipartUpload(ctx, bucket, fileName, uploadId, uploadParts, api.CompleteMultipartOptions{})
+	client, err := r.getBusClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.CompleteMultipartUpload(ctx, bucket, fileName, uploadId, uploadParts, api.CompleteMultipartOptions{})
 	if err != nil {
 		return err
 	}
@@ -387,11 +470,19 @@ func (r *RenterDefault) TriggerAutoPilot(_ context.Context) (bool, error) {
 }
 
 func (r *RenterDefault) AddHostsToAllowlist(ctx context.Context, hosts []types.PublicKey) error {
-	return r.busClient.UpdateHostAllowlist(ctx, hosts, nil, false)
+	client, err := r.getBusClient()
+	if err != nil {
+		return err
+	}
+	return client.UpdateHostAllowlist(ctx, hosts, nil, false)
 }
 
 func (r *RenterDefault) GetAllowlistedHosts(ctx context.Context) ([]types.PublicKey, error) {
-	return r.busClient.HostAllowlist(ctx)
+	client, err := r.getBusClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.HostAllowlist(ctx)
 }
 
 func (r *RenterDefault) SlabSize(ctx context.Context) (uint64, error) {
@@ -406,11 +497,19 @@ func (r *RenterDefault) SlabSize(ctx context.Context) (uint64, error) {
 }
 
 func (r *RenterDefault) ScanHost(ctx context.Context, host types.PublicKey, hostIP string) (api.RHPScanResponse, error) {
-	return r.workerClient.RHPScan(ctx, host, hostIP, 30*time.Second)
+	client, err := r.getWorkerClient()
+	if err != nil {
+		return api.RHPScanResponse{}, err
+	}
+	return client.RHPScan(ctx, host, hostIP, 30*time.Second)
 }
 
 func (r *RenterDefault) Hosts(ctx context.Context, usabilityMode core.RenterHostUsabilityMode, filterMode core.RenterHostFilterMode) ([]api.Host, error) {
-	return r.busClient.SearchHosts(ctx, api.SearchHostOptions{
+	client, err := r.getBusClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.SearchHosts(ctx, api.SearchHostOptions{
 		Limit:         -1,
 		FilterMode:    string(filterMode),
 		UsabilityMode: string(usabilityMode),
@@ -418,7 +517,11 @@ func (r *RenterDefault) Hosts(ctx context.Context, usabilityMode core.RenterHost
 }
 
 func (r *RenterDefault) Host(ctx context.Context, host types.PublicKey) (api.Host, error) {
-	return r.busClient.Host(ctx, host)
+	client, err := r.getBusClient()
+	if err != nil {
+		return api.Host{}, err
+	}
+	return client.Host(ctx, host)
 }
 
 func (r *RenterDefault) AutopilotHosts(ctx context.Context, usabilityMode core.RenterHostUsabilityMode, filterMode core.RenterHostFilterMode) ([]api.HostResponse, error) {
@@ -426,9 +529,17 @@ func (r *RenterDefault) AutopilotHosts(ctx context.Context, usabilityMode core.R
 }
 
 func (r *RenterDefault) ConsensusState(ctx context.Context) (api.ConsensusState, error) {
-	return r.busClient.ConsensusState(ctx)
+	client, err := r.getBusClient()
+	if err != nil {
+		return api.ConsensusState{}, err
+	}
+	return client.ConsensusState(ctx)
 }
 
 func (r *RenterDefault) RecommendedFee(ctx context.Context) (types.Currency, error) {
-	return r.busClient.RecommendedFee(ctx)
+	client, err := r.getBusClient()
+	if err != nil {
+		return types.Currency{}, err
+	}
+	return client.RecommendedFee(ctx)
 }


### PR DESCRIPTION
- Implement client manager for handling renterd cluster nodes
- Add support for distributed bus and worker clients
- Remove required key validation for non-clustered mode
- Update renter service to use cluster-aware client management

This change enables the renter service to work in both standalone and clustered modes, distributing requests across multiple renterd nodes when clustering is enabled.