### PR TITLE
refactor(service, core): move CONTENT_SCANNER_SERVICE constant to core

### DIFF
--- a/core/content_scan.go
+++ b/core/content_scan.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+const CONTENT_SCANNER_SERVICE = "content_scanner"
+
 // ScanResult represents the outcome of a content scan
 type ScanResult struct {
 	Passed    bool           `json:"passed"`

--- a/service/content_scan.go
+++ b/service/content_scan.go
@@ -14,8 +14,6 @@ import (
 	"sort"
 )
 
-const CONTENT_SCANNER_SERVICE = "content_scanner"
-
 // Default implementation
 type ContentScannerServiceDefault struct {
 	ctx      core.Context
@@ -42,7 +40,7 @@ func NewContentScannerService() (*ContentScannerServiceDefault, []core.ContextBu
 }
 
 func (s *ContentScannerServiceDefault) ID() string {
-	return CONTENT_SCANNER_SERVICE
+	return core.CONTENT_SCANNER_SERVICE
 }
 
 func (s *ContentScannerServiceDefault) RegisterScanner(scanner core.ContentScanner) error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Centralized the identifier for content scanning services to ensure consistency.
	- Removed duplicate definitions and updated references to use the unified service identifier for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->