### PR TITLE
refactor(db): disable dbmate AutoDumpSchema

### DIFF
--- a/db_migration.go
+++ b/db_migration.go
@@ -142,6 +142,7 @@ func (m *MigrationManager) executeMigrations(_ *gorm.DB) error {
 	dbMateMigration := dbmate.New(dbUrl)
 	dbMateMigration.FS = compositFs
 	dbMateMigration.MigrationsDir = compositFs.Mounts()
+	dbMateMigration.AutoDumpSchema = false
 
 	err = dbMateMigration.CreateAndMigrate()
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the migration process so that schema snapshots are no longer generated automatically during migrations. This change gives users more direct control over when and how schema dumps occur while maintaining a stable and reliable migration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->