### PR TITLE
refactor(testing): consolidate mock DB utilities in testing.go

### DIFF
--- a/core/testing/db/db.go
+++ b/core/testing/db/db.go
@@ -4,7 +4,6 @@ package db
 import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"go.lumeweb.com/portal/core"
-	coretesting "go.lumeweb.com/portal/core/testing"
 	"gorm.io/gorm"
 	"testing"
 )
@@ -35,31 +34,4 @@ func NewSQLMock(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	})
 
 	return db, mock
-}
-
-// WithMockDB adds a mock database to the test context
-func WithMockDB(db *gorm.DB) coretesting.TestContextBuilderOption {
-	return func(ctx coretesting.TestContext) (coretesting.TestContext, error) {
-		ctx.SetDB(db)
-		ctx.RegisterCleanup(func() {
-			sqlDB, err := db.DB()
-			if err == nil {
-				_ = sqlDB.Close()
-			}
-		})
-
-		return ctx, nil
-	}
-}
-
-// SetupSQLMock creates a new sqlmock and configures a test context with it.
-// It returns a test context with the mock database and the sqlmock interface.
-func SetupSQLMock(t *testing.T) (coretesting.TestContext, sqlmock.Sqlmock) {
-	// Create a mock database and gorm instance
-	mockDB, mock := NewSQLMock(t)
-
-	// Create the test context with the mock DB
-	ctx := coretesting.NewTestContext(t, WithMockDB(mockDB))
-
-	return ctx, mock
 }

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -4,6 +4,7 @@ package testing
 import (
 	"context"
 	"fmt"
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gookit/event"
 	"go.lumeweb.com/portal"
 	router "go.lumeweb.com/portal-router"
@@ -20,12 +21,12 @@ import (
 )
 
 var (
-	testCtxOpts          []TestContextBuilderOption
-	testCtxOptsMu        sync.RWMutex
-	runDBMigrations     bool = false
-	runDBMigrationsMu   sync.RWMutex
-	setupMockDB        bool = false
-	setupMockDBMu      sync.RWMutex
+	testCtxOpts       []TestContextBuilderOption
+	testCtxOptsMu     sync.RWMutex
+	runDBMigrations   bool = false
+	runDBMigrationsMu sync.RWMutex
+	setupMockDB       bool = false
+	setupMockDBMu     sync.RWMutex
 )
 
 // AddTestContextOptions adds one or more TestContextOptions to the global testing options collection
@@ -148,7 +149,7 @@ type TestContext interface {
 	Teardown()                                      // Clean up resources
 	RegisterCleanup(fn func())                      // Register custom cleanup functions
 	Router() router.Router
-	SetDB(*gorm.DB)                                 // Set the database instance
+	SetDB(*gorm.DB) // Set the database instance
 }
 
 // ResetAllState resets all global state in the core package and testing package
@@ -1031,6 +1032,33 @@ func BootEnvironment(ctx TestContext) error {
 	return nil
 }
 
+// WithMockDB adds a mock database to the test context
+func WithMockDB(db *gorm.DB) TestContextBuilderOption {
+	return func(ctx TestContext) (TestContext, error) {
+		ctx.SetDB(db)
+		ctx.RegisterCleanup(func() {
+			sqlDB, err := db.DB()
+			if err == nil {
+				_ = sqlDB.Close()
+			}
+		})
+
+		return ctx, nil
+	}
+}
+
+// SetupSQLMock creates a new sqlmock and configures a test context with it.
+// It returns a test context with the mock database and the sqlmock interface.
+func SetupSQLMock(t TB) (TestContext, sqlmock.Sqlmock) {
+	// Create a mock database and gorm instance
+	mockDB, mock := db.NewSQLMock(t.(*testing.T))
+
+	// Create the test context with the mock DB
+	ctx := NewTestContext(t, WithMockDB(mockDB))
+
+	return ctx, mock
+}
+
 // WithInMemorySQLite configures the test context to use an in-memory SQLite database
 func WithInMemorySQLite() TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
@@ -1044,6 +1072,6 @@ func WithInMemorySQLite() TestContextBuilderOption {
 			_ = provider.Close()
 		})
 
-		return db.WithMockDB(dbInst)(ctx)
+		return WithMockDB(dbInst)(ctx)
 	}
 }


### PR DESCRIPTION
Moved WithMockDB and SetupSQLMock functions from core/testing/db/db.go to core/testing/testing.go to better organize test utilities. This:
- Keeps all test context builder options together
- Removes circular dependency between packages
- Makes mock DB utilities more discoverable
- Maintains same functionality while cleaning up imports

The changes include:
- Removing duplicate functions from db/db.go
- Adding functions to testing.go with proper imports
- Updating WithInMemorySQLite to use local WithMockDB
- Minor whitespace cleanup in testing.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for SQL mocking in the test context, allowing for more flexible and isolated database testing.
- **Refactor**
	- Improved consistency in test context setup and variable formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->