### PR TITLE
refactor(renter): remove redundancy settings API dependency

### DIFF
--- a/core/renter.go
+++ b/core/renter.go
@@ -32,7 +32,6 @@ type RenterService interface {
 	DeleteObject(ctx context.Context, bucket string, fileName string) error
 	UpdateGougingSettings(ctx context.Context, settings api.GougingSettings) error
 	GougingSettings(ctx context.Context) (api.GougingSettings, error)
-	RedundancySettings(ctx context.Context) (api.RedundancySettings, error)
 	SlabSize(ctx context.Context) (uint64, error)
 
 	Service

--- a/go.mod
+++ b/go.mod
@@ -194,5 +194,4 @@ replace (
 	github.com/go-co-op/gocron/v2 => github.com/LumeWeb/gocron/v2 v2.0.0-20250627042150-965509f062b0
 	github.com/go-viper/mapstructure/v2 => github.com/LumeWeb/mapstructure/v2 v2.0.0-20241213212524-92525f5828be
 	github.com/tus/tusd/v2 => github.com/LumeWeb/tusd/v2 v2.2.3-0.20241020013555-e29b4c6c01b7
-	gorm.io/plugin/dbresolver => gorm.io/plugin/dbresolver v1.5.3
 )

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ github.com/gofiber/fiber/v2 v2.52.5/go.mod h1:KEOE+cXMhXG0zHc9d8+E38hoX+ZN7bhOtg
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
@@ -445,6 +446,7 @@ go.sia.tech/jape v0.14.0 h1:hyocTKqvcji+rC1vDE1djINlpErQQVDS6zoLMmxW3Xs=
 go.sia.tech/jape v0.14.0/go.mod h1:tONxoKrNr0iQWzBCygwlTkGoGjuEhyVpLGInvGd2mGY=
 go.sia.tech/mux v1.4.0 h1:LgsLHtn7l+25MwrgaPaUCaS8f2W2/tfvHIdXps04sVo=
 go.sia.tech/mux v1.4.0/go.mod h1:iNFi9ifFb2XhuD+LF4t2HBb4Mvgq/zIPKqwXU/NlqHA=
+go.sia.tech/renterd v1.1.1 h1:6d3uBFdXYdC6kN3LB37H44FYmXu+aDVqfbDAvdedtsg=
 go.sia.tech/renterd/v2 v2.4.0 h1:OLUXF7flQFWGaJznDJRjuqhP33QL7nPM4hr7g4WcayM=
 go.sia.tech/renterd/v2 v2.4.0/go.mod h1:A8ZYz7bskS7dLmOzFSu82T2TkkxexZ/MaM6N+rvhXZ4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/service/renter.go
+++ b/service/renter.go
@@ -26,6 +26,11 @@ import (
 
 var _ core.RenterService = (*RenterDefault)(nil)
 
+const (
+	// TODO: This is a workaround as we no longer have API access to fetch the redundancy settings
+	minShards = 10
+)
+
 func init() {
 	core.RegisterService(core.ServiceInfo{
 		ID: core.RENTER_SERVICE,
@@ -400,29 +405,8 @@ func (r *RenterDefault) GougingSettings(ctx context.Context) (api.GougingSetting
 	return settings, nil
 }
 
-func (r *RenterDefault) RedundancySettings(ctx context.Context) (api.RedundancySettings, error) {
-	var settings api.RedundancySettings
-	client, err := r.getBusClient()
-	if err != nil {
-		return api.RedundancySettings{}, err
-	}
-	settings, err = client.RedundancySettings(ctx)
-
-	if err != nil {
-		return api.RedundancySettings{}, err
-	}
-
-	return settings, nil
-}
-
-func (r *RenterDefault) SlabSize(ctx context.Context) (uint64, error) {
-	settings, err := r.RedundancySettings(ctx)
-
-	if err != nil {
-		return 0, err
-	}
-
-	return uint64(settings.MinShards * rhpv2.SectorSize), nil
+func (r *RenterDefault) SlabSize(_ context.Context) (uint64, error) {
+	return uint64(minShards * rhpv2.SectorSize), nil
 }
 
 func (r *RenterDefault) Host(ctx context.Context, host types.PublicKey) (api.Host, error) {


### PR DESCRIPTION
- Removed RedundancySettings method from core Renter interface
- Simplified SlabSize calculation to use constant minShards (10)
- Removed unused gorm dbresolver dependency
- Updated go.sum with new dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated slab size calculation to use a fixed value, ensuring consistent behavior when fetching redundancy settings is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->