### PR TITLE
feat(workflow): add NewScanOperation helper function

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -100,3 +100,11 @@ func NewUploadOperation(protocol string, handler OperationHandler) Operation {
 		handler,
 	)
 }
+
+func NewScanOperation(protocol string, handler OperationHandler) Operation {
+	return NewOperation(
+		fmt.Sprintf("%s.scan", protocol),
+		OpTypeScan,
+		handler,
+	)
+}


### PR DESCRIPTION
Add a convenience function NewScanOperation that creates a new scan operation with the proper naming convention for protocol-specific scan operations.

The function follows the same pattern as NewOperation but automatically formats the operation type as "<protocol>.scan" and sets the global type to OpTypeScan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for creating scan operations, allowing users to initiate scan actions for different protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->