### PR TITLE
feat(testing): add config manager support to MockHTTPService

### DIFF
--- a/core/testing/mock_http.go
+++ b/core/testing/mock_http.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"fmt"
 	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/core/testing/mocks"
@@ -9,7 +10,8 @@ import (
 // MockHTTPService implements core.HTTPService for testing with default Router expectations
 type MockHTTPService struct {
 	*mocks.MockHTTPService
-	router router.Router
+	router   router.Router
+	cmanager *MockConfigManager
 }
 
 // NewMockHTTPService creates a new mock HTTP service with default Router expectations
@@ -33,6 +35,27 @@ func NewMockHTTPService(t TB) *MockHTTPService {
 func (m *MockHTTPService) WithRouter(r router.Router) *MockHTTPService {
 	m.router = r
 	return m
+}
+
+func (m *MockHTTPService) WithConfigManager(c *MockConfigManager) *MockHTTPService {
+	m.cmanager = c
+	return m
+}
+
+func (m *MockHTTPService) APISubdomain(id string, proto bool) string {
+	formatter := ""
+
+	if proto {
+		formatter += "https://"
+	}
+
+	formatter += "%s.%s"
+
+	if core.GetAPI(id) == nil {
+		return ""
+	}
+
+	return fmt.Sprintf(formatter, core.GetAPI(id).Subdomain(), m.cmanager.Config().Core.Domain)
 }
 
 // Ensure MockHTTPService implements core.HTTPService


### PR DESCRIPTION
- Added cmanager field to MockHTTPService struct to store config manager reference
- Added WithConfigManager() method to set config manager
- Implemented APISubdomain() method that uses config manager to build URLs
- Maintains backward compatibility while adding new functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for mocking API subdomains, allowing more flexible testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->