### PR TITLE
fix: move TestingShutdown to testing.go as ShutdownTestContext

### DIFF
--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -1060,6 +1060,24 @@ func SetupSQLMock(t TB) (TestContext, sqlmock.Sqlmock) {
 }
 
 // WithInMemorySQLite configures the test context to use an in-memory SQLite database
+// ShutdownTestContext is a helper for tests that calls all registered exit functions
+// and cleans up resources without exiting the process.
+func ShutdownTestContext(ctx TestContext) {
+	// Cancel the context first to signal shutdown
+	ctx.Cancel()
+
+	// Wait for context cancellation to propagate
+	<-ctx.Done()
+
+	// Run all registered exit functions
+	if err := ProcessExitFuncs(ctx); err != nil {
+		ctx.Logger().Error("Error during test shutdown", zap.Error(err))
+	}
+
+	// Perform any additional cleanup
+	ctx.Teardown()
+}
+
 func WithInMemorySQLite() TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
 		provider := db.NewTestSQLiteProvider()

--- a/portal.go
+++ b/portal.go
@@ -595,20 +595,3 @@ func Shutdown(activePortal Portal, logger *zap.Logger) {
 	os.Exit(ctx.ExitCode())
 }
 
-// TestingShutdown is a helper for tests that calls all registered exit functions
-// and cleans up resources without exiting the process.
-func TestingShutdown(ctx TestContext) {
-	// Cancel the context first to signal shutdown
-	ctx.Cancel()
-
-	// Wait for context cancellation to propagate
-	<-ctx.Done()
-
-	// Run all registered exit functions
-	if err := ProcessExitFuncs(ctx); err != nil {
-		ctx.Logger().Error("Error during test shutdown", zap.Error(err))
-	}
-
-	// Perform any additional cleanup
-	ctx.Teardown()
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the approach for shutting down and cleaning up test contexts to ensure more consistent resource cleanup during testing. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->