### PR TITLE
fix(db): correct UUID handling in CronJob model and add tests

### DIFF
--- a/db/models/cron_job.go
+++ b/db/models/cron_job.go
@@ -34,6 +34,6 @@ type CronJob struct {
 
 func (t *CronJob) BeforeCreate(_ *gorm.DB) error {
 	id, err := uuid.NewRandom()
-	t.UUID = types.BinaryUUID(id)
+	t.UUID = types.ParseUUID(id)
 	return err
 }

--- a/db/types/binary_uuid.go
+++ b/db/types/binary_uuid.go
@@ -20,6 +20,11 @@ func ParseUUID(id string) BinaryUUID {
 	return BinaryUUID{BinUUID: datatypes.BinUUIDFromString(id)}
 }
 
+// NewBinUUID generates a new random (v4) UUID and returns it as a BinaryUUID
+func NewBinUUID() BinaryUUID {
+	return BinaryUUID{BinUUID: datatypes.NewBinUUIDv4()}
+}
+
 // MarshalJSON converts to JSON string
 func (b BinaryUUID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.String())

--- a/db/types/binary_uuid_test.go
+++ b/db/types/binary_uuid_test.go
@@ -65,3 +65,22 @@ func TestBinaryUUID_IsNil(t *testing.T) {
 	nonNil := ParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	assert.False(t, nonNil.IsNil())
 }
+
+func TestNewBinUUID(t *testing.T) {
+	// Generate new UUIDs
+	uuid1 := NewBinUUID()
+	uuid2 := NewBinUUID()
+
+	// Should not be nil
+	assert.False(t, uuid1.IsNil())
+	assert.False(t, uuid2.IsNil())
+
+	// Should be valid UUIDs
+	assert.NotEqual(t, uuid1.String(), uuid2.String())
+	assert.Len(t, uuid1.String(), 36)
+	assert.Len(t, uuid2.String(), 36)
+
+	// Should be v4 UUIDs (check format xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx)
+	assert.Equal(t, byte('4'), uuid1.String()[14])
+	assert.Equal(t, byte('4'), uuid2.String()[14])
+}


### PR DESCRIPTION
- Fixed UUID assignment in CronJob.BeforeCreate to use types.ParseUUID() instead of direct type conversion
- Added NewBinUUID() helper function to types package for generating random UUIDs
- Added comprehensive test cases for NewBinUUID() function
- Ensured proper UUID v4 format validation in tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a function to generate new random version 4 UUIDs.
- **Tests**
  - Introduced tests to verify the correct generation and format of new UUIDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->