### PR TITLE
feat(workflow): add OperationHelper interface and default implementation

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/knadh/koanf/v2"
 	"go.lumeweb.com/portal/db/models"
 )
 
@@ -107,4 +109,31 @@ func NewScanOperation(protocol string, handler OperationHandler) Operation {
 		OpTypeScan,
 		handler,
 	)
+}
+
+// OperationHelper provides helper methods for working with operations
+type OperationHelper interface {
+	// WorkflowData retrieves workflow metadata for a request
+	WorkflowData(requestID uint) (*koanf.Koanf, error)
+}
+
+// OperationHelperDefault is the default implementation of OperationHelper
+type OperationHelperDefault struct {
+	ctx Context
+}
+
+// NewOperationHelper creates a new OperationHelper instance
+func NewOperationHelper(ctx Context) OperationHelper {
+	return &OperationHelperDefault{
+		ctx: ctx,
+	}
+}
+
+// GetWorkflowData retrieves workflow metadata for a request
+func (h *OperationHelperDefault) WorkflowData(requestID uint) (*koanf.Koanf, error) {
+	// Get workflow service
+	workflow := GetService[WorkflowService](h.ctx, WORKFLOW_SERVICE)
+
+	// Get the workflow metadata
+	return workflow.GetWorkflowMetadata(h.ctx, requestID)
 }


### PR DESCRIPTION
Added new OperationHelper interface with WorkflowData method to retrieve workflow metadata. Implemented OperationHelperDefault struct that provides the default implementation using the workflow service. This provides a standardized way to access workflow metadata from operations.

The change includes:
- OperationHelper interface definition
- OperationHelperDefault implementation
- NewOperationHelper constructor
- Integration with existing workflow service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new helper for retrieving workflow metadata based on request ID, improving access to workflow information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->