### PR TITLE
refactor(cmd): restructure package layout and improve error handling

### DIFF
--- a/cmd/internal/cli/commands.go
+++ b/cmd/internal/cli/commands.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/urfave/cli/v3"
 	"go.lumeweb.com/portal/build"
-	portalcmd "go.lumeweb.com/portal/cmd"
+	"go.lumeweb.com/portal/cmd/internal/portal"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
@@ -36,8 +36,7 @@ func NewPortalCLI() *cli.Command {
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			portalcmd.Main()
-			return nil
+			return portal.StartServer()
 		},
 	}
 }

--- a/cmd/internal/portal/server.go
+++ b/cmd/internal/portal/server.go
@@ -1,4 +1,4 @@
-package portalcmd
+package portal
 
 import (
 	"go.lumeweb.com/portal"
@@ -8,18 +8,19 @@ import (
 	"os"
 )
 
-func Main() {
+func StartServer() error {
 	// Continue with normal portal initialization
 	cfg, err := config.NewManager()
 	logger := core.NewLogger(cfg)
 	if err != nil {
 		logger.Fatal("Failed to load config", zap.Error(err))
+		return err
 	}
 
 	ctx, err := core.NewContext(cfg, logger)
-
 	if err != nil {
 		logger.Fatal("Failed to create context", zap.Error(err))
+		return err
 	}
 
 	core.RegisterServicesFromPlugins()
@@ -27,6 +28,7 @@ func Main() {
 	err = cfg.Init()
 	if err != nil {
 		logger.Fatal("Failed to initialize config", zap.Error(err))
+		return err
 	}
 
 	logger.SetLevelFromConfig()
@@ -34,14 +36,12 @@ func Main() {
 	portal.NewActivePortal(ctx)
 
 	err = portal.Init()
-
 	if err != nil {
 		logger.Fatal("Failed to initialize portal", zap.Error(err))
 		os.Exit(core.ExitCodeFailedStartup)
 	}
 
 	err = portal.Start()
-
 	if err != nil {
 		logger.Error("Failed to start portal", zap.Error(err))
 		os.Exit(core.ExitCodeFailedStartup)
@@ -54,4 +54,6 @@ func Main() {
 		logger.Error("Failed to serve portal", zap.Error(err))
 		os.Exit(core.ExitCodeFailedStartup)
 	}
+
+	return nil
 }

--- a/cmd/internal/portal/signal.go
+++ b/cmd/internal/portal/signal.go
@@ -1,4 +1,4 @@
-package portalcmd
+package portal
 
 import (
 	"go.lumeweb.com/portal"
@@ -30,7 +30,7 @@ func trapSignals() {
 		for sig := range sigchan {
 			switch sig {
 			case syscall.SIGQUIT:
-				logger.Info("Wuitting process immediately", zap.String("signal", "SIGQUIT"))
+				logger.Info("Quitting process immediately", zap.String("signal", "SIGQUIT"))
 				os.Exit(core.ExitCodeForceQuit)
 
 			case syscall.SIGTERM:
@@ -51,6 +51,5 @@ func trapSignals() {
 				exitProcessFromSignal("SIGINT")
 			}
 		}
-
 	}()
 }

--- a/cmd/portal/main.go
+++ b/cmd/portal/main.go
@@ -7,14 +7,10 @@ import (
 	"os"
 )
 
-func Main() {
+func main() {
 	command := cli.NewPortalCLI()
 	ctx := context.Background()
 	if err := command.Run(ctx, os.Args); err != nil {
 		os.Exit(1)
 	}
-}
-
-func main() {
-	Main()
 }


### PR DESCRIPTION
- Move command files into internal/portal package
- Convert Main() to StartServer() with proper error returns
- Add comprehensive error handling in server startup flow
- Fix typo in SIGQUIT log message
- Simplify main entry point