### PR TITLE
refactor(config): improve etcd manager thread safety and API

### DIFF
--- a/config/etcd.go
+++ b/config/etcd.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"errors"
-	"strings"
-	"time"
-
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+	"strings"
+	"sync"
 )
 
 var _ Defaults = (*EtcdConfig)(nil)
@@ -17,6 +17,7 @@ type EtcdConfig struct {
 	Prefix      string   `config:"prefix"`
 	DialTimeout int      `config:"dial_timeout"`
 	manager     *EtcdManager
+	managerMu   sync.RWMutex
 }
 
 func (r *EtcdConfig) Validate() error {
@@ -53,32 +54,45 @@ func (r *EtcdConfig) Defaults() map[string]interface{} {
 	}
 }
 
-func (r *EtcdConfig) Client() (*clientv3.Client, error) {
-    if r.manager == nil {
-        return nil, errors.New("etcd manager not initialized")
-    }
-    return r.manager.Client(), nil
+// GetManager returns the EtcdManager, initializing it if necessary
+func (r *EtcdConfig) GetManager(logger *zap.Logger) (*EtcdManager, error) {
+	r.managerMu.RLock()
+	if r.manager != nil {
+		defer r.managerMu.RUnlock()
+		return r.manager, nil
+	}
+	r.managerMu.RUnlock()
+
+	r.managerMu.Lock()
+	defer r.managerMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if r.manager != nil {
+		return r.manager, nil
+	}
+
+	manager, err := NewEtcdManager(r, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	r.manager = manager
+	return r.manager, nil
 }
 
-func (r *EtcdConfig) InitManager(logger *zap.Logger) error {
-    if r.manager != nil {
-        return nil
-    }
-    
-    manager, err := NewEtcdManager(r, logger)
-    if err != nil {
-        return err
-    }
-    
-    r.manager = manager
-    return nil
+func (r *EtcdConfig) Client() (*clientv3.Client, error) {
+	// This method is deprecated - use GetManager().Client() instead
+	return nil, errors.New("deprecated: use GetManager().Client() instead")
 }
 
 func (r *EtcdConfig) Close() error {
-    if r.manager != nil {
-        return r.manager.Close()
-    }
-    return nil
+	r.managerMu.Lock()
+	defer r.managerMu.Unlock()
+
+	if r.manager != nil {
+		return r.manager.Close()
+	}
+	return nil
 }
 
 func (r *EtcdConfig) ComputePrefix(key string) string {

--- a/config/manager.go
+++ b/config/manager.go
@@ -98,7 +98,7 @@ func (m *ManagerDefault) Init() error {
 
 	// Initialize etcd manager if cluster is enabled
 	if m.root.Core.ClusterEnabled() && m.root.Core.Clustered.Etcd != nil {
-		err := m.root.Core.Clustered.Etcd.InitManager(m.logger)
+		_, err := m.root.Core.Clustered.Etcd.GetManager(m.logger)
 		if err != nil {
 			return fmt.Errorf("failed to initialize etcd manager: %w", err)
 		}
@@ -197,10 +197,11 @@ func (m *ManagerDefault) initLiveUpdates() error {
 }
 
 func (m *ManagerDefault) initClusterWatcher() error {
-	client, err := m.root.Core.Clustered.Etcd.Client()
+	etcdManager, err := m.root.Core.Clustered.Etcd.GetManager(m.logger)
 	if err != nil {
 		return err
 	}
+	client := etcdManager.Client()
 
 	// Create cancellable context
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1083,10 +1084,11 @@ func (m *ManagerDefault) saveClusterSpace(prefix string, overwrite bool) error {
 	}
 
 	ctx := context.Background()
-	client, err := m.root.Core.Clustered.Etcd.Client()
+	etcdManager, err := m.root.Core.Clustered.Etcd.GetManager(m.logger)
 	if err != nil {
 		return err
 	}
+	client := etcdManager.Client()
 
 	etcdPrefix := m.root.Core.Clustered.Etcd.ComputePrefix("/" + CLUSTER_CONFIG_KEY + "/" + strings.ReplaceAll(prefix, ".", "/"))
 

--- a/db_migration.go
+++ b/db_migration.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	dbModels "go.lumeweb.com/portal/db/models"
 	"go.uber.org/zap"
@@ -19,9 +20,9 @@ const (
 )
 
 type MigrationManager struct {
-	ctx        core.Context
-	etcdClient *clientv3.Client
-	logger     *core.Logger
+	ctx     core.Context
+	etcdMgr *config.EtcdManager
+	logger  *core.Logger
 }
 
 func NewMigrationManager(ctx core.Context) (*MigrationManager, error) {
@@ -32,15 +33,15 @@ func NewMigrationManager(ctx core.Context) (*MigrationManager, error) {
 		}, nil
 	}
 
-	client, err := ctx.Config().Config().Core.Clustered.Etcd.Client()
+	etcdManager, err := ctx.Config().Config().Core.Clustered.Etcd.GetManager(ctx.Logger().Logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create etcd client: %w", err)
+		return nil, fmt.Errorf("failed to get etcd manager: %w", err)
 	}
 
 	return &MigrationManager{
-		ctx:        ctx,
-		etcdClient: client,
-		logger:     ctx.Logger(),
+		ctx:     ctx,
+		etcdMgr: etcdManager,
+		logger:  ctx.Logger(),
 	}, nil
 }
 
@@ -66,13 +67,14 @@ func (m *MigrationManager) RunMigrations(db *gorm.DB) error {
 
 func (m *MigrationManager) acquireMigrationLock() (*etcdLease, error) {
 	// Create lease
-	resp, err := m.etcdClient.Grant(context.Background(), int64(migrationLockTTL.Seconds()))
+	client := m.etcdMgr.Client()
+	resp, err := client.Grant(context.Background(), int64(migrationLockTTL.Seconds()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create lease: %w", err)
 	}
 
 	// Try to acquire lock using lease
-	txn := m.etcdClient.Txn(context.Background())
+	txn := m.etcdMgr.Client().Txn(context.Background())
 	txn = txn.If(clientv3.Compare(clientv3.CreateRevision(migrationLockKey), "=", 0))
 	txn = txn.Then(clientv3.OpPut(migrationLockKey, "", clientv3.WithLease(resp.ID)))
 	txn = txn.Else(clientv3.OpGet(migrationLockKey))
@@ -88,7 +90,7 @@ func (m *MigrationManager) acquireMigrationLock() (*etcdLease, error) {
 
 	// Create lease keeper
 	lease := &etcdLease{
-		client: m.etcdClient,
+		client: m.etcdMgr.Client(),
 		id:     resp.ID,
 		logger: m.logger,
 		done:   make(chan struct{}),


### PR DESCRIPTION
- Add mutex protection for etcd manager initialization
- Deprecate direct Client() method in favor of GetManager()
- Update all etcd client usage to use GetManager pattern
- Refactor MigrationManager to store manager reference