### PR TITLE
fix(testing): ensure mock HTTP service includes router

### DIFF
--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -605,7 +605,7 @@ func WithMockCronService(tb TB) TestContextBuilderOption {
 // WithMockHTTPService adds a mock HTTPService to the test context.
 func WithMockHTTPService(tb TB) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
-		mockHTTPService := NewMockHTTPService(tb)
+		mockHTTPService := NewMockHTTPService(tb).WithRouter(ctx.Router())
 		ctx.RegisterService(core.HTTP_SERVICE, mockHTTPService)
 		return ctx, nil
 	}


### PR DESCRIPTION
The WithMockHTTPService test helper now properly initializes the mock HTTP service with the test context's router. This ensures the mock service matches the behavior of the real HTTP service which requires a router.

Previously the router was not being set, which could lead to nil pointer issues when testing code that depends on the HTTP service's router.