### PR TITLE
refactor(db): simplify UUID generation in CronJob model

### DIFF
--- a/db/models/cron_job.go
+++ b/db/models/cron_job.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"github.com/google/uuid"
 	"go.lumeweb.com/portal/db/types"
 	"gorm.io/gorm"
 	"time"
@@ -33,7 +32,6 @@ type CronJob struct {
 }
 
 func (t *CronJob) BeforeCreate(_ *gorm.DB) error {
-	id, err := uuid.NewRandom()
-	t.UUID = types.ParseUUID(id)
-	return err
+	t.UUID = types.NewBinUUID()
+	return nil
 }


### PR DESCRIPTION
Replace manual UUID generation using google/uuid with types.NewBinUUID() helper function in CronJob's BeforeCreate hook. This:
- Removes direct dependency on github.com/google/uuid
- Uses existing types.BinaryUUID functionality consistently
- Simplifies the code by removing error handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal process for generating unique identifiers for scheduled jobs, resulting in a more streamlined and efficient creation process. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->