### PR TITLE
feat(cron): add retry policy support and workflow cron integration

### DIFF
--- a/core/cron.go
+++ b/core/cron.go
@@ -42,6 +42,19 @@ type Cronable interface {
 	ScheduleJobs(cron CronService) error
 }
 
+type RetryPolicy struct {
+	MaxRetries    int           `json:"max_retries"`    // Maximum number of retry attempts (0 means no retries)
+	InitialDelay  time.Duration `json:"initial_delay"`  // Initial delay between retries
+	BackoffFactor float64       `json:"backoff_factor"` // Multiplier for exponential backoff (1.0 for constant delay)
+}
+
+// DefaultRetryPolicy provides sensible defaults for job retries
+var DefaultRetryPolicy = &RetryPolicy{
+	MaxRetries:    3,                  // Retry up to 3 times
+	InitialDelay:  5 * time.Minute,    // Start with 5 minute delay
+	BackoffFactor: 1.5,                // Exponential backoff factor
+}
+
 // CronScheduleDefinition defines a serializable schedule definition for cron jobs.
 // The meaning of fields depends on the CronScheduleType:
 //   - Daily: Runs every X days at specified time
@@ -50,21 +63,13 @@ type Cronable interface {
 //   - Cron: Uses cron expression for scheduling
 //   - Once: Runs once at specified time
 type CronScheduleDefinition struct {
-	Type CronScheduleType `json:"type"` // Type of schedule (daily, weekly, etc)
-
-	Interval uint `json:"interval,omitempty"` // Frequency multiplier based on type:
-	// - Daily: Days between runs (1 = daily, 2 = every 2 days)
-	// - Weekly: Weeks between runs (1 = weekly, 2 = biweekly)
-	// - Monthly: Months between runs (1 = monthly, 2 = every 2 months)
-	// - Cron/Once: Not used
-
-	AtTime time.Time `json:"at_time,omitempty"` // Execution time
-
-	DayOfWeek string `json:"day_of_week,omitempty"` // Day of week for weekly schedules (e.g. "Monday")
-
-	DayOfMonth int `json:"day_of_month,omitempty"` // Day of month for monthly schedules (1-31)
-
-	CronExpression string `json:"cron_expression,omitempty"` // Cron expression for CronScheduleTypeCron
+	Type           CronScheduleType `json:"type"`                      // Type of schedule (daily, weekly, etc)
+	Interval       uint             `json:"interval,omitempty"`        // Frequency multiplier based on type
+	AtTime         time.Time        `json:"at_time,omitempty"`         // Execution time
+	DayOfWeek      string           `json:"day_of_week,omitempty"`     // Day of week for weekly schedules
+	DayOfMonth     int              `json:"day_of_month,omitempty"`    // Day of month for monthly schedules
+	CronExpression string           `json:"cron_expression,omitempty"` // Cron expression for CronScheduleTypeCron
+	RetryPolicy    *RetryPolicy     `json:"retry_policy,omitempty"`    // Retry behavior configuration
 }
 
 // NewCronScheduleDefinition creates a new CronScheduleDefinition with defaults:
@@ -365,7 +370,7 @@ type CronService interface {
 	RegisterJobType(jobType string, factory CronJobFactoryFunc, defaultSchedule *CronScheduleDefinition) error
 
 	// RegisterJob registers a fully configured job instance.
-	RegisterJob(job CronJob) error
+	RegisterJob(job CronJob, retryPolicy *RetryPolicy) error
 
 	// RegisterPluginJobs registers all cron jobs from a plugin.
 	RegisterPluginJobs(plugin PluginInfo) error

--- a/core/workflow.go
+++ b/core/workflow.go
@@ -35,6 +35,22 @@ type WorkflowCoordinator interface {
 type WorkflowService interface {
 	Service
 	WorkflowCoordinator
+
+	// ExecuteWorkflowStep executes the operation handler for a workflow step
+	ExecuteWorkflowStep(ctx context.Context, requestID uint) error
+
+	// CanTransition checks if a workflow step can be transitioned from its current state
+	CanTransition(ctx context.Context, requestID uint) (bool, error)
+
+	// GetWorkflowStepInfo returns information about a specific workflow step
+	GetWorkflowStepInfo(ctx context.Context, requestID uint) (*WorkflowStepInfo, error)
+}
+
+// WorkflowStepInfo provides information about a workflow step
+type WorkflowStepInfo struct {
+	Operation       string
+	FailureBehavior FailureBehavior
+	Status          string
 }
 
 // OperationStep defines a single step in a workflow
@@ -47,6 +63,9 @@ type OperationStep struct {
 
 	// What to do if this step fails
 	FailureBehavior FailureBehavior
+
+	// Whether to delegate execution to cron system
+	DelegateToCron bool
 }
 
 // FailureBehavior defines behavior when a step fails
@@ -60,8 +79,9 @@ const (
 
 // WorkflowDefinition represents a registered workflow
 type WorkflowDefinition struct {
-	Name  string
-	Steps []OperationStep
+	Name               string
+	Steps              []OperationStep
+	AutoTriggerFirstStep bool // Whether to automatically trigger first step execution
 }
 
 // WorkflowStatus provides current status of a workflow instance

--- a/db/migrations/mysql/20250308183521_init.sql
+++ b/db/migrations/mysql/20250308183521_init.sql
@@ -73,6 +73,7 @@ CREATE TABLE `cron_jobs`
     `failures`       bigint unsigned DEFAULT NULL,
     `state`          varchar(20)     DEFAULT 'queued',
     `last_heartbeat` datetime(3)     DEFAULT NULL,
+    `retry_policy`   longtext        DEFAULT NULL,
     `version`        bigint unsigned DEFAULT '0',
     PRIMARY KEY (`id`),
     UNIQUE KEY `idx_cron_jobs_uuid` (`uuid`),

--- a/db/migrations/sqlite/20250308183521_init.sql
+++ b/db/migrations/sqlite/20250308183521_init.sql
@@ -134,6 +134,7 @@ CREATE TABLE `cron_jobs`
     `failures`       integer,
     `state`          varchar(20) DEFAULT 'queued',
     `last_heartbeat` datetime,
+    `retry_policy`   text,
     `version`        integer DEFAULT 0
 );
 CREATE INDEX `idx_cron_jobs_deleted_at` ON `cron_jobs` (`deleted_at`);

--- a/db/models/cron_job.go
+++ b/db/models/cron_job.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"go.lumeweb.com/portal/db/types"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	"time"
 )
@@ -40,13 +41,14 @@ type CronJob struct {
 	Origin        string
 	SourceID      string
 	JobType       string
-	Args          string
-	SchedDef      string
+	Args          datatypes.JSON
+	SchedDef      datatypes.JSON
 	ScheduleType  string
 	State         CronJobState
 	LastRun       *time.Time
 	LastHeartbeat *time.Time
 	Failures      uint
+	RetryPolicy   datatypes.JSON
 	Version       int64
 }
 

--- a/service/cron.go
+++ b/service/cron.go
@@ -11,6 +11,7 @@ import (
 	"go.lumeweb.com/portal/db/types"
 	"go.lumeweb.com/portal/service/internal/cron"
 	"go.uber.org/zap"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	"strings"
 	"time"
@@ -27,17 +28,18 @@ func init() {
 }
 
 type CronServiceDefault struct {
-	ctx              core.Context
-	db               *gorm.DB
-	coordinator      core.CronCoordinator
-	jobFactory       core.CronJobFactory
-	scheduleRegistry core.CronScheduleRegistry
-	logger           *core.Logger
-	stateMachine     core.CronJobStateMachine
-	stopHeartbeat    chan struct{}
-	heartbeatTicker  *time.Ticker
-	monitor          core.CronMonitor
-	entities         []core.Cronable
+	ctx                core.Context
+	db                 *gorm.DB
+	coordinator        core.CronCoordinator
+	jobFactory         core.CronJobFactory
+	scheduleRegistry   core.CronScheduleRegistry
+	logger             *core.Logger
+	stateMachine       core.CronJobStateMachine
+	stopHeartbeat      chan struct{}
+	heartbeatTicker    *time.Ticker
+	monitor            core.CronMonitor
+	entities           []core.Cronable
+	defaultRetryPolicy *core.RetryPolicy
 }
 
 func (c *CronServiceDefault) initializeComponents(ctx core.Context) error {
@@ -238,7 +240,7 @@ func (c *CronServiceDefault) Coordinator() core.CronCoordinator {
 	return c.coordinator
 }
 
-func (c *CronServiceDefault) RegisterJob(job core.CronJob) error {
+func (c *CronServiceDefault) RegisterJob(job core.CronJob, retryPolicy *core.RetryPolicy) error {
 	if job == nil {
 		return fmt.Errorf("job cannot be nil")
 	}
@@ -286,7 +288,7 @@ func (c *CronServiceDefault) RegisterJob(job core.CronJob) error {
 		return fmt.Errorf("job with ID %s already exists", job.ID())
 	}
 
-	// Serialize the arguments
+	// Serialize the arguments and retry policy
 	var argsBytes []byte
 	if job.Args() != nil {
 		var err error
@@ -298,6 +300,18 @@ func (c *CronServiceDefault) RegisterJob(job core.CronJob) error {
 		if string(argsBytes) == "null" {
 			argsBytes = nil
 		}
+	}
+
+	// Use provided retry policy or default if none specified
+	if retryPolicy == nil {
+		retryPolicy = core.DefaultRetryPolicy
+	}
+
+	var retryPolicyBytes []byte
+	var err error
+	retryPolicyBytes, err = json.Marshal(retryPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal retry policy: %w", err)
 	}
 
 	// Get schedule definition from job
@@ -317,14 +331,15 @@ func (c *CronServiceDefault) RegisterJob(job core.CronJob) error {
 
 	// Create the database record
 	cronJob := models.CronJob{
-		UUID:     types.FromUUID(job.ID()),
-		Origin:   job.Origin(),
-		SourceID: job.SourceID(),
-		JobType:  jobType,
-		Args:     string(argsBytes),
-		SchedDef: string(schedDefBytes),
-		State:    models.CronJobStateQueued,
-		Version:  1,
+		UUID:        types.FromUUID(job.ID()),
+		Origin:      job.Origin(),
+		SourceID:    job.SourceID(),
+		JobType:     jobType,
+		Args:        datatypes.JSON(argsBytes),
+		RetryPolicy: datatypes.JSON(retryPolicyBytes),
+		SchedDef:    datatypes.JSON(schedDefBytes),
+		State:       models.CronJobStateQueued,
+		Version:     1,
 	}
 
 	if err := c.db.Create(&cronJob).Error; err != nil {
@@ -365,7 +380,7 @@ func (s *CronServiceDefault) RegisterJobType(
 		if err != nil {
 			return fmt.Errorf("failed to create default job: %w", err)
 		}
-		return s.RegisterJob(job)
+		return s.RegisterJob(job, defaultSchedule.RetryPolicy)
 	}
 	return nil
 }

--- a/service/internal/cron/job_creator.go
+++ b/service/internal/cron/job_creator.go
@@ -40,16 +40,26 @@ func (j *JobCreator) CreateFromDB(jobID uuid.UUID) (core.CronJob, error) {
 	}
 
 	// Populate job arguments
-	if err := j.populateJobArguments(job, cronJob.Args); err != nil {
+	if err := j.populateJobArguments(job, string(cronJob.Args), string(cronJob.RetryPolicy)); err != nil {
 		return nil, err
 	}
 
 	return job, nil
 }
 
-func (j *JobCreator) populateJobArguments(job core.CronJob, args string) error {
-	if len(args) == 0 {
+func (j *JobCreator) populateJobArguments(job core.CronJob, args string, retryPolicy string) error {
+	if len(args) == 0 && len(retryPolicy) == 0 {
 		return nil
+	}
+
+	if len(retryPolicy) > 0 {
+		var policy core.RetryPolicy
+		if err := json.Unmarshal([]byte(retryPolicy), &policy); err != nil {
+			return fmt.Errorf("failed to unmarshal retry policy: %w", err)
+		}
+		if jobWithPolicy, ok := job.(interface{ SetRetryPolicy(policy *core.RetryPolicy) }); ok {
+			jobWithPolicy.SetRetryPolicy(&policy)
+		}
 	}
 
 	argsPtr := job.Args()

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -11,6 +11,7 @@ import (
 	"go.lumeweb.com/portal/db/types"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
+	"math"
 	"sync"
 	"time"
 )
@@ -32,6 +33,10 @@ type StandaloneCoordinator struct {
 	failureMu     sync.Mutex
 	maxFailures   int
 }
+
+const (
+	maxRetryDelay = 24 * time.Hour // Maximum allowed delay for retries
+)
 
 type CoordinatorOptions struct {
 	JobCreator   *JobCreator
@@ -182,6 +187,46 @@ func (s *StandaloneCoordinator) EnqueueJob(jobID uuid.UUID) error {
 		return s.ExecuteJob(jobID)
 	}
 
+	// Calculate delay if this is a retry
+	var delay time.Duration
+	if failures, exists := s.failureCounts[jobID]; exists && failures > 0 {
+		var retryPolicy *core.RetryPolicy
+		if dbJob, err := s.getJobRecord(jobID); err == nil && len(dbJob.RetryPolicy) > 0 {
+			if err := json.Unmarshal([]byte(dbJob.RetryPolicy), &retryPolicy); err == nil && retryPolicy != nil {
+				// Validate retry policy parameters
+				if retryPolicy.InitialDelay < 0 {
+					s.logger.Error("Invalid retry policy: InitialDelay cannot be negative",
+						zap.String("jobID", jobID.String()),
+						zap.Duration("initialDelay", retryPolicy.InitialDelay))
+					return fmt.Errorf("invalid retry policy: InitialDelay cannot be negative")
+				}
+				if retryPolicy.BackoffFactor < 1 {
+					s.logger.Error("Invalid retry policy: BackoffFactor must be >= 1",
+						zap.String("jobID", jobID.String()),
+						zap.Float64("backoffFactor", retryPolicy.BackoffFactor))
+					return fmt.Errorf("invalid retry policy: BackoffFactor must be >= 1")
+				}
+				if retryPolicy.MaxRetries < 0 {
+					s.logger.Error("Invalid retry policy: MaxRetries cannot be negative",
+						zap.String("jobID", jobID.String()),
+						zap.Int("maxRetries", retryPolicy.MaxRetries))
+					return fmt.Errorf("invalid retry policy: MaxRetries cannot be negative")
+				}
+
+				delay = retryPolicy.InitialDelay * time.Duration(math.Pow(retryPolicy.BackoffFactor, float64(failures-1)))
+				// Cap the delay at maxRetryDelay
+				if delay > maxRetryDelay {
+					delay = maxRetryDelay
+				}
+			}
+		}
+	}
+
+	// Apply delay to job definition if needed
+	if delay > 0 {
+		jobDef = gocron.OneTimeJob(gocron.OneTimeJobStartDateTime(time.Now().Add(delay)))
+	}
+
 	// Define the before job runs event listener
 	beforeJobRuns := func(jobID uuid.UUID, jobName string) {
 		s.logger.Debug("Before job runs", zap.String("jobID", jobID.String()), zap.String("jobName", jobName))
@@ -213,7 +258,21 @@ func (s *StandaloneCoordinator) EnqueueJob(jobID uuid.UUID) error {
 		// Increment failure count
 		s.failureCounts[jobID]++
 
-		if s.failureCounts[jobID] >= s.maxFailures {
+		var retryPolicy *core.RetryPolicy
+		if dbJob, err := s.getJobRecord(jobID); err == nil && len(dbJob.RetryPolicy) > 0 {
+			if err := json.Unmarshal([]byte(dbJob.RetryPolicy), &retryPolicy); err != nil {
+				s.logger.Error("Failed to parse retry policy",
+					zap.String("jobID", jobID.String()),
+					zap.Error(err))
+			}
+		}
+
+		maxFailures := s.maxFailures
+		if retryPolicy != nil && retryPolicy.MaxRetries > 0 {
+			maxFailures = retryPolicy.MaxRetries
+		}
+
+		if s.failureCounts[jobID] >= maxFailures {
 			s.logger.Error("Job exceeded maximum failure threshold - marking as permanently failed",
 				zap.String("jobID", jobID.String()),
 				zap.Int("failures", s.failureCounts[jobID]))

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -17,13 +17,18 @@ import (
 )
 
 var _ core.WorkflowService = (*WorkflowCoordinatorDefault)(nil)
+var _ core.Cronable = (*WorkflowCoordinatorDefault)(nil)
+
+var (
+	noRetryPolicy = &core.RetryPolicy{MaxRetries: 0}
+)
 
 // Register service
 func init() {
 	core.RegisterService(core.ServiceInfo{
 		ID:      core.WORKFLOW_SERVICE,
 		Factory: NewWorkflowCoordinator,
-		Depends: []string{core.REQUEST_SERVICE},
+		Depends: []string{core.REQUEST_SERVICE, core.CRON_SERVICE},
 	})
 }
 
@@ -51,9 +56,25 @@ type WorkflowCoordinatorDefault struct {
 	ctx         core.Context
 	logger      *core.Logger
 	requestSvc  core.RequestService
+	cronService core.CronService
 	db          *gorm.DB
 	workflows   map[string]*core.WorkflowDefinition
 	workflowsMu sync.RWMutex
+}
+
+func (w *WorkflowCoordinatorDefault) RegisterTasks(cron core.CronService) error {
+	err := cron.RegisterJobType(workflowStepExecutorJobType, func() (core.CronJob, error) {
+		return newWorkflowStepExecutorJob(), nil
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *WorkflowCoordinatorDefault) ScheduleJobs(_ core.CronService) error {
+	return nil
 }
 
 // NewWorkflowCoordinator creates a new workflow coordinator
@@ -67,7 +88,10 @@ func NewWorkflowCoordinator() (core.Service, []core.ContextBuilderOption, error)
 			coordinator.ctx = ctx
 			coordinator.logger = ctx.ServiceLogger(coordinator)
 			coordinator.requestSvc = core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
+			coordinator.cronService = core.GetService[core.CronService](ctx, core.CRON_SERVICE)
 			coordinator.db = ctx.DB()
+
+			coordinator.cronService.RegisterEntity(coordinator)
 			return nil
 		}),
 	)
@@ -210,6 +234,28 @@ func (w *WorkflowCoordinatorDefault) StartWorkflow(ctx context.Context, name str
 		zap.String("workflow", workflow.Name),
 		zap.Uint("requestID", createdReq.ID))
 
+	// Auto-trigger first step if configured
+	if workflow.AutoTriggerFirstStep {
+		firstStep := workflow.Steps[0]
+		if firstStep.DelegateToCron {
+			if err := w.dispatchToCron(ctx, createdReq.ID); err != nil {
+				w.logger.Error("Failed to dispatch first step to cron",
+					zap.String("workflow", workflow.Name),
+					zap.Uint("requestID", createdReq.ID),
+					zap.Error(err))
+				return createdReq, nil // Return request even if cron dispatch fails
+			}
+		} else {
+			if err := w.ExecuteWorkflowStep(ctx, createdReq.ID); err != nil {
+				w.logger.Error("Failed to execute first step",
+					zap.String("workflow", workflow.Name),
+					zap.Uint("requestID", createdReq.ID),
+					zap.Error(err))
+				return createdReq, nil // Return request even if execution fails
+			}
+		}
+	}
+
 	return createdReq, nil
 }
 
@@ -291,10 +337,25 @@ func (w *WorkflowCoordinatorDefault) CompleteWorkflowStep(ctx context.Context, r
 		return fmt.Errorf("failed to update current request metadata: %w", err)
 	}
 
-	w.logger.Info("Advanced workflow to next step",
-		zap.String("workflow", metadata.WorkflowName),
-		zap.Int("step", nextStepIdx),
-		zap.Uint("nextRequestID", createdReq.ID))
+	if nextStep.DelegateToCron {
+		if err := w.dispatchToCron(ctx, createdReq.ID); err != nil {
+			return err
+		}
+		w.logger.Info("Delegated workflow step to cron",
+			zap.String("workflow", metadata.WorkflowName),
+			zap.Int("step", nextStepIdx),
+			zap.Uint("nextRequestID", createdReq.ID))
+	} else {
+		// Execute the next step directly
+		err = w.ExecuteWorkflowStep(ctx, createdReq.ID)
+		if err != nil {
+			return err
+		}
+		w.logger.Info("Advanced workflow to next step",
+			zap.String("workflow", metadata.WorkflowName),
+			zap.Int("step", nextStepIdx),
+			zap.Uint("nextRequestID", createdReq.ID))
+	}
 
 	return nil
 }
@@ -412,7 +473,98 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStatus(ctx context.Context, requ
 	return status, nil
 }
 
+// ExecuteWorkflowStep executes the operation handler for a workflow step
+func (w *WorkflowCoordinatorDefault) ExecuteWorkflowStep(ctx context.Context, requestID uint) error {
+	// Get current request
+	req, err := w.requestSvc.GetRequest(ctx, requestID)
+	if err != nil {
+		return fmt.Errorf("failed to get request: %w", err)
+	}
+
+	// Get workflow metadata
+	var metadata WorkflowMetadata
+	if err := json.Unmarshal(req.Metadata, &metadata); err != nil {
+		return fmt.Errorf("invalid workflow meta %w", err)
+	}
+
+	// Get workflow and current step
+	workflow, err := w.GetWorkflow(metadata.WorkflowName)
+	if err != nil {
+		return err
+	}
+	currentStep := workflow.Steps[metadata.CurrentStep]
+
+	// Execute the operation handler
+	err = currentStep.Handler.Execute(ctx, req)
+	if err != nil {
+		// Fail the workflow step
+		return w.FailWorkflowStep(ctx, req.ID, err.Error())
+	}
+
+	// Complete the workflow step
+	return w.CompleteWorkflowStep(ctx, req.ID)
+}
+
+// CanTransition checks if a workflow step can be transitioned from its current state
+func (w *WorkflowCoordinatorDefault) CanTransition(ctx context.Context, requestID uint) (bool, error) {
+	// Get current request
+	req, err := w.requestSvc.GetRequest(ctx, requestID)
+	if err != nil {
+		return false, fmt.Errorf("failed to get request: %w", err)
+	}
+
+	// Check if the request is already completed or failed
+	if req.Status == models.RequestStatusCompleted || req.Status == models.RequestStatusFailed {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// GetWorkflowStepInfo returns information about a specific workflow step
+func (w *WorkflowCoordinatorDefault) GetWorkflowStepInfo(ctx context.Context, requestID uint) (*core.WorkflowStepInfo, error) {
+	// Get current request
+	req, err := w.requestSvc.GetRequest(ctx, requestID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get request: %w", err)
+	}
+
+	// Parse metadata
+	var metadata WorkflowMetadata
+	if err := json.Unmarshal(req.Metadata, &metadata); err != nil {
+		return nil, fmt.Errorf("invalid workflow meta %w", err)
+	}
+
+	workflow, err := w.GetWorkflow(metadata.WorkflowName)
+	if err != nil {
+		return nil, err
+	}
+
+	currentStep := workflow.Steps[metadata.CurrentStep]
+
+	return &core.WorkflowStepInfo{
+		Operation:       currentStep.Operation,
+		FailureBehavior: currentStep.FailureBehavior,
+		Status:          string(req.Status),
+	}, nil
+}
+
 // scheduleRetry schedules a retry for a failed step
+func (w *WorkflowCoordinatorDefault) dispatchToCron(ctx context.Context, requestID uint) error {
+	// Create and register the workflow step executor job
+	job, err := w.cronService.JobFactory().CreateJob(workflowStepExecutorJobType)
+	if err != nil {
+		return fmt.Errorf("failed to create job instance: %w", err)
+	}
+
+	job.SetArgs(requestID)
+
+	if err := w.cronService.RegisterJob(job, noRetryPolicy); err != nil {
+		return fmt.Errorf("failed to register workflow step job: %w", err)
+	}
+	return nil
+}
+
 func (w *WorkflowCoordinatorDefault) scheduleRetry(ctx context.Context, requestID uint) error {
 	// Get current request
 	req, err := w.requestSvc.GetRequest(ctx, requestID)

--- a/service/workflow_cron.go
+++ b/service/workflow_cron.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+)
+
+const workflowStepExecutorJobType = "core.workflow.step_executor"
+
+type workflowStepExecutorJob struct {
+	*core.BaseCronJob
+}
+
+func newWorkflowStepExecutorJob() *workflowStepExecutorJob {
+	return &workflowStepExecutorJob{
+		BaseCronJob: core.NewBaseCronJob(
+			uuid.New(),
+			core.JobOriginCore,
+			workflowStepExecutorJobType,
+			"Workflow Step Executor",
+			nil,
+			nil,
+		),
+	}
+}
+
+func (j *workflowStepExecutorJob) Run(ctx core.Context) error {
+	workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+	if workflowSvc == nil {
+		return fmt.Errorf("%s", "failed to get workflow service")
+	}
+
+	// args represents the workflow step requestID to execute
+	args, ok := j.Args().(uint)
+	if !ok {
+		return fmt.Errorf("invalid job arguments type, expected uint got %T", j.Args())
+	}
+
+	// Check if the step can be transitioned
+	canTransition, err := workflowSvc.CanTransition(ctx, args)
+	if err != nil {
+		return fmt.Errorf("failed to check transition status: %w", err)
+	}
+
+	if !canTransition {
+		// Log and exit if the step cannot be transitioned
+		ctx.Logger().Info("Skipping workflow step execution",
+			zap.Uint("requestID", args))
+		return nil
+	}
+
+	// Execute the workflow step
+	return workflowSvc.ExecuteWorkflowStep(ctx, args)
+}

--- a/service/workflow_integration_test.go
+++ b/service/workflow_integration_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal/core"
@@ -46,13 +47,10 @@ func TestWorkflowCoordinatorDefault_RegisterWorkflow_Integration(t *testing.T) {
 		// Create a mock operation handler
 		mockHandler := coreTesting.NewMockOperationHandler(tb)
 
-		// Create a mock operation
-		mockOperation := coreTesting.NewMockOperation(tb).WithType(func() string { return operationName }).WithHandler(func() core.OperationHandler { return mockHandler })
-
 		steps := []core.OperationStep{
 			{
 				Operation: operationName,
-				Handler:   mockOperation.Handler(),
+				Handler:   mockHandler,
 			},
 		}
 
@@ -122,14 +120,11 @@ func TestWorkflowCoordinatorDefault_FailWorkflowStep_Integration(t *testing.T) {
 		// Create a mock operation handler
 		mockHandler := coreTesting.NewMockOperationHandler(tb)
 
-		// Create a mock operation
-		mockOperation := coreTesting.NewMockOperation(tb).WithType(func() string { return operationName }).WithHandler(func() core.OperationHandler { return mockHandler })
-
 		steps := []core.OperationStep{
 			{
 				Operation:       operationName,
 				FailureBehavior: core.FailWorkflow,
-				Handler:         mockOperation.Handler(),
+				Handler:         mockHandler,
 			},
 		}
 
@@ -444,6 +439,219 @@ func TestWorkflowCoordinatorDefault_GetWorkflowStatus_PreviousSteps_Integration(
 		assert.Len(tb, status.PreviousSteps, 2)
 		assert.Contains(tb, status.PreviousSteps, req1.ID)
 		assert.Contains(tb, status.PreviousSteps, req2.ID)
+
+	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, NewRequestService),
+		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator),
+	)
+}
+
+func TestWorkflowCoordinatorDefault_ExecuteWorkflowStep_Integration(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		registerTestProtocol(tb)
+
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		requestService := core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
+		require.NotNil(tb, requestService)
+
+		// 1. Define a workflow
+		workflowName := "testWorkflow"
+		operationName := "test.operation"
+
+		// Create a mock operation handler that will succeed
+		mockHandler := coreTesting.NewMockOperationHandler(tb).WithExecute(
+			func(ctx context.Context, req *models.Request) error {
+				return nil
+			},
+		)
+
+		steps := []core.OperationStep{
+			{
+				Operation: operationName,
+				Handler:   mockHandler,
+			},
+		}
+
+		// 2. Register the workflow
+		err := workflowService.RegisterWorkflow(workflowName, steps)
+		require.NoError(tb, err)
+
+		// 3. Start the workflow
+		initialData := map[string]interface{}{"key": "value"}
+		req, err := workflowService.StartWorkflow(context.Background(), workflowName, initialData)
+		require.NoError(tb, err)
+		require.NotNil(tb, req)
+
+		// 4. Execute the workflow step
+		err = workflowService.ExecuteWorkflowStep(context.Background(), req.ID)
+		require.NoError(tb, err)
+
+		// 5. Verify the request was completed
+		updatedReq, err := requestService.GetRequest(context.Background(), req.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, models.RequestStatusCompleted, updatedReq.Status)
+
+	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, NewRequestService),
+		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator),
+	)
+}
+
+func TestWorkflowCoordinatorDefault_ExecuteWorkflowStep_Failure_Integration(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		registerTestProtocol(tb)
+
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		requestService := core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
+		require.NotNil(tb, requestService)
+
+		// 1. Define a workflow
+		workflowName := "testWorkflow"
+		operationName := "test.operation"
+		failureReason := "test failure"
+
+		// Create a mock operation handler that will fail
+		mockHandler := coreTesting.NewMockOperationHandler(tb).WithExecute(
+			func(ctx context.Context, req *models.Request) error {
+				return fmt.Errorf("%s", failureReason)
+			},
+		)
+
+		steps := []core.OperationStep{
+			{
+				Operation:       operationName,
+				FailureBehavior: core.FailWorkflow,
+				Handler:         mockHandler,
+			},
+		}
+
+		// 2. Register the workflow
+		err := workflowService.RegisterWorkflow(workflowName, steps)
+		require.NoError(tb, err)
+
+		// 3. Start the workflow
+		initialData := map[string]interface{}{"key": "value"}
+		req, err := workflowService.StartWorkflow(context.Background(), workflowName, initialData)
+		require.NoError(tb, err)
+		require.NotNil(tb, req)
+
+		// 4. Execute the workflow step (should fail)
+		err = workflowService.ExecuteWorkflowStep(context.Background(), req.ID)
+		require.NoError(tb, err) // The error is handled internally
+
+		// 5. Verify the request was failed
+		updatedReq, err := requestService.GetRequest(context.Background(), req.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, models.RequestStatusFailed, updatedReq.Status)
+		assert.Equal(tb, failureReason, updatedReq.StatusMessage)
+
+	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, NewRequestService),
+		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator),
+	)
+}
+
+func TestWorkflowCoordinatorDefault_CanTransition_Integration(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		registerTestProtocol(tb)
+
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		requestService := core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
+		require.NotNil(tb, requestService)
+
+		// 1. Define a workflow
+		workflowName := "testWorkflow"
+		operationName := "test.operation"
+
+		// Create a mock operation handler
+		mockHandler := coreTesting.NewMockOperationHandler(tb)
+
+		// Create a mock operation
+		mockOperation := coreTesting.NewMockOperation(tb).WithType(func() string { return operationName }).WithHandler(func() core.OperationHandler { return mockHandler })
+
+		steps := []core.OperationStep{
+			{
+				Operation: operationName,
+				Handler:   mockOperation.Handler(),
+			},
+		}
+
+		// 2. Register the workflow
+		err := workflowService.RegisterWorkflow(workflowName, steps)
+		require.NoError(tb, err)
+
+		// 3. Start the workflow
+		initialData := map[string]interface{}{"key": "value"}
+		req, err := workflowService.StartWorkflow(context.Background(), workflowName, initialData)
+		require.NoError(tb, err)
+		require.NotNil(tb, req)
+
+		// 4. Test CanTransition with pending request
+		canTransition, err := workflowService.CanTransition(context.Background(), req.ID)
+		require.NoError(tb, err)
+		assert.True(tb, canTransition)
+
+		// 5. Complete the request
+		err = workflowService.CompleteWorkflowStep(context.Background(), req.ID)
+		require.NoError(tb, err)
+
+		// 6. Test CanTransition with completed request
+		canTransition, err = workflowService.CanTransition(context.Background(), req.ID)
+		require.NoError(tb, err)
+		assert.False(tb, canTransition)
+
+	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, NewRequestService),
+		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator),
+	)
+}
+
+func TestWorkflowCoordinatorDefault_GetWorkflowStepInfo_Integration(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		registerTestProtocol(tb)
+
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		requestService := core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
+		require.NotNil(tb, requestService)
+
+		// 1. Define a workflow
+		workflowName := "testWorkflow"
+		operationName := "test.operation"
+
+		// Create a mock operation handler
+		mockHandler := coreTesting.NewMockOperationHandler(tb)
+
+		// Create a mock operation
+		mockOperation := coreTesting.NewMockOperation(tb).WithType(func() string { return operationName }).WithHandler(func() core.OperationHandler { return mockHandler })
+
+		steps := []core.OperationStep{
+			{
+				Operation:       operationName,
+				FailureBehavior: core.FailWorkflow,
+				Handler:         mockOperation.Handler(),
+			},
+		}
+
+		// 2. Register the workflow
+		err := workflowService.RegisterWorkflow(workflowName, steps)
+		require.NoError(tb, err)
+
+		// 3. Start the workflow
+		initialData := map[string]interface{}{"key": "value"}
+		req, err := workflowService.StartWorkflow(context.Background(), workflowName, initialData)
+		require.NoError(tb, err)
+		require.NotNil(tb, req)
+
+		// 4. Get workflow step info
+		info, err := workflowService.GetWorkflowStepInfo(context.Background(), req.ID)
+		require.NoError(tb, err)
+		assert.Equal(tb, operationName, info.Operation)
+		assert.Equal(tb, core.FailWorkflow, info.FailureBehavior)
+		assert.Equal(tb, string(models.RequestStatusPending), info.Status)
 
 	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, NewRequestService),
 		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator),

--- a/service/workflow_test.go
+++ b/service/workflow_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -710,6 +711,194 @@ func TestWorkflowCoordinatorDefault_FailWorkflowStep_ContinueWorkflow(t *testing
 		// Assert
 		assert.NoError(tb, err)
 
+	}, coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator))
+}
+
+func TestWorkflowCoordinatorDefault_ExecuteWorkflowStep(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		requestService := core.GetService[*coreMocks.MockRequestService](ctx, core.REQUEST_SERVICE)
+		require.NotNil(tb, requestService)
+
+		workflowName := "testWorkflow"
+		operationName := "testOp"
+		initialData := map[string]interface{}{"key": "value"}
+
+		// Mock operation handler
+		mockHandler := coreMocks.NewMockOperationHandler(tb)
+		mockHandler.EXPECT().ValidateRequest(mock.Anything, mock.Anything).Return(nil)
+		mockHandler.EXPECT().Execute(mock.Anything, mock.Anything).Return(nil)
+		steps := []core.OperationStep{{
+			Operation: operationName,
+			Handler:   mockHandler,
+		}}
+		testWorkflowRegister(tb, workflowService, workflowName, steps)
+
+		// Mock CreateRequest to return the created request
+		mockRequest := &models.Request{
+			Operation: operationName,
+			Status:    models.RequestStatusPending,
+			Metadata:  datatypes.JSON([]byte(`{"workflow_name":"testWorkflow","current_step":0,"total_steps":1,"started_at":1751145351,"initial_data":{"key":"value"}}`)),
+		}
+		requestService.EXPECT().CreateRequest(mock.Anything, mock.Anything, mock.Anything).
+			Return(mockRequest, nil)
+		requestService.EXPECT().GetRequest(mock.Anything, mockRequest.ID).Return(mockRequest, nil)
+		requestService.EXPECT().CompleteRequest(mock.Anything, mockRequest.ID).Return(nil)
+
+		req := testWorkflowStart(tb, context.Background(), workflowService, workflowName, initialData)
+
+		// Act
+		err := workflowService.ExecuteWorkflowStep(context.Background(), req.ID)
+
+		// Assert
+		assert.NoError(tb, err)
+	}, coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator))
+}
+
+func TestWorkflowCoordinatorDefault_ExecuteWorkflowStep_Failure(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		requestService := core.GetService[*coreMocks.MockRequestService](ctx, core.REQUEST_SERVICE)
+		require.NotNil(tb, requestService)
+
+		workflowName := "testWorkflow"
+		operationName := "testOp"
+		initialData := map[string]interface{}{"key": "value"}
+		failureReason := "test failure"
+
+		// Mock operation handler
+		mockHandler := coreMocks.NewMockOperationHandler(tb)
+		mockHandler.EXPECT().ValidateRequest(mock.Anything, mock.Anything).Return(nil)
+		mockHandler.EXPECT().Execute(mock.Anything, mock.Anything).Return(fmt.Errorf("%s", failureReason))
+		steps := []core.OperationStep{{
+			Operation: operationName,
+			Handler:   mockHandler,
+		}}
+		testWorkflowRegister(tb, workflowService, workflowName, steps)
+
+		// Mock CreateRequest to return the created request
+		mockRequest := &models.Request{
+			Operation: operationName,
+			Status:    models.RequestStatusPending,
+			Metadata:  datatypes.JSON([]byte(`{"workflow_name":"testWorkflow","current_step":0,"total_steps":1,"started_at":1751145351,"initial_data":{"key":"value"}}`)),
+		}
+		requestService.EXPECT().CreateRequest(mock.Anything, mock.Anything, mock.Anything).
+			Return(mockRequest, nil)
+		requestService.EXPECT().GetRequest(mock.Anything, mockRequest.ID).Return(mockRequest, nil)
+		requestService.EXPECT().FailRequest(mock.Anything, mockRequest.ID, failureReason).Return(nil)
+
+		req := testWorkflowStart(tb, context.Background(), workflowService, workflowName, initialData)
+
+		// Act
+		err := workflowService.ExecuteWorkflowStep(context.Background(), req.ID)
+
+		// Assert
+		assert.NoError(tb, err)
+	}, coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator))
+}
+
+func TestWorkflowCoordinatorDefault_CanTransition(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		requestService := core.GetService[*coreMocks.MockRequestService](ctx, core.REQUEST_SERVICE)
+		require.NotNil(tb, requestService)
+
+		workflowName := "testWorkflow"
+		operationName := "testOp"
+		initialData := map[string]interface{}{"key": "value"}
+
+		// Mock operation handler
+		mockHandler := coreMocks.NewMockOperationHandler(tb)
+		mockHandler.EXPECT().ValidateRequest(mock.Anything, mock.Anything).Return(nil)
+		steps := []core.OperationStep{{
+			Operation: operationName,
+			Handler:   mockHandler,
+		}}
+		testWorkflowRegister(tb, workflowService, workflowName, steps)
+
+		// Mock CreateRequest to return the created request
+		mockRequest := &models.Request{
+			Operation: operationName,
+			Status:    models.RequestStatusPending,
+			Metadata:  datatypes.JSON([]byte(`{"workflow_name":"testWorkflow","current_step":0,"total_steps":1,"started_at":1751145351,"initial_data":{"key":"value"}}`)),
+		}
+		requestService.EXPECT().CreateRequest(mock.Anything, mock.Anything, mock.Anything).
+			Return(mockRequest, nil)
+		requestService.EXPECT().GetRequest(mock.Anything, mockRequest.ID).Return(mockRequest, nil)
+
+		req := testWorkflowStart(tb, context.Background(), workflowService, workflowName, initialData)
+
+		// Test pending request
+		canTransition, err := workflowService.CanTransition(context.Background(), req.ID)
+		assert.NoError(tb, err)
+		assert.True(tb, canTransition)
+
+		// Test completed request
+		mockRequest.Status = models.RequestStatusCompleted
+		canTransition, err = workflowService.CanTransition(context.Background(), req.ID)
+		assert.NoError(tb, err)
+		assert.False(tb, canTransition)
+
+		// Test failed request
+		mockRequest.Status = models.RequestStatusFailed
+		canTransition, err = workflowService.CanTransition(context.Background(), req.ID)
+		assert.NoError(tb, err)
+		assert.False(tb, canTransition)
+	}, coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator))
+}
+
+func TestWorkflowCoordinatorDefault_GetWorkflowStepInfo(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		// Arrange
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		requestService := core.GetService[*coreMocks.MockRequestService](ctx, core.REQUEST_SERVICE)
+		require.NotNil(tb, requestService)
+
+		workflowName := "testWorkflow"
+		operationName := "testOp"
+		initialData := map[string]interface{}{"key": "value"}
+
+		// Mock operation handler
+		mockHandler := coreMocks.NewMockOperationHandler(tb)
+		mockHandler.EXPECT().ValidateRequest(mock.Anything, mock.Anything).Return(nil)
+		steps := []core.OperationStep{{
+			Operation:       operationName,
+			FailureBehavior: core.FailWorkflow,
+			Handler:         mockHandler,
+		}}
+		testWorkflowRegister(tb, workflowService, workflowName, steps)
+
+		// Mock CreateRequest to return the created request
+		mockRequest := &models.Request{
+			Operation: operationName,
+			Status:    models.RequestStatusPending,
+			Metadata:  datatypes.JSON([]byte(`{"workflow_name":"testWorkflow","current_step":0,"total_steps":1,"started_at":1751145351,"initial_data":{"key":"value"}}`)),
+		}
+		requestService.EXPECT().CreateRequest(mock.Anything, mock.Anything, mock.Anything).
+			Return(mockRequest, nil)
+		requestService.EXPECT().GetRequest(mock.Anything, mockRequest.ID).Return(mockRequest, nil)
+
+		req := testWorkflowStart(tb, context.Background(), workflowService, workflowName, initialData)
+
+		// Act
+		info, err := workflowService.GetWorkflowStepInfo(context.Background(), req.ID)
+
+		// Assert
+		assert.NoError(tb, err)
+		assert.Equal(tb, operationName, info.Operation)
+		assert.Equal(tb, core.FailWorkflow, info.FailureBehavior)
+		assert.Equal(tb, string(models.RequestStatusPending), info.Status)
 	}, coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, NewWorkflowCoordinator))
 }
 


### PR DESCRIPTION
- Added RetryPolicy struct with configurable max retries, initial delay and backoff factor
- Integrated workflow steps with cron service for deferred execution
- Added workflow step executor cron job type
- Enhanced CronJob model to store retry policy as JSON
- Updated cron service to handle retry policies when registering jobs
- Added workflow step execution methods to workflow service interface
- Implemented cron delegation for workflow steps with DelegateToCron flag
- Added comprehensive tests for new functionality
- Improved workflow step execution with retry logic and status tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configurable retry policies for scheduled (cron) jobs, including maximum retries, initial delay, and exponential backoff.
  * Enabled asynchronous execution of workflow steps via cron jobs, with options to auto-trigger steps and delegate execution to the scheduler.
  * Introduced new APIs for executing workflow steps, checking transition eligibility, and retrieving step information.

* **Database**
  * Updated cron job tables to store retry policy and job arguments as JSON, supporting richer job configuration.

* **Bug Fixes**
  * Improved handling of job retries and failure thresholds based on per-job retry policies.

* **Tests**
  * Added comprehensive tests for workflow step execution, failure handling, transition checks, and step info retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->