### PR TITLE
refactor(core, service): GetScanResults and GetScanResultById should return the model not the core type so we can have the db id

### DIFF
--- a/core/content_scan.go
+++ b/core/content_scan.go
@@ -53,10 +53,10 @@ type ContentScannerService interface {
 	ScanContent(ctx context.Context, hash StorageHash) ([]*ScanResult, error)
 
 	// GetScanResults retrieves previous scan results
-	GetScanResults(ctx context.Context, hash StorageHash) ([]*ScanResult, error)
+	GetScanResults(ctx context.Context, hash StorageHash) ([]*models.ScanResult, error)
 
 	// GetScanResultById retrieves a specific scan result by its unique identifier.
-	GetScanResultById(ctx context.Context, id uint) (*ScanResult, error)
+	GetScanResultById(ctx context.Context, id uint) (*models.ScanResult, error)
 
 	Service
 }

--- a/service/content_scan.go
+++ b/service/content_scan.go
@@ -115,8 +115,8 @@ func (s *ContentScannerServiceDefault) ScanContent(ctx context.Context, hash cor
 	return results, nil
 }
 
-func (s *ContentScannerServiceDefault) GetScanResults(ctx context.Context, hash core.StorageHash) ([]*core.ScanResult, error) {
-	var results []*core.ScanResult
+func (s *ContentScannerServiceDefault) GetScanResults(ctx context.Context, hash core.StorageHash) ([]*models.ScanResult, error) {
+	var results []*models.ScanResult
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		return db.RetryOnLock(tx, func(db *gorm.DB) *gorm.DB {
@@ -135,8 +135,8 @@ func (s *ContentScannerServiceDefault) GetScanResults(ctx context.Context, hash 
 	return results, nil
 }
 
-func (s *ContentScannerServiceDefault) GetScanResultById(ctx context.Context, id uint) (*core.ScanResult, error) {
-	var result *core.ScanResult
+func (s *ContentScannerServiceDefault) GetScanResultById(ctx context.Context, id uint) (*models.ScanResult, error) {
+	var result *models.ScanResult
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		return db.RetryOnLock(tx, func(db *gorm.DB) *gorm.DB {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the scan results handling by aligning the data responses with a unified model, enhancing consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->