### PR TITLE
feat(testing): add mock access service and default test context options

### DIFF
--- a/core/testing/mock_access.go
+++ b/core/testing/mock_access.go
@@ -1,0 +1,31 @@
+package testing
+
+import (
+	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal/core/testing/mocks"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockAccessService implements core.AccessService for testing with default RegisterRoute expectations
+type MockAccessService struct {
+	*mocks.MockAccessService
+}
+
+// NewMockAccessService creates a new mock access service with default RegisterRoute expectations
+func NewMockAccessService(t TB) *MockAccessService {
+	mockAccess := mocks.NewMockAccessService(t)
+	access := &MockAccessService{
+		MockAccessService: mockAccess,
+	}
+
+	// Set up default expectation for RegisterRoute
+	// This allows router registration to proceed without explicit mocks in every test
+	mockAccess.On("RegisterRoute", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+		Maybe().
+		Return(nil)
+
+	return access
+}
+
+// Ensure MockAccessService implements core.AccessService
+var _ core.AccessService = (*MockAccessService)(nil)

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -232,8 +232,8 @@ func NewTestContext(tb TB, opts ...TestContextBuilderOption) TestContext {
 		cleanupFuncs: []func(){},
 	}
 
-	// Apply options
-	finalCtx, err := ProcessCtxOptions(testCtx, opts...)
+	// Apply default options first, then any custom options
+	finalCtx, err := ProcessCtxOptions(testCtx, append(DefaultTestContextOptions(tb), opts...)...)
 	if err != nil {
 		return nil
 	}
@@ -535,6 +535,22 @@ func WrapCoreOptions(opts []core.ContextBuilderOption) []TestContextBuilderOptio
 	return wrapped
 }
 
+// WithMockAccessService adds a mock access service to the test context
+func WithMockAccessService(tb TB) TestContextBuilderOption {
+	return func(ctx TestContext) (TestContext, error) {
+		mockAccessService := NewMockAccessService(tb)
+		ctx.RegisterService(core.ACCESS_SERVICE, mockAccessService)
+		return ctx, nil
+	}
+}
+
+// DefaultTestContextOptions returns the default options used for new test contexts
+func DefaultTestContextOptions(tb TB) []TestContextBuilderOption {
+	return []TestContextBuilderOption{
+		WithMockAccessService(tb),
+	}
+}
+
 // GetMockConfig returns the mock config manager from the context for testing
 // Panics if the config manager is not a mock
 func GetMockConfig(ctx core.Context) *MockConfigManager {
@@ -543,6 +559,20 @@ func GetMockConfig(ctx core.Context) *MockConfigManager {
 		panic("config manager is not a mock - use NewMockContext() for testing")
 	}
 	return mockConfig
+}
+
+// GetMockAccessService returns the mock access service from the context for testing
+// Panics if the access service is not a mock
+func GetMockAccessService(ctx core.Context) *MockAccessService {
+	accessSvc := ctx.Service(core.ACCESS_SERVICE)
+	if accessSvc == nil {
+		panic("access service not found in context")
+	}
+	mockAccess, ok := accessSvc.(*MockAccessService)
+	if !ok {
+		panic("access service is not a mock - use NewTestContext() for testing")
+	}
+	return mockAccess
 }
 
 // RegisterAPI registers an API and wraps any returned context options for test context


### PR DESCRIPTION
- Added new MockAccessService implementation in core/testing/mock_access.go
  - Provides default RegisterRoute expectations for testing
- Modified core/testing/testing.go to:
  - Include default test context options with mock access service
  - Add helper functions for getting mock access service from context
  - Apply default options before custom options in NewTestContext

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test setup by introducing a mock access service that is automatically included in the default test context options.
  - Added helper functions to streamline the creation and retrieval of mock services during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->