### PR TITLE
feat(workflow): add StartWorkflow method to OperationHelper

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -125,6 +125,8 @@ type OperationHelper interface {
 	Context() Context
 	// Logger returns the operation logger
 	Logger() *Logger
+	// StartWorkflow starts a new workflow with the given name and options
+	StartWorkflow(name string, opts ...WorkflowOption) (*models.Request, error)
 }
 
 // OperationHelperDefault is the default implementation of OperationHelper
@@ -221,4 +223,10 @@ func (h *OperationHelperDefault) Context() Context {
 // Logger returns the operation logger
 func (h *OperationHelperDefault) Logger() *Logger {
 	return h.ctx.Logger()
+}
+
+// StartWorkflow starts a new workflow with the given name and options
+func (h *OperationHelperDefault) StartWorkflow(name string, opts ...WorkflowOption) (*models.Request, error) {
+	workflow := GetService[WorkflowService](h.ctx, WORKFLOW_SERVICE)
+	return workflow.StartWorkflow(h.ctx, name, opts...)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to start workflows directly through the operation helper interface, providing a more streamlined workflow initiation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->