### PR TITLE
feat(workflow): add request conversion and foreground execution

### DIFF
--- a/core/workflow.go
+++ b/core/workflow.go
@@ -27,6 +27,9 @@ type WorkflowCoordinator interface {
 	// Start a new workflow instance
 	StartWorkflow(ctx context.Context, name string, opts ...WorkflowOption) (*models.Request, error)
 
+	// Convert an existing request to a workflow
+	ConvertRequestToWorkflow(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...WorkflowOption) error
+
 	// Advance workflow to next step with optional data
 	CompleteWorkflowStep(ctx context.Context, requestID uint, opts ...WorkflowOption) error
 
@@ -79,8 +82,8 @@ type OperationStep struct {
 	// What to do if this step fails
 	FailureBehavior FailureBehavior
 
-	// Whether to delegate execution to cron system
-	DelegateToCron bool
+	// Whether to run the operation in the active request directly or send to the cron system
+	Foreground bool
 }
 
 // FailureBehavior defines behavior when a step fails
@@ -192,16 +195,16 @@ func (o *WorkflowOptionsDefault) MergeStruct(data any, tag string) error {
 	if o.koanfCache == nil {
 		o.koanfCache = koanf.New(".")
 	}
-	
+
 	k := koanf.New(".")
 	if err := k.Load(structs.Provider(data, tag), nil); err != nil {
 		return err
 	}
-	
+
 	if err := o.koanfCache.Merge(k); err != nil {
 		return err
 	}
-	
+
 	o.data = o.koanfCache.Raw()
 	return nil
 }

--- a/db/migrations/mysql/20250308183521_init.sql
+++ b/db/migrations/mysql/20250308183521_init.sql
@@ -244,6 +244,7 @@ CREATE TABLE `tus_requests`
     `deleted_at`    datetime(3)     DEFAULT NULL,
     `request_id`    bigint unsigned DEFAULT NULL,
     `tus_upload_id` varchar(500)    DEFAULT NULL,
+    `upload_hash`   varbinary(64)   DEFAULT NULL,
     `completed`     tinyint(1)      DEFAULT NULL,
     PRIMARY KEY (`id`),
     UNIQUE KEY `idx_tus_requests_request_id` (`request_id`),

--- a/db/migrations/sqlite/20250308183521_init.sql
+++ b/db/migrations/sqlite/20250308183521_init.sql
@@ -272,6 +272,7 @@ CREATE TABLE `tus_requests`
     `deleted_at`    datetime,
     `request_id`    integer,
     `tus_upload_id` varchar(500),
+    `upload_hash`   varbinary(64),
     `completed`     numeric,
     CONSTRAINT `fk_tus_requests_request` FOREIGN KEY (`request_id`) REFERENCES `requests` (`id`)
 );

--- a/db/models/tus_request.go
+++ b/db/models/tus_request.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	mh "github.com/multiformats/go-multihash"
 	"go.lumeweb.com/portal/db/models/data_models"
 	"gorm.io/gorm"
 )
@@ -15,6 +16,7 @@ type TUSRequest struct {
 	RequestID   uint `gorm:"uniqueIndex"`
 	Request     Request
 	TUSUploadID string `gorm:"uniqueIndex"`
+	UploadHash  mh.Multihash
 	Completed   bool
 }
 

--- a/service/tus.go
+++ b/service/tus.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/labstack/echo/v4"
+	"github.com/samber/lo"
 	tusHandler "github.com/tus/tusd/v2/pkg/handler"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
@@ -59,18 +60,6 @@ func (t *TUSServiceDefault) ID() string {
 	return core.TUS_SERVICE
 }
 
