### PR TITLE
feat(testing): improve documentation and add mock service factory support

### DIFF
--- a/core/testing/doc.go
+++ b/core/testing/doc.go
@@ -171,12 +171,47 @@
 //		})
 //	}
 //
+//	func TestServiceWithMockDependency(t *testing.T) {
+//		coreTesting.RunTestCase(t, func(t coreTesting.TB, ctx coreTesting.TestContext) {
+//			// Use WithMockServiceFactory to provide a mock that needs the testing.TB instance.
+//			// This factory function will be called during BootEnvironment.
+//			ctx, err := coreTesting.ProcessCtxOptions(ctx,
+//				coreTesting.WithMockServiceFactory(core.MY_DEPENDENCY_SERVICE, func(tb coreTesting.TB) interface{} {
+//					// Create the mock using the provided TB
+//					mockDependency := coreMocks.NewMockMyDependencyService(tb) // Assuming this mock exists
+//					// Set expectations here if needed for the mock's initialization phase
+//					return mockDependency
+//				}),
+//				// Add the real service that depends on the mock
+//				// coreTesting.WithRealMyService(), // Assuming this option exists
+//			)
+//			require.NoError(t, err)
+//
+//			// Retrieve the mock from the context to set expectations for the test logic
+//			mockDependency := coreTesting.GetMockMyDependencyService(ctx) // Assuming this helper exists
+//			assert.NotNil(t, mockDependency)
+//
+//			// Set expectation on the mock for the test logic
+//			mockDependency.EXPECT().DoSomething().Return(nil).Once()
+//
+//			// Get the real service that uses the dependency
+//			// myService := core.GetService[core.MyService](ctx, core.MY_SERVICE)
+//			// assert.NotNil(t, myService)
+//
+//			// Call the service method that uses the dependency
+//			// err := myService.PerformAction()
+//			// assert.NoError(t, err)
+//
+//			// Assert that the mock expectation was met (handled by t.Cleanup)
+//		})
+//	}
+//
 // In this pattern:
 //   - No `TestMain` is required.
 //   - Each test function calls `testing.RunTestCase` or `testing.RunTestCaseWithDB`.
 //   - `RunTestCase` internally calls `testing.SetupTest` (which creates a new
 //     `TestContext` for this test) and registers `ctx.Teardown()` with `t.Cleanup()`.
-//   - `DefaultTestEnvironmentOptions` are applied to the context by default.
+//   - `DefaultTestContextOptions` are applied to the context by default.
 //   - Additional `TestContextBuilderOption`s can be passed to `RunTestCase` or
 //     `RunTestCaseWithDB` to customize the environment for that specific test.
 //   - Helpers like `RegisterAPI`, `RegisterProtocol`, `RegisterAPIExtension`,
@@ -230,14 +265,48 @@
 //
 //   - `DefaultTestContextOptions(tb TB)`: Provides a standard set of options
 //     for `SetupTest`, typically including mock implementations of
-//     common core services and a default router.
+//     common core services and a default router. These options are applied
+//     automatically by `SetupTest` and `RunTestCase` helpers and do not
+//     need to be explicitly passed unless you want to override them.
+//     The default options currently include:
+//       - `WithDomain("test.local")`
+//       - `WithRandomSeedPhrase()`
+//       - `WithCoreEvents()`
+//       - `WithSQLite(tb)` (if `EnableMockDB()` is called, e.g., by `WithDB` helpers)
+//       - `WithMockAccessService(tb)`
+//       - `WithRouter(...)` (a default test router)
+//       - `WithMockAuthService(tb)`
+//       - `WithMockConfigService(tb)`
+//       - `WithMockContentScannerService(tb)`
+//       - `WithMockCronService(tb)`
+//       - `WithMockHTTPService(tb)`
+//       - `WithMockHashMappingService(tb)`
+//       - `WithMockMailerService(tb)`
+//       - `WithMockOTPService(tb)`
+//       - `WithMockPasswordResetService(tb)`
+//       - `WithMockPinService(tb)`
+//       - `WithMockRequestService(tb)`
+//       - `WithMockRenterService(tb)`
+//       - `WithMockStorageService(tb)`
+//       - `WithMockTUSService(tb)`
+//       - `WithMockUserService(tb)`
+//       - `WithMockWorkflowService(tb)`
 //
 //   - `WithInMemorySQLite()`: A `TestContextBuilderOption` that configures the
 //     context to use a real, in-memory SQLite database. Useful for testing
-//     database interactions without external dependencies.
+//     database interactions without external dependencies. This is included
+//     in the default options if `EnableMockDB()` is called.
 //
 //   - `WithMockService(id string, service core.Service)`: A `TestContextBuilderOption`
