### PR TITLE
fix(testing): relax MockServiceFactory type constraint and add service validation

### DIFF
--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -830,7 +830,7 @@ func WrapCoreOptions(opts []core.ContextBuilderOption) []TestContextBuilderOptio
 type MockServiceFactory = func(interface {
 	mock.TestingT
 	Cleanup(func())
-}) core.Service
+}) any
 
 // WithMockServiceFactory creates a TestContextBuilderOption that registers a service
 // by calling a factory function during the test context's BootEnvironment phase.
@@ -851,8 +851,14 @@ func WithMockServiceFactory(id string, factory MockServiceFactory) TestContextBu
 			// Call the factory function to create the service using the test's TB
 			serviceInstance := factory(tctx.T())
 
+			// Ensure the mock implements core.Service
+			service, ok := serviceInstance.(core.Service)
+			if !ok {
+				return fmt.Errorf("mock for service '%s' does not implement core.Service", id)
+			}
+
 			// Register the created service in the context
-			tctx.RegisterService(id, serviceInstance)
+			tctx.RegisterService(id, service)
 
 			// The testing.TB.Cleanup registered by SetupTest should handle
 			// verifying expectations on mocks created with tctx.T().


### PR DESCRIPTION
- Changed MockServiceFactory return type from core.Service to any to be more flexible
- Added explicit type check in WithMockServiceFactory to ensure registered services implement core.Service
- Maintains type safety while allowing more flexible mock creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling when registering mock services by ensuring they implement the required interface, providing clearer feedback if they do not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->