-// Operations returns the list of operations supported by this service
-func (t *TUSServiceDefault) Operations() []core.Operation {
-	// Create and return the TUS upload operation
-	return []core.Operation{
-		core.NewOperation(
-			models.RequestOperationTusUpload,
-			core.OpTypeUpload,
-			NewTUSOperationHandler(t.ctx),
-		),
-	}
-}
-
 // Name returns the protocol name
 func (t *TUSServiceDefault) Name() string {
 	return "tus"
@@ -97,7 +86,7 @@ func (t *TUSServiceDefault) UploadExists(ctx context.Context, id string) (bool, 
 }
 
 func (t *TUSServiceDefault) UploadHashExists(ctx context.Context, hash core.StorageHash) (bool, *models.TUSRequest) {
-	req, err := t.requests.GetRequestByUploadHash(ctx, hash, core.RequestFilter{
+	req, err := t.requests.QueryRequest(ctx, &models.TUSRequest{UploadHash: hash.Multihash()}, core.RequestFilter{
 		Operation: models.RequestOperationTusUpload,
 	})
 
@@ -159,13 +148,12 @@ func (t *TUSServiceDefault) CreateUpload(ctx context.Context, hash core.StorageH
 		Protocol:  protocol.Name(),
 		Operation: models.RequestOperationTusUpload,
 		Status:    models.RequestStatusPending,
-		UserID:    uploaderID,
+		UserID:    lo.ToPtr(uploaderID),
 		SourceIP:  uploaderIP,
-		MimeType:  mimeType,
 	}
 
 	if hash != nil {
-		upload.HashType = hash.CIDType()
+		upload.CIDType = hash.CIDType()
 	}
 
 	tusData := &models.TUSRequest{TUSUploadID: uploadID}
@@ -275,7 +263,7 @@ func TUSDefaultUploadProgressHandler(e echo.Context, ctx core.Context) TUSUpload
 
 // TUSOperationHandler implements core.OperationHandler for TUS uploads
 type TUSOperationHandler struct {
-	ctx        core.Context
+	core.OperationHelper
 	tusService core.TUSService
 	logger     *core.Logger
 }
@@ -284,9 +272,8 @@ type TUSOperationHandler struct {
 func NewTUSOperationHandler(ctx core.Context) *TUSOperationHandler {
 	svc := core.GetService[core.TUSService](ctx, core.TUS_SERVICE)
 	return &TUSOperationHandler{
-		ctx:        ctx,
-		tusService: svc,
-		logger:     ctx.ServiceLogger(svc),
+		tusService:      svc,
+		OperationHelper: core.NewOperationHelper(ctx),
 	}
 }
 
@@ -299,7 +286,7 @@ func (h *TUSOperationHandler) ValidateRequest(_ context.Context, _ *models.Reque
 // Execute processes a TUS upload request
 func (h *TUSOperationHandler) Execute(ctx context.Context, req *models.Request) error {
 	// Get the TUS upload data
-	data, err := core.GetService[core.RequestService](h.ctx, core.REQUEST_SERVICE).GetRequestData(ctx, req)
+	data, err := core.GetService[core.RequestService](h.Context(), core.REQUEST_SERVICE).GetRequestData(ctx, req)
 	if err != nil {
 		return err
 	}
@@ -321,7 +308,7 @@ func (h *TUSOperationHandler) Execute(ctx context.Context, req *models.Request) 
 // GetStatus gets the status of a TUS upload request
 func (h *TUSOperationHandler) GetStatus(ctx context.Context, req *models.Request) (core.RequestStatus, error) {
 	// Get the TUS upload data
-	data, err := core.GetService[core.RequestService](h.ctx, core.REQUEST_SERVICE).GetRequestData(ctx, req)
+	data, err := core.GetService[core.RequestService](h.Context(), core.REQUEST_SERVICE).GetRequestData(ctx, req)
 	if err != nil {
 		return core.RequestStatus{}, err
 	}
@@ -354,7 +341,7 @@ func (h *TUSOperationHandler) Cleanup(_ context.Context, _ *models.Request) erro
 	return nil
 }
 
-func TUSDefaultUploadCompletedHandler(ctx core.Context, processHandler TUSUploadCallbackHandler) TUSUploadCallbackHandler {
+func TUSDefaultUploadCompletedHandler(ctx core.Context, processHandler TUSUploadCallbackHandler, workflowName string) TUSUploadCallbackHandler {
 	return func(handler *tus.TusHandler, info tusHandler.HookEvent) {
 		// Call the original handler first
 		processHandler(handler, info)
@@ -368,43 +355,51 @@ func TUSDefaultUploadCompletedHandler(ctx core.Context, processHandler TUSUpload
 			return // Not our upload, nothing to do
 		}
 
-		// Update TUS request to mark as completed
-		tusReq.Completed = true
 		requestSvc := core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
-		req, err := requestSvc.GetRequest(ctx, tusReq.RequestID)
-		if err != nil {
+		exists, err := requestSvc.RequestExists(ctx, tusReq.RequestID)
+		if !exists || err != nil {
 			ctx.Logger().Error("Failed to get request", zap.Error(err))
 			return
 		}
-		if err := requestSvc.UpdateRequestData(ctx, req, tusReq); err != nil {
-			ctx.Logger().Error("Failed to update TUS request", zap.Error(err))
-			return
-		}
 
-		// Mark the request as completed
-		if err := requestSvc.CompleteRequest(ctx, tusReq.RequestID); err != nil {
-			ctx.Logger().Error("Failed to complete request", zap.Error(err))
-			return
-		}
-
-		// Check if request is part of a workflow
-		request, err := requestSvc.GetRequest(ctx, tusReq.RequestID)
-		if err != nil {
-			return // Can't get request, ignore
-		}
-
-		// If request has workflow metadata, advance the workflow
-		if len(request.Metadata) > 0 {
-			// Try to get workflow service - it might not be available in all contexts
-			if workflowSvc, ok := ctx.Service(core.WORKFLOW_SERVICE).(core.WorkflowCoordinator); ok {
-				if err := workflowSvc.CompleteWorkflowStep(ctx, tusReq.RequestID); err != nil {
-					ctx.Logger().Error("Failed to complete workflow step", zap.Error(err))
-					// Don't return error here - the upload itself succeeded
-				}
+		// Get the workflow service
+		workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		if workflowSvc == nil {
+			ctx.Logger().Error("Workflow service not available")
+			// Mark request as failed since workflow service is unavailable
+			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID, "Workflow service unavailable"); updateErr != nil {
+				ctx.Logger().Error("Failed to update request status after workflow service failure", 
+					zap.Error(updateErr),
+					zap.Uint("requestID", tusReq.RequestID))
 			}
+			return
 		}
 
-		return
+		// Convert the request to a workflow and start it
+		err = workflowSvc.ConvertRequestToWorkflow(ctx, tusReq.RequestID, workflowName, 0)
+		if err != nil {
+			ctx.Logger().Error("Failed to convert request to workflow", zap.Error(err))
+			// Mark request as failed since workflow conversion failed
+			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID, fmt.Sprintf("Workflow conversion failed: %v", err)); updateErr != nil {
+				ctx.Logger().Error("Failed to update request status after workflow conversion failure", 
+					zap.Error(updateErr),
+					zap.Uint("requestID", tusReq.RequestID))
+			}
+			return
+		}
+
+		// Execute the first step of the workflow
+		err = workflowSvc.ExecuteWorkflowStep(ctx, tusReq.RequestID)
+		if err != nil {
+			ctx.Logger().Error("Failed to execute workflow step", zap.Error(err))
+			// Mark request as failed since workflow execution failed
+			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID, fmt.Sprintf("Workflow execution failed: %v", err)); updateErr != nil {
+				ctx.Logger().Error("Failed to update request status after workflow execution failure", 
+					zap.Error(updateErr),
+					zap.Uint("requestID", tusReq.RequestID))
+			}
+			return
+		}
 	}
 }
 

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -286,21 +286,21 @@ func (w *WorkflowCoordinatorDefault) StartWorkflow(ctx context.Context, name str
 	// Auto-trigger first step if configured
 	if workflow.AutoTriggerFirstStep {
 		firstStep := workflow.Steps[0]
-		if firstStep.DelegateToCron {
-			if err := w.dispatchToCron(ctx, createdReq.ID); err != nil {
-				w.logger.Error("Failed to dispatch first step to cron",
-					zap.String("workflow", workflow.Name),
-					zap.Uint("requestID", createdReq.ID),
-					zap.Error(err))
-				return createdReq, nil // Return request even if cron dispatch fails
-			}
-		} else {
+		if firstStep.Foreground {
 			if err := w.ExecuteWorkflowStep(ctx, createdReq.ID); err != nil {
 				w.logger.Error("Failed to execute first step",
 					zap.String("workflow", workflow.Name),
 					zap.Uint("requestID", createdReq.ID),
 					zap.Error(err))
 				return createdReq, nil // Return request even if execution fails
+			}
+		} else {
+			if err := w.dispatchToCron(ctx, createdReq.ID); err != nil {
+				w.logger.Error("Failed to dispatch first step to cron",
+					zap.String("workflow", workflow.Name),
+					zap.Uint("requestID", createdReq.ID),
+					zap.Error(err))
+				return createdReq, nil // Return request even if cron dispatch fails
 			}
 		}
 	}
@@ -389,21 +389,21 @@ func (w *WorkflowCoordinatorDefault) CompleteWorkflowStep(ctx context.Context, r
 		return fmt.Errorf("failed to update current request metadata: %w", err)
 	}
 
-	if nextStep.DelegateToCron {
-		if err := w.dispatchToCron(ctx, createdReq.ID); err != nil {
-			return err
-		}
-		w.logger.Info("Delegated workflow step to cron",
-			zap.String("workflow", metadata.WorkflowName),
-			zap.Int("step", nextStepIdx),
-			zap.Uint("nextRequestID", createdReq.ID))
-	} else {
+	if nextStep.Foreground {
 		// Execute the next step directly
 		err = w.ExecuteWorkflowStep(ctx, createdReq.ID)
 		if err != nil {
 			return err
 		}
 		w.logger.Info("Advanced workflow to next step",
+			zap.String("workflow", metadata.WorkflowName),
+			zap.Int("step", nextStepIdx),
+			zap.Uint("nextRequestID", createdReq.ID))
+	} else {
+		if err := w.dispatchToCron(ctx, createdReq.ID); err != nil {
+			return err
+		}
+		w.logger.Info("Delegated workflow step to cron",
 			zap.String("workflow", metadata.WorkflowName),
 			zap.Int("step", nextStepIdx),
 			zap.Uint("nextRequestID", createdReq.ID))
@@ -705,6 +705,54 @@ func (w *WorkflowCoordinatorDefault) jsonToKoanf(jsonStr string) (*koanf.Koanf, 
 		return nil, err
 	}
 	return k, nil
+}
+
+func (w *WorkflowCoordinatorDefault) ConvertRequestToWorkflow(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...core.WorkflowOption) error {
+	// Get the existing request
+	req, err := w.requestSvc.GetRequest(ctx, requestID)
+	if err != nil {
+		return fmt.Errorf("failed to get request: %w", err)
+	}
+
+	// Get the workflow definition
+	workflow, err := w.GetWorkflow(workflowName)
+	if err != nil {
+		return fmt.Errorf("failed to get workflow: %w", err)
+	}
+
+	if startStep < 0 || startStep >= len(workflow.Steps) {
+		return fmt.Errorf("invalid start step: %d", startStep)
+	}
+
+	// Create the WorkflowMetadata
+	metadata := WorkflowMetadata{
+		WorkflowName: workflow.Name,
+		CurrentStep:  startStep,
+		TotalSteps:   len(workflow.Steps),
+		StartedAt:    time.Now().Unix(),
+	}
+
+	processedOpts, metadataJSON, err := w.processWorkflowOptions(opts, &metadata)
+	if err != nil {
+		return err
+	}
+
+	// Update the request's metadata and operation
+	req.Metadata = datatypes.JSON(metadataJSON)
+	req.Operation = workflow.Steps[startStep].Operation
+
+	w.handleRequestData(processedOpts, req)
+
+	if userID := processedOpts.UserID(); userID > 0 {
+		req.UserID = &userID
+	}
+
+	// Save the updated request
+	if err := w.requestSvc.UpdateRequest(ctx, req); err != nil {
+		return fmt.Errorf("failed to update request: %w", err)
+	}
+
+	return nil
 }
 
 func (w *WorkflowCoordinatorDefault) scheduleRetry(ctx context.Context, requestID uint) error {


### PR DESCRIPTION
- Added ConvertRequestToWorkflow method to convert existing requests to workflows
- Renamed DelegateToCron to Foreground for clearer semantics in workflow steps
- Added upload_hash field to TUSRequest model and database tables
- Modified TUS upload completion handler to use workflow conversion
- Updated workflow execution logic to handle foreground/background steps
- Improved request data handling in workflow operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for associating uploads with a unique hash value.
  * Introduced the ability to convert existing requests into workflow instances, allowing workflows to start at any step.
* **Improvements**
  * Enhanced workflow integration for upload completion, enabling tighter coordination between uploads and workflows.
  * Updated workflow step handling to clarify whether steps run immediately or are scheduled.
* **Database**
  * Added a new column for upload hash to the uploads table in both MySQL and SQLite databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->