### PR TITLE
refactor(config, renter): reorganize Sia cluster validation logic

### DIFF
--- a/config/sia.go
+++ b/config/sia.go
@@ -11,6 +11,7 @@ var _ Defaults = (*SiaConfig)(nil)
 type SiaConfig struct {
 	Key                string `config:"key"`
 	URL                string `config:"url"`
+	Cluster            bool   `config:"cluster"`
 	HostScoreAPIURL    string `config:"host_score_api_url"`
 	MaxContractSCPrice string `config:"max_contract_sc_price"`
 	MaxRPCSCPrice      string `config:"max_rpc_sc_price"`
@@ -19,6 +20,7 @@ type SiaConfig struct {
 func (s SiaConfig) Defaults() map[string]interface{} {
 	return map[string]interface{}{
 		"key":                   "",
+		"cluster":               false,
 		"url":                   "",
 		"host_score_api_url":    "https://api.hostscore.info",
 		"max_rpc_sc_price":      1000,
@@ -27,8 +29,11 @@ func (s SiaConfig) Defaults() map[string]interface{} {
 }
 
 func (s SiaConfig) Validate() error {
+	if s.Key == "" {
+		return errors.New("core.storage.sia.key is required")
+	}
 
-	if s.URL == "" {
+	if s.Cluster && s.URL == "" {
 		return errors.New("core.storage.sia.url is required")
 	}
 

--- a/service/renter.go
+++ b/service/renter.go
@@ -139,14 +139,11 @@ func (r *RenterDefault) init() error {
 		return fmt.Errorf("failed to start client manager: %w", err)
 	}
 
-	if !r.ctx.Config().Config().Core.ClusterEnabled() {
+	clusterEnabled := r.ctx.Config().Config().Core.ClusterEnabled() && r.ctx.Config().Config().Core.Storage.Sia.Cluster
+
+	if !clusterEnabled {
 		addr := r.config.Config().Core.Storage.Sia.URL
 		passwd := r.config.Config().Core.Storage.Sia.Key
-
-		if passwd == "" {
-			return errors.New("core.storage.sia.key is required")
-		}
-
 		addrURL, err := url.Parse(addr)
 		if err != nil {
 			return err


### PR DESCRIPTION
Move Sia configuration validation to the appropriate layer and consolidate cluster enablement checks. This change:

- Adds explicit cluster config field to improve configuration clarity
- Moves key validation to config validation layer
- Makes URL validation conditional on cluster mode
- Consolidates cluster enablement logic in renter service