### PR TITLE
refactor(workflow): move request validation to RequestService and simplify workflow steps

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -15,6 +15,9 @@ var (
 )
 
 type RequestService interface {
+	// Request validation
+	ValidateRequest(ctx context.Context, req *models.Request) error
+
 	// Model registration methods
 	// RegisterRequestModel registers a protocol-specific request data model for an operation
 	RegisterRequestModel(operation string, model data_models.RequestDataModel)

--- a/core/workflow.go
+++ b/core/workflow.go
@@ -76,9 +76,6 @@ type OperationStep struct {
 	// The operation identifier (e.g., "ipfs.upload" or "content.scan")
 	Operation string
 
-	// The handler for this operation
-	Handler OperationHandler
-
 	// What to do if this step fails
 	FailureBehavior FailureBehavior
 

--- a/service/request.go
+++ b/service/request.go
@@ -76,17 +76,9 @@ func (r *RequestServiceDefault) ID() string {
 }
 
 func (r *RequestServiceDefault) CreateRequest(ctx context.Context, req *models.Request, data interface{}) (*models.Request, error) {
-	// Find the operation handler
-	_, handler, err := r.findOperationHandler(req.Operation)
-	if err != nil {
-		return nil, err
-	}
-
-	// Validate the request if handler available
-	if handler != nil {
-		if err := handler.ValidateRequest(ctx, req); err != nil {
-			return nil, fmt.Errorf("request validation failed: %w", err)
-		}
+	// Validate the request
+	if err := r.ValidateRequest(ctx, req); err != nil {
+		return nil, fmt.Errorf("request validation failed: %w", err)
 	}
 
 	// Set default values if not specified
@@ -384,6 +376,21 @@ func (r *RequestServiceDefault) GetRequestStatus(ctx context.Context, id uint) (
 	}
 
 	return status, nil
+}
+
+func (r *RequestServiceDefault) ValidateRequest(ctx context.Context, req *models.Request) error {
+	// Find the operation handler
+	_, handler, err := r.findOperationHandler(req.Operation)
+	if err != nil {
+		return fmt.Errorf("failed to find handler for operation %s: %w", req.Operation, err)
+	}
+
+	// Validate if handler exists
+	if handler != nil {
+		return handler.ValidateRequest(ctx, req)
+	}
+
+	return nil
 }
 
 func (r *RequestServiceDefault) RequestExists(ctx context.Context, id uint) (bool, error) {

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -181,12 +181,6 @@ func (w *WorkflowCoordinatorDefault) RegisterWorkflow(name string, steps []core.
 		return fmt.Errorf("workflow '%s' already exists", name)
 	}
 
-	// Ensure all steps have handlers
-	for i := range steps {
-		if steps[i].Handler == nil {
-			return fmt.Errorf("step %d has nil handler", i)
-		}
-	}
 
 	w.workflows[name] = &core.WorkflowDefinition{
 		Name:  name,
@@ -268,8 +262,8 @@ func (w *WorkflowCoordinatorDefault) StartWorkflow(ctx context.Context, name str
 		req.UserID = &userID
 	}
 
-	// Validate the request
-	if err := firstStep.Handler.ValidateRequest(ctx, req); err != nil {
+	// Validate the request using request service
+	if err := w.requestSvc.ValidateRequest(ctx, req); err != nil {
 		return nil, err
 	}
 
@@ -546,7 +540,7 @@ func (w *WorkflowCoordinatorDefault) ExecuteWorkflowStep(ctx context.Context, re
 	}
 	currentStep := workflow.Steps[metadata.CurrentStep]
 
-	// Delegate execution to RequestService
+	// Delegate execution to RequestService which will lookup the handler
 	err = w.requestSvc.ExecuteRequest(ctx, requestID)
 	if err != nil {
 		// Handle failure according to step's behavior


### PR DESCRIPTION
- Added ValidateRequest method to RequestService interface and implementation
- Removed Handler field from OperationStep in workflow definitions
- Updated workflow execution to use RequestService for validation
- Removed redundant handler checks during workflow registration
- Simplified request creation flow by centralizing validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized request validation logic within the request service, simplifying request creation and workflow execution.
  * Removed direct handler association from workflow steps, delegating handler lookup and validation to the request service.

* **Chores**
  * Updated internal validation flow to improve code maintainability and reduce duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->