### PR TITLE
fix(testing): update MockHTTPService to use config.Manager interface

### DIFF
--- a/core/testing/mock_http.go
+++ b/core/testing/mock_http.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"fmt"
 	router "go.lumeweb.com/portal-router"
+	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/core/testing/mocks"
 )
@@ -11,7 +12,7 @@ import (
 type MockHTTPService struct {
 	*mocks.MockHTTPService
 	router   router.Router
-	cmanager *MockConfigManager
+	cmanager config.Manager
 }
 
 // NewMockHTTPService creates a new mock HTTP service with default Router expectations
@@ -37,7 +38,7 @@ func (m *MockHTTPService) WithRouter(r router.Router) *MockHTTPService {
 	return m
 }
 
-func (m *MockHTTPService) WithConfigManager(c *MockConfigManager) *MockHTTPService {
+func (m *MockHTTPService) WithConfigManager(c config.Manager) *MockHTTPService {
 	m.cmanager = c
 	return m
 }

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -605,7 +605,7 @@ func WithMockCronService(tb TB) TestContextBuilderOption {
 // WithMockHTTPService adds a mock HTTPService to the test context.
 func WithMockHTTPService(tb TB) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
-		mockHTTPService := NewMockHTTPService(tb).WithRouter(ctx.Router())
+		mockHTTPService := NewMockHTTPService(tb).WithRouter(ctx.Router()).WithConfigManager(ctx.Config())
 		ctx.RegisterService(core.HTTP_SERVICE, mockHTTPService)
 		return ctx, nil
 	}


### PR DESCRIPTION
- Changed MockHTTPService.cmanager type from *MockConfigManager to config.Manager interface
- Updated WithConfigManager() to accept config.Manager instead of *MockConfigManager
- Modified WithMockHTTPService() to pass context's Config() to mock service

This makes the mock HTTP service more flexible by working with any config.Manager implementation rather than being tightly coupled to MockConfigManager.