### PR TITLE
refactor(config): move validation utilities to separate file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,9 +1,6 @@
 package config
 
 import (
-	"fmt"
-	"github.com/Oudwins/zog"
-	"github.com/Oudwins/zog/conf"
 	"go.lumeweb.com/configmanager"
 	"go.lumeweb.com/configmanager/source"
 	"go.uber.org/zap"
@@ -38,56 +35,4 @@ type Manager interface {
 type Config struct {
 	Core   CoreConfig              `config:"core"`
 	Plugin map[string]PluginEntity `config:"plugin"`
-}
-
-func ZogUInt(opts ...zog.SchemaOption) *zog.NumberSchema[uint] {
-	s := &zog.NumberSchema[uint]{}
-
-	// Custom coercer to handle the type alias conversion during coercion.
-	customCoercer := func(data any) (any, error) {
-		num, err := conf.Coercers.Int(data) // Use the default string coercer first
-		if err != nil {
-			return nil, err
-		}
-
-		// Ensure the value is non-negative for unsigned types
-		if num.(int) < 0 {
-			return nil, fmt.Errorf("value must be non-negative, got %d", num.(int))
-		}
-
-		return num, nil
-	}
-
-	opts = append(opts, zog.WithCoercer(customCoercer))
-
-	for _, opt := range opts {
-		opt(s)
-	}
-	return s
-}
-
-func ZogUInt64(opts ...zog.SchemaOption) *zog.NumberSchema[uint64] {
-	s := &zog.NumberSchema[uint64]{}
-
-	// Custom coercer to handle the type alias conversion during coercion.
-	customCoercer := func(data any) (any, error) {
-		num, err := conf.Coercers.Int(data) // Use the default string coercer first
-		if err != nil {
-			return nil, err
-		}
-
-		// Ensure the value is non-negative for unsigned types
-		if num.(int) < 0 {
-			return nil, fmt.Errorf("value must be non-negative, got %d", num.(int))
-		}
-
-		return num, nil
-	}
-
-	opts = append(opts, zog.WithCoercer(customCoercer))
-
-	for _, opt := range opts {
-		opt(s)
-	}
-	return s
 }

--- a/config/validators.go
+++ b/config/validators.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"github.com/Oudwins/zog"
+	"github.com/Oudwins/zog/conf"
+)
+
+// StringLike creates a StringSchema for type aliases of string.
+func ZogStringLike[T ~string](opts ...zog.SchemaOption) *zog.StringSchema[T] {
+	s := &zog.StringSchema[T]{}
+
+	// Custom coercer to handle the type alias conversion during coercion.
+	customCoercer := func(data any) (any, error) {
+		str, err := conf.Coercers.String(data)
+		if err != nil {
+			return nil, err
+		}
+		return T(str.(string)), nil
+	}
+
+	opts = append(opts, zog.WithCoercer(customCoercer))
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func makeUintCoercer[T ~uint | ~uint64](parseFn func(any) (T, error)) func(any) (any, error) {
+	return func(data any) (any, error) {
+		num, err := parseFn(data)
+		if err != nil {
+			return nil, err
+		}
+		return num, nil
+	}
+}
+
+// ZogUInt creates a NumberSchema for uint values
+func ZogUInt(opts ...zog.SchemaOption) *zog.NumberSchema[uint] {
+	s := &zog.NumberSchema[uint]{}
+	parseFn := func(data any) (uint, error) {
+		num, err := conf.Coercers.Int(data)
+		if err != nil {
+			return 0, err
+		}
+		if num.(int) < 0 {
+			return 0, fmt.Errorf("value must be non-negative, got %d", num.(int))
+		}
+		return uint(num.(int)), nil
+	}
+	opts = append(opts, zog.WithCoercer(makeUintCoercer(parseFn)))
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// ZogUInt64 creates a NumberSchema for uint64 values
+func ZogUInt64(opts ...zog.SchemaOption) *zog.NumberSchema[uint64] {
+	s := &zog.NumberSchema[uint64]{}
+	parseFn := func(data any) (uint64, error) {
+		str := fmt.Sprintf("%v", data)
+		return strconv.ParseUint(str, 10, 64)
+	}
+	opts = append(opts, zog.WithCoercer(makeUintCoercer(parseFn)))
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}


### PR DESCRIPTION
- Extracted ZogUInt, ZogUInt64 and related validation functions from config.go
- Created new validators.go file to contain all validation utilities
- Simplified validation function implementations by extracting common coercer logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced schema validators for custom string and unsigned integer types, improving input validation for these data types.

* **Refactor**
  * Relocated and streamlined unsigned integer schema helpers to a dedicated file, resulting in a more organized configuration structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->