### PR TITLE
feat(workflow): add workflow data update methods and caching

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -117,6 +117,10 @@ type OperationHelper interface {
 	WorkflowData(requestID uint) (*koanf.Koanf, error)
 	// StructuredWorkflowData retrieves workflow metadata and unmarshals it into the provided struct
 	StructuredWorkflowData(requestID uint, out any) error
+	// UpdateWorkflowData updates workflow metadata with the provided data map
+	UpdateWorkflowData(requestID uint, data map[string]any) error
+	// UpdateWorkflowDataStruct updates workflow metadata with the provided struct
+	UpdateWorkflowDataStruct(requestID uint, data any) error
 	// Protocol retrieves a protocol instance by ID
 	Protocol() Protocol
 	// StorageHash retrieves the storage hash from the current request
@@ -134,6 +138,7 @@ type OperationHelperDefault struct {
 	ctx       Context
 	proto     string
 	unmarshalTag string // Tag to use for unmarshaling (default: "json")
+	workflow  WorkflowService // Cached workflow service instance
 }
 
 // DefaultUnmarshalTag is the default tag used for unmarshaling
@@ -144,6 +149,7 @@ func NewOperationHelper(ctx Context) OperationHelper {
 	return &OperationHelperDefault{
 		ctx:          ctx,
 		unmarshalTag: DefaultUnmarshalTag,
+		workflow:     GetService[WorkflowService](ctx, WORKFLOW_SERVICE),
 	}
 }
 
@@ -153,6 +159,7 @@ func NewProtocolOperationHelper(ctx Context, proto string) OperationHelper {
 		ctx:          ctx,
 		proto:        proto,
 		unmarshalTag: DefaultUnmarshalTag,
+		workflow:     GetService[WorkflowService](ctx, WORKFLOW_SERVICE),
 	}
 }
 
@@ -225,8 +232,17 @@ func (h *OperationHelperDefault) Logger() *Logger {
 	return h.ctx.Logger()
 }
 
+// UpdateWorkflowData updates workflow metadata with the provided data map
+func (h *OperationHelperDefault) UpdateWorkflowData(requestID uint, data map[string]any) error {
+	return h.workflow.UpdateWorkflowData(h.ctx, requestID, data)
+}
+
+// UpdateWorkflowDataStruct updates workflow metadata with the provided struct
+func (h *OperationHelperDefault) UpdateWorkflowDataStruct(requestID uint, data any) error {
+	return h.workflow.UpdateWorkflowDataStruct(h.ctx, requestID, data, h.unmarshalTag)
+}
+
 // StartWorkflow starts a new workflow with the given name and options
 func (h *OperationHelperDefault) StartWorkflow(name string, opts ...WorkflowOption) (*models.Request, error) {
-	workflow := GetService[WorkflowService](h.ctx, WORKFLOW_SERVICE)
-	return workflow.StartWorkflow(h.ctx, name, opts...)
+	return h.workflow.StartWorkflow(h.ctx, name, opts...)
 }

--- a/core/workflow.go
+++ b/core/workflow.go
@@ -52,6 +52,13 @@ type WorkflowService interface {
 
 	// GetWorkflowMetadata returns the workflow metadata for a request
 	GetWorkflowMetadata(ctx context.Context, requestID uint) (*koanf.Koanf, error)
+
+	// UpdateWorkflowData updates workflow metadata with the provided data map
+	UpdateWorkflowData(ctx context.Context, requestID uint, data map[string]any) error
+
+	// UpdateWorkflowDataStruct updates workflow metadata with the provided struct
+	// using the specified struct tag (e.g. "json")
+	UpdateWorkflowDataStruct(ctx context.Context, requestID uint, data any, tag string) error
 }
 
 // WorkflowStepInfo provides information about a workflow step
