### PR TITLE
fix: update portal-router and gswagger dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.19
 	go.lumeweb.com/httputil v0.4.2
 	go.lumeweb.com/portal-middleware v0.2.7
-	go.lumeweb.com/portal-router v0.3.2
+	go.lumeweb.com/portal-router v0.3.4
 	go.sia.tech/core v0.10.4
 	go.sia.tech/coreutils v0.12.1
 	go.sia.tech/renterd v1.1.1
@@ -111,7 +111,7 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
-	go.lumeweb.com/gswagger v0.17.0 // indirect
+	go.lumeweb.com/gswagger v0.17.2 // indirect
 	go.lumeweb.com/queryutil v0.3.2 // indirect
 	go.sia.tech/jape v0.12.1 // indirect
 	golang.org/x/sync v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -661,6 +661,8 @@ go.lumeweb.com/gswagger v0.16.1 h1:5TU+B2NymPkqQv0DijIjGqbs+LbHZKy/4NoRDr6z1K0=
 go.lumeweb.com/gswagger v0.16.1/go.mod h1:ihCqZdOheP96os/K3QlVv4LT7oS+fEc0f+TAyJd7CaA=
 go.lumeweb.com/gswagger v0.17.0 h1:eVtmSO5G3PVUkgp6FQCHxQN/OVT4xGC0ZSvIhKSV0yU=
 go.lumeweb.com/gswagger v0.17.0/go.mod h1:ihCqZdOheP96os/K3QlVv4LT7oS+fEc0f+TAyJd7CaA=
+go.lumeweb.com/gswagger v0.17.2 h1:V4aF2665sKcxLzmVMGMO1h1X64MTJqhxA6wY3k3mQcw=
+go.lumeweb.com/gswagger v0.17.2/go.mod h1:ihCqZdOheP96os/K3QlVv4LT7oS+fEc0f+TAyJd7CaA=
 go.lumeweb.com/httputil v0.4.2 h1:lNs97zejaFtj68u+tSL//O4z5cI4E/HCN5tDy3HwNvU=
 go.lumeweb.com/httputil v0.4.2/go.mod h1:zO42Pj9Wwz0BVs1kPytfMlpQ39vqtd61N8US+4OG5qs=
 go.lumeweb.com/portal-middleware v0.2.3 h1:ac23kBVgOtnlR5nyMEdaMZtBf1QngkFEDWHvwbGblSk=
@@ -685,6 +687,8 @@ go.lumeweb.com/portal-router v0.2.1 h1:e1stKdlFfowmIFEC3F/7WxMpBIhXEWBJJqwCN/3G5
 go.lumeweb.com/portal-router v0.2.1/go.mod h1:uCR/MI5I7jeyOoaGVmo8DyJrGdOyjQilN9tcir2RyBM=
 go.lumeweb.com/portal-router v0.3.2 h1:ROL6BVWmtu98MVW/a0VP2R1eBIXC56dy6i+9ucPKtFE=
 go.lumeweb.com/portal-router v0.3.2/go.mod h1:sZmPm0U9m5l9fOSmsHrNvda6LsZ2oXjWboWOsbSOMRw=
+go.lumeweb.com/portal-router v0.3.4 h1:AwM8hRLDdhK02hrW7bS5bg76E3gb9abWXzXEy3EMEo8=
+go.lumeweb.com/portal-router v0.3.4/go.mod h1:iRt/bm7HMyrgrjmWlA/y+8ou5VZvzJCl57WjFiY5+PA=
 go.lumeweb.com/queryutil v0.3.2 h1:toTfreL3JJjPeul7NOUxXfG8lNhGyxodPUMR41uWp4A=
 go.lumeweb.com/queryutil v0.3.2/go.mod h1:tcD4meQIXQYNjJ8i0dahCa8kpzQyks+d7PiC+qCXdNg=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/service/http.go
+++ b/service/http.go
@@ -57,35 +57,25 @@ type HTTPServiceDefault struct {
 	fsCache     sync.Map // Cache for bundle filesystems
 }
 
-//var _ handlers.RecoveryHandlerLogger = (*recoverLogger)(nil)
-/*
-type recoverLogger struct {
-	ctx core.Context
-}
-
-func (r *recoverLogger) Println(v ...interface{}) {
-	r.ctx.Logger().Error("Recovered from panic", zap.Any("panic", v))
-}*/
-
 func NewHTTPService() (*HTTPServiceDefault, []core.ContextBuilderOption, error) {
-	_router, err := router.NewRouter(router.APIInfo())
-	if err != nil {
-		return nil, nil, err
-	}
+	_http := &HTTPServiceDefault{}
 
-	_http := &HTTPServiceDefault{
-		router: _router,
-	}
-
-	srv := &http.Server{
-		Handler: _http.router,
-	}
+	srv := &http.Server{}
 
 	opts := core.ContextOptions(
 		core.ContextWithStartupFunc(func(ctx core.Context) error {
 			_http.ctx = ctx
 			_http.logger = ctx.ServiceLogger(_http)
 			_http.access = ctx.Service(core.ACCESS_SERVICE).(core.AccessService)
+
+			_router, err := router.NewRouter(router.APIInfo().Title(fmt.Sprintf("%s Meta API", ctx.Config().Config().Core.PortalName)).Version(build.GetInfo().Version))
+			if err != nil {
+				return err
+			}
+
+			_http.router = _router
+			srv.Handler = _http.router
+
 			return nil
 		}),
 		core.ContextWithExitFunc(func(ctx core.Context) error {
@@ -147,6 +137,8 @@ func (h *HTTPServiceDefault) Init() error {
 		if err != nil {
 			return fmt.Errorf("failed to create host router for API %s: %w", api.Name(), err)
 		}
+
+		router.UpdateRouterInfo(hostRouter, apiInfo)
 
 		// Configure the main API using the gswagger router
 		err = api.Configure(hostRouter, h.access)


### PR DESCRIPTION
- Updated go.lumeweb.com/portal-router from v0.3.2 to v0.3.4
- Updated go.lumeweb.com/gswagger from v0.17.0 to v0.17.2
- Modified HTTP service initialization to create router during startup
- Added router info update for API configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the initialization process for the HTTP service and router, enhancing startup behavior and metadata handling.
  - Removed unused commented-out code for better code clarity.

- **Chores**
  - Updated internal dependencies to their latest patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->