### PR TITLE
fix(core): StorageHashDefault.String needs to call Multihash B58String, not String as String is an alias to HexString

### DIFF
--- a/core/storage.go
+++ b/core/storage.go
@@ -175,7 +175,7 @@ func (s StorageHashDefault) Type() uint64 {
 }
 
 func (s StorageHashDefault) String() string {
-	return s.Multihash().String()
+	return s.Multihash().B58String()
 }
 
 func NewStorageHash(hash []byte, typ uint64, cidType uint64, proof []byte) StorageHash {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated how hash values are displayed by switching to Base58 encoding for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->