-//     to register a specific mock service implementation in the context.
+//     to register a specific mock service implementation in the context. Use this
+//     when you have a pre-created mock instance that does not require the
+//     `testing.TB` instance during its construction or initial setup.
+//
+//   - `WithMockServiceFactory(id string, factory MockServiceFactory)`: A `TestContextBuilderOption`
+//     to register a service using a factory function. The factory function is called
+//     during the `BootEnvironment` phase, providing access to the `testing.TB` instance.
+//     Use this when your mock service requires the `testing.TB` instance during
+//     its creation (e.g., for mocks generated by `testify/mock` which use `t.Cleanup`).
 //
 //   - `WithConfigValue(key string, value interface{})`: A `TestContextBuilderOption`
 //     to set a specific configuration value in the mock config manager.

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -542,11 +542,34 @@ func (c *testContext) Teardown() {
 	}
 }
 
-// WithMockService adds a mock service to the test context
-func WithMockService(id string, service core.Service) TestContextBuilderOption {
+// WithMockService adds a mock service to the test context by calling the mock constructor
+// during the test context's BootEnvironment phase. The mock must implement core.Service.
+func WithMockService(id string, mockConstructor func(tb TB) interface{}) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
-		ctx.RegisterService(id, service)
-		return ctx, nil
+		// Register a startup function that will create and register the mock later
+		startupOpt := core.ContextWithStartupFunc(func(coreCtx core.Context) error {
+			// Cast the core.Context back to TestContext to access the TB
+			tctx, ok := coreCtx.(TestContext)
+			if !ok {
+				return fmt.Errorf("context is not a TestContext, cannot use WithMockService")
+			}
+
+			// Create the mock instance using the test's TB
+			mockInstance := mockConstructor(tctx.T())
+
+			// Ensure the mock implements core.Service
+			if _, ok := mockInstance.(core.Service); !ok {
+				return fmt.Errorf("mock for service '%s' does not implement core.Service", id)
+			}
+
+			// Register the mock in the context
+			tctx.RegisterService(id, mockInstance)
+
+			return nil
+		})
+
+		// Apply the startup option to the context
+		return ProcessCtxOptions(ctx, WrapCoreOption(startupOpt))
 	}
 }
 
@@ -802,6 +825,45 @@ func WrapCoreOptions(opts []core.ContextBuilderOption) []TestContextBuilderOptio
 		wrapped = append(wrapped, WrapCoreOption(opt))
 	}
 	return wrapped
+}
+
+type MockServiceFactory = func(interface {
+	mock.TestingT
+	Cleanup(func())
+}) core.Service
+
+// WithMockServiceFactory creates a TestContextBuilderOption that registers a service
+// by calling a factory function during the test context's BootEnvironment phase.
+// This allows mocks that require the testing.TB instance to be created with the
+// correct TB for each individual test run.
+func WithMockServiceFactory(id string, factory MockServiceFactory) TestContextBuilderOption {
+	return func(ctx TestContext) (TestContext, error) {
+		// We don't create the service here. Instead, we register a startup function
+		// that will create and register the service later, when BootEnvironment runs.
+		startupOpt := core.ContextWithStartupFunc(func(coreCtx core.Context) error {
+			// Cast the core.Context back to TestContext to access the TB
+			tctx, ok := coreCtx.(TestContext)
+			if !ok {
+				// This should not happen if the context is created by the testing package
+				return fmt.Errorf("context is not a TestContext, cannot use WithMockServiceFactory")
+			}
+
+			// Call the factory function to create the service using the test's TB
+			serviceInstance := factory(tctx.T())
+
+			// Register the created service in the context
+			tctx.RegisterService(id, serviceInstance)
+
+			// The testing.TB.Cleanup registered by SetupTest should handle
+			// verifying expectations on mocks created with tctx.T().
+
+			return nil
+		})
+
+		// Apply the startup option to the context
+		// We need to wrap the core.ContextWithStartupFunc option
+		return ProcessCtxOptions(ctx, WrapCoreOption(startupOpt))
+	}
 }
 
 // --- Modular Mock Service Setup Functions ---


### PR DESCRIPTION
- Enhanced testing documentation with:
  - Added example for TestServiceWithMockDependency
  - Clarified DefaultTestContextOptions behavior
  - Documented all default mock services included
  - Added documentation for WithMockServiceFactory

- Added new WithMockServiceFactory function to support:
  - Creating mock services during BootEnvironment phase
  - Access to testing.TB instance for mock setup
  - Better integration with mock expectations and cleanup

- Updated WithMockService to use factory pattern consistently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded and clarified testing documentation with detailed explanations and new examples, including usage of mock service factories and context options.
  - Improved descriptions of default context options and clarified the behavior of in-memory SQLite usage.
  - Enhanced formatting and terminology for better clarity.

- **New Features**
  - Added support for registering mock services using a factory function, allowing integration of mocks that require access to the test instance.
  - Updated mock service registration to defer creation until the appropriate test phase, ensuring proper setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->