@@ -104,6 +111,7 @@ type WorkflowOptions interface {
 	SetUserID(id uint)
 	MergeData(data WorkflowData) error
 	MergeJSON(jsonData string) error
+	MergeStruct(data any, tag string) error
 	MarshalData() ([]byte, error)
 	HasData() bool
 	GetKoanf() (*koanf.Koanf, error)
@@ -179,6 +187,25 @@ func (o *WorkflowOptionsDefault) MergeData(data WorkflowData) error {
 	return nil
 }
 
+// MergeStruct merges struct data into the cached koanf instance using the specified tag
+func (o *WorkflowOptionsDefault) MergeStruct(data any, tag string) error {
+	if o.koanfCache == nil {
+		o.koanfCache = koanf.New(".")
+	}
+	
+	k := koanf.New(".")
+	if err := k.Load(structs.Provider(data, tag), nil); err != nil {
+		return err
+	}
+	
+	if err := o.koanfCache.Merge(k); err != nil {
+		return err
+	}
+	
+	o.data = o.koanfCache.Raw()
+	return nil
+}
+
 // MergeJSON merges raw JSON data into the cached koanf instance
 func (o *WorkflowOptionsDefault) MergeJSON(jsonData string) error {
 	if jsonData == "" {
@@ -245,11 +272,7 @@ func WithWorkflowData(data WorkflowData) WorkflowOption {
 // and merged into the workflow data.
 func WithWorkflowStructData(data any, tag string) WorkflowOption {
 	return func(o WorkflowOptions) error {
-		k := koanf.New(".")
-		if err := k.Load(structs.Provider(data, tag), nil); err != nil {
-			return err
-		}
-		return o.MergeData(k.Raw())
+		return o.MergeStruct(data, tag)
 	}
 }
 

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -99,12 +99,13 @@ func (w *WorkflowCoordinatorDefault) processWorkflowOptions(opts []core.Workflow
 	}
 
 	// Serialize the final koanf data for storage
-	metadataBytes, err := options.MarshalData()
+	dataBytes, err := options.MarshalData()
 	if err != nil {
 		return nil, nil, err
 	}
+	metadataBytes := string(dataBytes)
 
-	return options, metadataBytes, nil
+	return options, []byte(metadataBytes), nil
 }
 
 // WorkflowMetadata stored in request.Metadata JSON field
@@ -638,6 +639,58 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowMetadata(ctx context.Context, re
 	}
 
 	return k, nil
+}
+
+func (w *WorkflowCoordinatorDefault) UpdateWorkflowData(ctx context.Context, requestID uint, data map[string]any) error {
+	// Get current request
+	req, err := w.requestSvc.GetRequest(ctx, requestID)
+	if err != nil {
+		return err
+	}
+
+	// Parse existing metadata
+	var metadata WorkflowMetadata
+	if err := json.Unmarshal(req.Metadata, &metadata); err != nil {
+		return fmt.Errorf("invalid workflow meta %w", err)
+	}
+
+	// Create workflow options and merge data
+	opts := core.NewWorkflowOptions()
+	if metadata.Data != "" {
+		if err := opts.MergeJSON(metadata.Data); err != nil {
+			return err
+		}
+	}
+	if err := opts.MergeData(data); err != nil {
+		return err
+	}
+
+	// Marshal back to JSON
+	dataBytes, err := opts.MarshalData()
+	if err != nil {
+		return fmt.Errorf("failed to marshal workflow data: %w", err)
+	}
+	metadata.Data = string(dataBytes)
+
+	// Update request metadata
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal workflow metadata: %w", err)
+	}
+
+	req.Metadata = metadataBytes
+	return w.requestSvc.UpdateRequest(ctx, req)
+}
+
+func (w *WorkflowCoordinatorDefault) UpdateWorkflowDataStruct(ctx context.Context, requestID uint, data any, tag string) error {
+	// Create workflow options and load struct data
+	opts := core.NewWorkflowOptions()
+	if err := opts.MergeStruct(data, tag); err != nil {
+		return err
+	}
+
+	// Use the map version to update
+	return w.UpdateWorkflowData(ctx, requestID, opts.Data())
 }
 
 // jsonToKoanf converts a JSON string to a koanf.Koanf instance


### PR DESCRIPTION
- Added UpdateWorkflowData and UpdateWorkflowDataStruct methods to OperationHelper
- Cached WorkflowService instance in OperationHelperDefault
- Added MergeStruct method to WorkflowOptions for struct merging
- Simplified WithWorkflowStructData option using new MergeStruct
- Improved workflow metadata handling in WorkflowCoordinator
- Fixed metadata byte handling in workflow service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to update workflow metadata using either a map or a struct, allowing more flexible and structured workflow data updates.

* **Refactor**
  * Improved internal handling of workflow data updates for better efficiency and maintainability.
  * Enhanced merging of structured data into workflow options for streamlined configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->