### PR TITLE
feat(testing): enhance mock HTTP service and test context with router support

### DIFF
--- a/core/testing/mock_http.go
+++ b/core/testing/mock_http.go
@@ -1,0 +1,41 @@
+package testing
+
+import (
+	"github.com/stretchr/testify/mock"
+	router "go.lumeweb.com/portal-router"
+	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal/core/testing/mocks"
+	"testing"
+)
+
+// MockHTTPService implements core.HTTPService for testing with default Router expectations
+type MockHTTPService struct {
+	*mocks.MockHTTPService
+	router router.Router
+}
+
+// NewMockHTTPService creates a new mock HTTP service with default Router expectations
+func NewMockHTTPService(t mock.TestingT) *MockHTTPService {
+	mockHTTPService := mocks.NewMockHTTPService(t)
+	httpService := &MockHTTPService{
+		MockHTTPService: mockHTTPService,
+	}
+
+	// Set up default expectation for Router
+	mockHTTPService.On("Router").
+		Maybe().
+		Return(func() router.Router {
+			return httpService.router
+		})
+
+	return httpService
+}
+
+// WithRouter sets the router for the mock HTTP service
+func (m *MockHTTPService) WithRouter(r router.Router) *MockHTTPService {
+	m.router = r
+	return m
+}
+
+// Ensure MockHTTPService implements core.HTTPService
+var _ core.HTTPService = (*MockHTTPService)(nil)

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -164,6 +164,7 @@ type defaultContext struct {
 	db           *gorm.DB
 	cancel       context.CancelFunc
 	event        *event.Manager
+	router       router.Router
 }
 
 // testContext extends the default context for testing
@@ -282,6 +283,14 @@ func (c *testContext) Teardown() {
 func WithMockService(id string, service core.Service) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
 		ctx.RegisterService(id, service)
+		return ctx, nil
+	}
+}
+
+// WithRouter adds a router to the test context
+func WithRouter(r router.Router) TestContextBuilderOption {
+	return func(ctx TestContext) (TestContext, error) {
+		ctx.(*testContext).router = r
 		return ctx, nil
 	}
 }
@@ -424,6 +433,10 @@ func (c *testContext) Err() error {
 // Value implements the Context interface
 func (c *testContext) Value(key interface{}) interface{} {
 	return c.Context.Value(key)
+}
+
+func (c *testContext) Router() router.Router {
+	return c.router
 }
 
 // ProcessCtxOptions applies a series of ContextBuilderOptions to a TestContext.
@@ -591,7 +604,7 @@ func WithMockCronService(tb TB) TestContextBuilderOption {
 // WithMockHTTPService adds a mock HTTPService to the test context.
 func WithMockHTTPService(tb TB) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
-		mockHTTPService := mocks.NewMockHTTPService(tb)
+		mockHTTPService := NewMockHTTPService(tb)
 		ctx.RegisterService(core.HTTP_SERVICE, mockHTTPService)
 		return ctx, nil
 	}
@@ -701,8 +714,14 @@ func WithMockWorkflowService(tb TB) TestContextBuilderOption {
 // DefaultTestContextOptions returns the default options used for new test contexts.
 // These options include mock implementations of common core services.
 func DefaultTestContextOptions(tb TB) []TestContextBuilderOption {
+	_router, err := router.NewRouter(router.APIInfo().Title("Test API").Version("1.0.0"))
+	if err != nil {
+		panic(fmt.Sprintf("failed to create test router: %v", err))
+	}
+
 	return []TestContextBuilderOption{
 		WithMockAccessService(tb),
+		WithRouter(_router),
 		WithMockAuthService(tb),
 		WithMockConfigService(tb),
 		WithMockContentScannerService(tb),


### PR DESCRIPTION
- Added new MockHTTPService implementation in core/testing/mock_http.go
  - Wraps existing MockHTTPService with router functionality
  - Provides WithRouter() method for test configuration
  - Ensures interface compliance with core.HTTPService

- Modified testContext in core/testing/testing.go to:
  - Add router field and Router() accessor method
  - Add WithRouter builder option
  - Update WithMockHTTPService to use new mock implementation
  - Include router in DefaultTestContextOptions

These changes improve testing capabilities by providing better control over HTTP routing in test scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Test environments now include a preconfigured router by default.
  - Added the ability to inject and retrieve a custom router in test contexts.

- **Chores**
  - Improved test infrastructure with a new mock HTTP service and enhanced router support for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->