### PR TITLE
feat(protocol): add workflows support to Protocol interface

### DIFF
--- a/core/protocol.go
+++ b/core/protocol.go
@@ -19,6 +19,7 @@ type Protocol interface {
 	Name() string
 	Config() config.ProtocolConfig
 	Operations() []Operation
+	Workflows() []WorkflowDefinition
 }
 
 type ProtocolInit interface {

--- a/core/testing/mocks/CronService.go
+++ b/core/testing/mocks/CronService.go
@@ -328,16 +328,16 @@ func (_c *MockCronService_RegisterEntity_Call) RunAndReturn(run func(entity core
 }
 
 // RegisterJob provides a mock function for the type MockCronService
-func (_mock *MockCronService) RegisterJob(job core.CronJob) error {
-	ret := _mock.Called(job)
+func (_mock *MockCronService) RegisterJob(job core.CronJob, retryPolicy *core.RetryPolicy) error {
+	ret := _mock.Called(job, retryPolicy)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RegisterJob")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(core.CronJob) error); ok {
-		r0 = returnFunc(job)
+	if returnFunc, ok := ret.Get(0).(func(core.CronJob, *core.RetryPolicy) error); ok {
+		r0 = returnFunc(job, retryPolicy)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -351,18 +351,24 @@ type MockCronService_RegisterJob_Call struct {
 
 // RegisterJob is a helper method to define mock.On call
 //   - job core.CronJob
-func (_e *MockCronService_Expecter) RegisterJob(job interface{}) *MockCronService_RegisterJob_Call {
-	return &MockCronService_RegisterJob_Call{Call: _e.mock.On("RegisterJob", job)}
+//   - retryPolicy *core.RetryPolicy
+func (_e *MockCronService_Expecter) RegisterJob(job interface{}, retryPolicy interface{}) *MockCronService_RegisterJob_Call {
+	return &MockCronService_RegisterJob_Call{Call: _e.mock.On("RegisterJob", job, retryPolicy)}
 }
 
-func (_c *MockCronService_RegisterJob_Call) Run(run func(job core.CronJob)) *MockCronService_RegisterJob_Call {
+func (_c *MockCronService_RegisterJob_Call) Run(run func(job core.CronJob, retryPolicy *core.RetryPolicy)) *MockCronService_RegisterJob_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 core.CronJob
 		if args[0] != nil {
 			arg0 = args[0].(core.CronJob)
 		}
+		var arg1 *core.RetryPolicy
+		if args[1] != nil {
+			arg1 = args[1].(*core.RetryPolicy)
+		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -373,7 +379,7 @@ func (_c *MockCronService_RegisterJob_Call) Return(err error) *MockCronService_R
 	return _c
 }
 
-func (_c *MockCronService_RegisterJob_Call) RunAndReturn(run func(job core.CronJob) error) *MockCronService_RegisterJob_Call {
+func (_c *MockCronService_RegisterJob_Call) RunAndReturn(run func(job core.CronJob, retryPolicy *core.RetryPolicy) error) *MockCronService_RegisterJob_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/testing/mocks/Protocol.go
+++ b/core/testing/mocks/Protocol.go
@@ -172,3 +172,49 @@ func (_c *MockProtocol_Operations_Call) RunAndReturn(run func() []core.Operation
 	_c.Call.Return(run)
 	return _c
 }
+
+// Workflows provides a mock function for the type MockProtocol
+func (_mock *MockProtocol) Workflows() []core.WorkflowDefinition {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Workflows")
+	}
+
+	var r0 []core.WorkflowDefinition
+	if returnFunc, ok := ret.Get(0).(func() []core.WorkflowDefinition); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]core.WorkflowDefinition)
+		}
+	}
+	return r0
+}
+
+// MockProtocol_Workflows_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Workflows'
+type MockProtocol_Workflows_Call struct {
+	*mock.Call
+}
+
+// Workflows is a helper method to define mock.On call
+func (_e *MockProtocol_Expecter) Workflows() *MockProtocol_Workflows_Call {
+	return &MockProtocol_Workflows_Call{Call: _e.mock.On("Workflows")}
+}
+
+func (_c *MockProtocol_Workflows_Call) Run(run func()) *MockProtocol_Workflows_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockProtocol_Workflows_Call) Return(workflowDefinitions []core.WorkflowDefinition) *MockProtocol_Workflows_Call {
+	_c.Call.Return(workflowDefinitions)
+	return _c
+}
+
+func (_c *MockProtocol_Workflows_Call) RunAndReturn(run func() []core.WorkflowDefinition) *MockProtocol_Workflows_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/core/testing/mocks/ProtocolParser.go
+++ b/core/testing/mocks/ProtocolParser.go
@@ -284,3 +284,49 @@ func (_c *MockProtocolParser_TryParse_Call) RunAndReturn(run func(s string) (cor
 	_c.Call.Return(run)
 	return _c
 }
+
+// Workflows provides a mock function for the type MockProtocolParser
+func (_mock *MockProtocolParser) Workflows() []core.WorkflowDefinition {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Workflows")
+	}
+
+	var r0 []core.WorkflowDefinition
+	if returnFunc, ok := ret.Get(0).(func() []core.WorkflowDefinition); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]core.WorkflowDefinition)
+		}
+	}
+	return r0
+}
+
+// MockProtocolParser_Workflows_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Workflows'
+type MockProtocolParser_Workflows_Call struct {
+	*mock.Call
+}
+
+// Workflows is a helper method to define mock.On call
+func (_e *MockProtocolParser_Expecter) Workflows() *MockProtocolParser_Workflows_Call {
+	return &MockProtocolParser_Workflows_Call{Call: _e.mock.On("Workflows")}
+}
+
+func (_c *MockProtocolParser_Workflows_Call) Run(run func()) *MockProtocolParser_Workflows_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockProtocolParser_Workflows_Call) Return(workflowDefinitions []core.WorkflowDefinition) *MockProtocolParser_Workflows_Call {
+	_c.Call.Return(workflowDefinitions)
+	return _c
+}
+
+func (_c *MockProtocolParser_Workflows_Call) RunAndReturn(run func() []core.WorkflowDefinition) *MockProtocolParser_Workflows_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/core/testing/mocks/RenterService.go
+++ b/core/testing/mocks/RenterService.go
@@ -476,66 +476,6 @@ func (_c *MockRenterService_ID_Call) RunAndReturn(run func() string) *MockRenter
 	return _c
 }
 
-// RedundancySettings provides a mock function for the type MockRenterService
-func (_mock *MockRenterService) RedundancySettings(ctx context.Context) (api.RedundancySettings, error) {
-	ret := _mock.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for RedundancySettings")
-	}
-
-	var r0 api.RedundancySettings
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (api.RedundancySettings, error)); ok {
-		return returnFunc(ctx)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) api.RedundancySettings); ok {
-		r0 = returnFunc(ctx)
-	} else {
-		r0 = ret.Get(0).(api.RedundancySettings)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = returnFunc(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockRenterService_RedundancySettings_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RedundancySettings'
-type MockRenterService_RedundancySettings_Call struct {
-	*mock.Call
-}
-
-// RedundancySettings is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockRenterService_Expecter) RedundancySettings(ctx interface{}) *MockRenterService_RedundancySettings_Call {
-	return &MockRenterService_RedundancySettings_Call{Call: _e.mock.On("RedundancySettings", ctx)}
-}
-
-func (_c *MockRenterService_RedundancySettings_Call) Run(run func(ctx context.Context)) *MockRenterService_RedundancySettings_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockRenterService_RedundancySettings_Call) Return(redundancySettings api.RedundancySettings, err error) *MockRenterService_RedundancySettings_Call {
-	_c.Call.Return(redundancySettings, err)
-	return _c
-}
-
-func (_c *MockRenterService_RedundancySettings_Call) RunAndReturn(run func(ctx context.Context) (api.RedundancySettings, error)) *MockRenterService_RedundancySettings_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // SlabSize provides a mock function for the type MockRenterService
 func (_mock *MockRenterService) SlabSize(ctx context.Context) (uint64, error) {
 	ret := _mock.Called(ctx)

--- a/core/testing/mocks/RequestService.go
+++ b/core/testing/mocks/RequestService.go
@@ -290,6 +290,63 @@ func (_c *MockRequestService_DeleteRequest_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// ExecuteRequest provides a mock function for the type MockRequestService
+func (_mock *MockRequestService) ExecuteRequest(ctx context.Context, id uint) error {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecuteRequest")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockRequestService_ExecuteRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecuteRequest'
+type MockRequestService_ExecuteRequest_Call struct {
+	*mock.Call
+}
+
+// ExecuteRequest is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id uint
+func (_e *MockRequestService_Expecter) ExecuteRequest(ctx interface{}, id interface{}) *MockRequestService_ExecuteRequest_Call {
+	return &MockRequestService_ExecuteRequest_Call{Call: _e.mock.On("ExecuteRequest", ctx, id)}
+}
+
+func (_c *MockRequestService_ExecuteRequest_Call) Run(run func(ctx context.Context, id uint)) *MockRequestService_ExecuteRequest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRequestService_ExecuteRequest_Call) Return(err error) *MockRequestService_ExecuteRequest_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockRequestService_ExecuteRequest_Call) RunAndReturn(run func(ctx context.Context, id uint) error) *MockRequestService_ExecuteRequest_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FailRequest provides a mock function for the type MockRequestService
 func (_mock *MockRequestService) FailRequest(ctx context.Context, id uint, reason string) error {
 	ret := _mock.Called(ctx, id, reason)
@@ -491,80 +548,6 @@ func (_c *MockRequestService_GetRequestByHash_Call) Return(request *models.Reque
 }
 
 func (_c *MockRequestService_GetRequestByHash_Call) RunAndReturn(run func(ctx context.Context, hash core.StorageHash, filter core.RequestFilter) (*models.Request, error)) *MockRequestService_GetRequestByHash_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetRequestByUploadHash provides a mock function for the type MockRequestService
-func (_mock *MockRequestService) GetRequestByUploadHash(ctx context.Context, hash core.StorageHash, filter core.RequestFilter) (*models.Request, error) {
-	ret := _mock.Called(ctx, hash, filter)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetRequestByUploadHash")
-	}
-
-	var r0 *models.Request
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, core.StorageHash, core.RequestFilter) (*models.Request, error)); ok {
-		return returnFunc(ctx, hash, filter)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, core.StorageHash, core.RequestFilter) *models.Request); ok {
-		r0 = returnFunc(ctx, hash, filter)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*models.Request)
-		}
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, core.StorageHash, core.RequestFilter) error); ok {
-		r1 = returnFunc(ctx, hash, filter)
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
-}
-
-// MockRequestService_GetRequestByUploadHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRequestByUploadHash'
-type MockRequestService_GetRequestByUploadHash_Call struct {
-	*mock.Call
-}
-
-// GetRequestByUploadHash is a helper method to define mock.On call
-//   - ctx context.Context
-//   - hash core.StorageHash
-//   - filter core.RequestFilter
-func (_e *MockRequestService_Expecter) GetRequestByUploadHash(ctx interface{}, hash interface{}, filter interface{}) *MockRequestService_GetRequestByUploadHash_Call {
-	return &MockRequestService_GetRequestByUploadHash_Call{Call: _e.mock.On("GetRequestByUploadHash", ctx, hash, filter)}
-}
-
-func (_c *MockRequestService_GetRequestByUploadHash_Call) Run(run func(ctx context.Context, hash core.StorageHash, filter core.RequestFilter)) *MockRequestService_GetRequestByUploadHash_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 core.StorageHash
-		if args[1] != nil {
-			arg1 = args[1].(core.StorageHash)
-		}
-		var arg2 core.RequestFilter
-		if args[2] != nil {
-			arg2 = args[2].(core.RequestFilter)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockRequestService_GetRequestByUploadHash_Call) Return(request *models.Request, err error) *MockRequestService_GetRequestByUploadHash_Call {
-	_c.Call.Return(request, err)
-	return _c
-}
-
-func (_c *MockRequestService_GetRequestByUploadHash_Call) RunAndReturn(run func(ctx context.Context, hash core.StorageHash, filter core.RequestFilter) (*models.Request, error)) *MockRequestService_GetRequestByUploadHash_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1324,6 +1307,63 @@ func (_c *MockRequestService_UpdateRequestStatus_Call) Return(err error) *MockRe
 }
 
 func (_c *MockRequestService_UpdateRequestStatus_Call) RunAndReturn(run func(ctx context.Context, id uint, status models.RequestStatusType) error) *MockRequestService_UpdateRequestStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ValidateRequest provides a mock function for the type MockRequestService
+func (_mock *MockRequestService) ValidateRequest(ctx context.Context, req *models.Request) error {
+	ret := _mock.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateRequest")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *models.Request) error); ok {
+		r0 = returnFunc(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockRequestService_ValidateRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateRequest'
+type MockRequestService_ValidateRequest_Call struct {
+	*mock.Call
+}
+
+// ValidateRequest is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *models.Request
+func (_e *MockRequestService_Expecter) ValidateRequest(ctx interface{}, req interface{}) *MockRequestService_ValidateRequest_Call {
+	return &MockRequestService_ValidateRequest_Call{Call: _e.mock.On("ValidateRequest", ctx, req)}
+}
+
+func (_c *MockRequestService_ValidateRequest_Call) Run(run func(ctx context.Context, req *models.Request)) *MockRequestService_ValidateRequest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *models.Request
+		if args[1] != nil {
+			arg1 = args[1].(*models.Request)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRequestService_ValidateRequest_Call) Return(err error) *MockRequestService_ValidateRequest_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockRequestService_ValidateRequest_Call) RunAndReturn(run func(ctx context.Context, req *models.Request) error) *MockRequestService_ValidateRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/testing/mocks/TestingProtocolPinHandler.go
+++ b/core/testing/mocks/TestingProtocolPinHandler.go
@@ -538,3 +538,49 @@ func (_c *MockTestingProtocolPinHandler_UpdateProtocolPin_Call) RunAndReturn(run
 	_c.Call.Return(run)
 	return _c
 }
+
+// Workflows provides a mock function for the type MockTestingProtocolPinHandler
+func (_mock *MockTestingProtocolPinHandler) Workflows() []core.WorkflowDefinition {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Workflows")
+	}
+
+	var r0 []core.WorkflowDefinition
+	if returnFunc, ok := ret.Get(0).(func() []core.WorkflowDefinition); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]core.WorkflowDefinition)
+		}
+	}
+	return r0
+}
+
+// MockTestingProtocolPinHandler_Workflows_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Workflows'
+type MockTestingProtocolPinHandler_Workflows_Call struct {
+	*mock.Call
+}
+
+// Workflows is a helper method to define mock.On call
+func (_e *MockTestingProtocolPinHandler_Expecter) Workflows() *MockTestingProtocolPinHandler_Workflows_Call {
+	return &MockTestingProtocolPinHandler_Workflows_Call{Call: _e.mock.On("Workflows")}
+}
+
+func (_c *MockTestingProtocolPinHandler_Workflows_Call) Run(run func()) *MockTestingProtocolPinHandler_Workflows_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockTestingProtocolPinHandler_Workflows_Call) Return(workflowDefinitions []core.WorkflowDefinition) *MockTestingProtocolPinHandler_Workflows_Call {
+	_c.Call.Return(workflowDefinitions)
+	return _c
+}
+
+func (_c *MockTestingProtocolPinHandler_Workflows_Call) RunAndReturn(run func() []core.WorkflowDefinition) *MockTestingProtocolPinHandler_Workflows_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/core/testing/mocks/TestingProtocolRequestDataHandler.go
+++ b/core/testing/mocks/TestingProtocolRequestDataHandler.go
@@ -600,3 +600,49 @@ func (_c *MockTestingProtocolRequestDataHandler_UpdateProtocolData_Call) RunAndR
 	_c.Call.Return(run)
 	return _c
 }
+
+// Workflows provides a mock function for the type MockTestingProtocolRequestDataHandler
+func (_mock *MockTestingProtocolRequestDataHandler) Workflows() []core.WorkflowDefinition {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Workflows")
+	}
+
+	var r0 []core.WorkflowDefinition
+	if returnFunc, ok := ret.Get(0).(func() []core.WorkflowDefinition); ok {
+		r0 = returnFunc()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]core.WorkflowDefinition)
+		}
+	}
+	return r0
+}
+
+// MockTestingProtocolRequestDataHandler_Workflows_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Workflows'
+type MockTestingProtocolRequestDataHandler_Workflows_Call struct {
+	*mock.Call
+}
+
+// Workflows is a helper method to define mock.On call
+func (_e *MockTestingProtocolRequestDataHandler_Expecter) Workflows() *MockTestingProtocolRequestDataHandler_Workflows_Call {
+	return &MockTestingProtocolRequestDataHandler_Workflows_Call{Call: _e.mock.On("Workflows")}
+}
+
+func (_c *MockTestingProtocolRequestDataHandler_Workflows_Call) Run(run func()) *MockTestingProtocolRequestDataHandler_Workflows_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockTestingProtocolRequestDataHandler_Workflows_Call) Return(workflowDefinitions []core.WorkflowDefinition) *MockTestingProtocolRequestDataHandler_Workflows_Call {
+	_c.Call.Return(workflowDefinitions)
+	return _c
+}
+
+func (_c *MockTestingProtocolRequestDataHandler_Workflows_Call) RunAndReturn(run func() []core.WorkflowDefinition) *MockTestingProtocolRequestDataHandler_Workflows_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/core/testing/mocks/WorkflowCoordinator.go
+++ b/core/testing/mocks/WorkflowCoordinator.go
@@ -40,16 +40,24 @@ func (_m *MockWorkflowCoordinator) EXPECT() *MockWorkflowCoordinator_Expecter {
 }
 
 // CompleteWorkflowStep provides a mock function for the type MockWorkflowCoordinator
-func (_mock *MockWorkflowCoordinator) CompleteWorkflowStep(ctx context.Context, requestID uint) error {
-	ret := _mock.Called(ctx, requestID)
+func (_mock *MockWorkflowCoordinator) CompleteWorkflowStep(ctx context.Context, requestID uint, opts ...core.WorkflowOption) error {
+	// core.WorkflowOption
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, requestID)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CompleteWorkflowStep")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
-		r0 = returnFunc(ctx, requestID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, ...core.WorkflowOption) error); ok {
+		r0 = returnFunc(ctx, requestID, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -64,11 +72,13 @@ type MockWorkflowCoordinator_CompleteWorkflowStep_Call struct {
 // CompleteWorkflowStep is a helper method to define mock.On call
 //   - ctx context.Context
 //   - requestID uint
-func (_e *MockWorkflowCoordinator_Expecter) CompleteWorkflowStep(ctx interface{}, requestID interface{}) *MockWorkflowCoordinator_CompleteWorkflowStep_Call {
-	return &MockWorkflowCoordinator_CompleteWorkflowStep_Call{Call: _e.mock.On("CompleteWorkflowStep", ctx, requestID)}
+//   - opts ...core.WorkflowOption
+func (_e *MockWorkflowCoordinator_Expecter) CompleteWorkflowStep(ctx interface{}, requestID interface{}, opts ...interface{}) *MockWorkflowCoordinator_CompleteWorkflowStep_Call {
+	return &MockWorkflowCoordinator_CompleteWorkflowStep_Call{Call: _e.mock.On("CompleteWorkflowStep",
+		append([]interface{}{ctx, requestID}, opts...)...)}
 }
 
-func (_c *MockWorkflowCoordinator_CompleteWorkflowStep_Call) Run(run func(ctx context.Context, requestID uint)) *MockWorkflowCoordinator_CompleteWorkflowStep_Call {
+func (_c *MockWorkflowCoordinator_CompleteWorkflowStep_Call) Run(run func(ctx context.Context, requestID uint, opts ...core.WorkflowOption)) *MockWorkflowCoordinator_CompleteWorkflowStep_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -78,9 +88,18 @@ func (_c *MockWorkflowCoordinator_CompleteWorkflowStep_Call) Run(run func(ctx co
 		if args[1] != nil {
 			arg1 = args[1].(uint)
 		}
+		var arg2 []core.WorkflowOption
+		variadicArgs := make([]core.WorkflowOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(core.WorkflowOption)
+			}
+		}
+		arg2 = variadicArgs
 		run(
 			arg0,
 			arg1,
+			arg2...,
 		)
 	})
 	return _c
@@ -91,7 +110,95 @@ func (_c *MockWorkflowCoordinator_CompleteWorkflowStep_Call) Return(err error) *
 	return _c
 }
 
-func (_c *MockWorkflowCoordinator_CompleteWorkflowStep_Call) RunAndReturn(run func(ctx context.Context, requestID uint) error) *MockWorkflowCoordinator_CompleteWorkflowStep_Call {
+func (_c *MockWorkflowCoordinator_CompleteWorkflowStep_Call) RunAndReturn(run func(ctx context.Context, requestID uint, opts ...core.WorkflowOption) error) *MockWorkflowCoordinator_CompleteWorkflowStep_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ConvertRequestToWorkflow provides a mock function for the type MockWorkflowCoordinator
+func (_mock *MockWorkflowCoordinator) ConvertRequestToWorkflow(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...core.WorkflowOption) error {
+	// core.WorkflowOption
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, requestID, workflowName, startStep)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConvertRequestToWorkflow")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, int, ...core.WorkflowOption) error); ok {
+		r0 = returnFunc(ctx, requestID, workflowName, startStep, opts...)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowCoordinator_ConvertRequestToWorkflow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConvertRequestToWorkflow'
+type MockWorkflowCoordinator_ConvertRequestToWorkflow_Call struct {
+	*mock.Call
+}
+
+// ConvertRequestToWorkflow is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+//   - workflowName string
+//   - startStep int
+//   - opts ...core.WorkflowOption
+func (_e *MockWorkflowCoordinator_Expecter) ConvertRequestToWorkflow(ctx interface{}, requestID interface{}, workflowName interface{}, startStep interface{}, opts ...interface{}) *MockWorkflowCoordinator_ConvertRequestToWorkflow_Call {
+	return &MockWorkflowCoordinator_ConvertRequestToWorkflow_Call{Call: _e.mock.On("ConvertRequestToWorkflow",
+		append([]interface{}{ctx, requestID, workflowName, startStep}, opts...)...)}
+}
+
+func (_c *MockWorkflowCoordinator_ConvertRequestToWorkflow_Call) Run(run func(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...core.WorkflowOption)) *MockWorkflowCoordinator_ConvertRequestToWorkflow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		var arg4 []core.WorkflowOption
+		variadicArgs := make([]core.WorkflowOption, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(core.WorkflowOption)
+			}
+		}
+		arg4 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4...,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowCoordinator_ConvertRequestToWorkflow_Call) Return(err error) *MockWorkflowCoordinator_ConvertRequestToWorkflow_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowCoordinator_ConvertRequestToWorkflow_Call) RunAndReturn(run func(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...core.WorkflowOption) error) *MockWorkflowCoordinator_ConvertRequestToWorkflow_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -393,8 +500,16 @@ func (_c *MockWorkflowCoordinator_RegisterWorkflow_Call) RunAndReturn(run func(n
 }
 
 // StartWorkflow provides a mock function for the type MockWorkflowCoordinator
-func (_mock *MockWorkflowCoordinator) StartWorkflow(ctx context.Context, name string, initialData any) (*models.Request, error) {
-	ret := _mock.Called(ctx, name, initialData)
+func (_mock *MockWorkflowCoordinator) StartWorkflow(ctx context.Context, name string, opts ...core.WorkflowOption) (*models.Request, error) {
+	// core.WorkflowOption
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, name)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartWorkflow")
@@ -402,18 +517,18 @@ func (_mock *MockWorkflowCoordinator) StartWorkflow(ctx context.Context, name st
 
 	var r0 *models.Request
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, any) (*models.Request, error)); ok {
-		return returnFunc(ctx, name, initialData)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...core.WorkflowOption) (*models.Request, error)); ok {
+		return returnFunc(ctx, name, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, any) *models.Request); ok {
-		r0 = returnFunc(ctx, name, initialData)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...core.WorkflowOption) *models.Request); ok {
+		r0 = returnFunc(ctx, name, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Request)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, any) error); ok {
-		r1 = returnFunc(ctx, name, initialData)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...core.WorkflowOption) error); ok {
+		r1 = returnFunc(ctx, name, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -428,12 +543,13 @@ type MockWorkflowCoordinator_StartWorkflow_Call struct {
 // StartWorkflow is a helper method to define mock.On call
 //   - ctx context.Context
 //   - name string
-//   - initialData any
-func (_e *MockWorkflowCoordinator_Expecter) StartWorkflow(ctx interface{}, name interface{}, initialData interface{}) *MockWorkflowCoordinator_StartWorkflow_Call {
-	return &MockWorkflowCoordinator_StartWorkflow_Call{Call: _e.mock.On("StartWorkflow", ctx, name, initialData)}
+//   - opts ...core.WorkflowOption
+func (_e *MockWorkflowCoordinator_Expecter) StartWorkflow(ctx interface{}, name interface{}, opts ...interface{}) *MockWorkflowCoordinator_StartWorkflow_Call {
+	return &MockWorkflowCoordinator_StartWorkflow_Call{Call: _e.mock.On("StartWorkflow",
+		append([]interface{}{ctx, name}, opts...)...)}
 }
 
-func (_c *MockWorkflowCoordinator_StartWorkflow_Call) Run(run func(ctx context.Context, name string, initialData any)) *MockWorkflowCoordinator_StartWorkflow_Call {
+func (_c *MockWorkflowCoordinator_StartWorkflow_Call) Run(run func(ctx context.Context, name string, opts ...core.WorkflowOption)) *MockWorkflowCoordinator_StartWorkflow_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -443,14 +559,18 @@ func (_c *MockWorkflowCoordinator_StartWorkflow_Call) Run(run func(ctx context.C
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 any
-		if args[2] != nil {
-			arg2 = args[2].(any)
+		var arg2 []core.WorkflowOption
+		variadicArgs := make([]core.WorkflowOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(core.WorkflowOption)
+			}
 		}
+		arg2 = variadicArgs
 		run(
 			arg0,
 			arg1,
-			arg2,
+			arg2...,
 		)
 	})
 	return _c
@@ -461,7 +581,7 @@ func (_c *MockWorkflowCoordinator_StartWorkflow_Call) Return(request *models.Req
 	return _c
 }
 
-func (_c *MockWorkflowCoordinator_StartWorkflow_Call) RunAndReturn(run func(ctx context.Context, name string, initialData any) (*models.Request, error)) *MockWorkflowCoordinator_StartWorkflow_Call {
+func (_c *MockWorkflowCoordinator_StartWorkflow_Call) RunAndReturn(run func(ctx context.Context, name string, opts ...core.WorkflowOption) (*models.Request, error)) *MockWorkflowCoordinator_StartWorkflow_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/testing/mocks/WorkflowService.go
+++ b/core/testing/mocks/WorkflowService.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	"context"
 
+	"github.com/knadh/koanf/v2"
 	mock "github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
@@ -39,36 +40,45 @@ func (_m *MockWorkflowService) EXPECT() *MockWorkflowService_Expecter {
 	return &MockWorkflowService_Expecter{mock: &_m.Mock}
 }
 
-// CompleteWorkflowStep provides a mock function for the type MockWorkflowService
-func (_mock *MockWorkflowService) CompleteWorkflowStep(ctx context.Context, requestID uint) error {
+// CanTransition provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) CanTransition(ctx context.Context, requestID uint) (bool, error) {
 	ret := _mock.Called(ctx, requestID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for CompleteWorkflowStep")
+		panic("no return value specified for CanTransition")
 	}
 
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) (bool, error)); ok {
+		return returnFunc(ctx, requestID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) bool); ok {
 		r0 = returnFunc(ctx, requestID)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(bool)
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint) error); ok {
+		r1 = returnFunc(ctx, requestID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
-// MockWorkflowService_CompleteWorkflowStep_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompleteWorkflowStep'
-type MockWorkflowService_CompleteWorkflowStep_Call struct {
+// MockWorkflowService_CanTransition_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CanTransition'
+type MockWorkflowService_CanTransition_Call struct {
 	*mock.Call
 }
 
-// CompleteWorkflowStep is a helper method to define mock.On call
+// CanTransition is a helper method to define mock.On call
 //   - ctx context.Context
 //   - requestID uint
-func (_e *MockWorkflowService_Expecter) CompleteWorkflowStep(ctx interface{}, requestID interface{}) *MockWorkflowService_CompleteWorkflowStep_Call {
-	return &MockWorkflowService_CompleteWorkflowStep_Call{Call: _e.mock.On("CompleteWorkflowStep", ctx, requestID)}
+func (_e *MockWorkflowService_Expecter) CanTransition(ctx interface{}, requestID interface{}) *MockWorkflowService_CanTransition_Call {
+	return &MockWorkflowService_CanTransition_Call{Call: _e.mock.On("CanTransition", ctx, requestID)}
 }
 
-func (_c *MockWorkflowService_CompleteWorkflowStep_Call) Run(run func(ctx context.Context, requestID uint)) *MockWorkflowService_CompleteWorkflowStep_Call {
+func (_c *MockWorkflowService_CanTransition_Call) Run(run func(ctx context.Context, requestID uint)) *MockWorkflowService_CanTransition_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -86,12 +96,233 @@ func (_c *MockWorkflowService_CompleteWorkflowStep_Call) Run(run func(ctx contex
 	return _c
 }
 
+func (_c *MockWorkflowService_CanTransition_Call) Return(b bool, err error) *MockWorkflowService_CanTransition_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockWorkflowService_CanTransition_Call) RunAndReturn(run func(ctx context.Context, requestID uint) (bool, error)) *MockWorkflowService_CanTransition_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CompleteWorkflowStep provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) CompleteWorkflowStep(ctx context.Context, requestID uint, opts ...core.WorkflowOption) error {
+	// core.WorkflowOption
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, requestID)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompleteWorkflowStep")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, ...core.WorkflowOption) error); ok {
+		r0 = returnFunc(ctx, requestID, opts...)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowService_CompleteWorkflowStep_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompleteWorkflowStep'
+type MockWorkflowService_CompleteWorkflowStep_Call struct {
+	*mock.Call
+}
+
+// CompleteWorkflowStep is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+//   - opts ...core.WorkflowOption
+func (_e *MockWorkflowService_Expecter) CompleteWorkflowStep(ctx interface{}, requestID interface{}, opts ...interface{}) *MockWorkflowService_CompleteWorkflowStep_Call {
+	return &MockWorkflowService_CompleteWorkflowStep_Call{Call: _e.mock.On("CompleteWorkflowStep",
+		append([]interface{}{ctx, requestID}, opts...)...)}
+}
+
+func (_c *MockWorkflowService_CompleteWorkflowStep_Call) Run(run func(ctx context.Context, requestID uint, opts ...core.WorkflowOption)) *MockWorkflowService_CompleteWorkflowStep_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 []core.WorkflowOption
+		variadicArgs := make([]core.WorkflowOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(core.WorkflowOption)
+			}
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
+	})
+	return _c
+}
+
 func (_c *MockWorkflowService_CompleteWorkflowStep_Call) Return(err error) *MockWorkflowService_CompleteWorkflowStep_Call {
 	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockWorkflowService_CompleteWorkflowStep_Call) RunAndReturn(run func(ctx context.Context, requestID uint) error) *MockWorkflowService_CompleteWorkflowStep_Call {
+func (_c *MockWorkflowService_CompleteWorkflowStep_Call) RunAndReturn(run func(ctx context.Context, requestID uint, opts ...core.WorkflowOption) error) *MockWorkflowService_CompleteWorkflowStep_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ConvertRequestToWorkflow provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) ConvertRequestToWorkflow(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...core.WorkflowOption) error {
+	// core.WorkflowOption
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, requestID, workflowName, startStep)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConvertRequestToWorkflow")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, int, ...core.WorkflowOption) error); ok {
+		r0 = returnFunc(ctx, requestID, workflowName, startStep, opts...)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowService_ConvertRequestToWorkflow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConvertRequestToWorkflow'
+type MockWorkflowService_ConvertRequestToWorkflow_Call struct {
+	*mock.Call
+}
+
+// ConvertRequestToWorkflow is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+//   - workflowName string
+//   - startStep int
+//   - opts ...core.WorkflowOption
+func (_e *MockWorkflowService_Expecter) ConvertRequestToWorkflow(ctx interface{}, requestID interface{}, workflowName interface{}, startStep interface{}, opts ...interface{}) *MockWorkflowService_ConvertRequestToWorkflow_Call {
+	return &MockWorkflowService_ConvertRequestToWorkflow_Call{Call: _e.mock.On("ConvertRequestToWorkflow",
+		append([]interface{}{ctx, requestID, workflowName, startStep}, opts...)...)}
+}
+
+func (_c *MockWorkflowService_ConvertRequestToWorkflow_Call) Run(run func(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...core.WorkflowOption)) *MockWorkflowService_ConvertRequestToWorkflow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 int
+		if args[3] != nil {
+			arg3 = args[3].(int)
+		}
+		var arg4 []core.WorkflowOption
+		variadicArgs := make([]core.WorkflowOption, len(args)-4)
+		for i, a := range args[4:] {
+			if a != nil {
+				variadicArgs[i] = a.(core.WorkflowOption)
+			}
+		}
+		arg4 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4...,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_ConvertRequestToWorkflow_Call) Return(err error) *MockWorkflowService_ConvertRequestToWorkflow_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowService_ConvertRequestToWorkflow_Call) RunAndReturn(run func(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...core.WorkflowOption) error) *MockWorkflowService_ConvertRequestToWorkflow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ExecuteWorkflowStep provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) ExecuteWorkflowStep(ctx context.Context, requestID uint) error {
+	ret := _mock.Called(ctx, requestID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecuteWorkflowStep")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, requestID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowService_ExecuteWorkflowStep_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecuteWorkflowStep'
+type MockWorkflowService_ExecuteWorkflowStep_Call struct {
+	*mock.Call
+}
+
+// ExecuteWorkflowStep is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+func (_e *MockWorkflowService_Expecter) ExecuteWorkflowStep(ctx interface{}, requestID interface{}) *MockWorkflowService_ExecuteWorkflowStep_Call {
+	return &MockWorkflowService_ExecuteWorkflowStep_Call{Call: _e.mock.On("ExecuteWorkflowStep", ctx, requestID)}
+}
+
+func (_c *MockWorkflowService_ExecuteWorkflowStep_Call) Run(run func(ctx context.Context, requestID uint)) *MockWorkflowService_ExecuteWorkflowStep_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_ExecuteWorkflowStep_Call) Return(err error) *MockWorkflowService_ExecuteWorkflowStep_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowService_ExecuteWorkflowStep_Call) RunAndReturn(run func(ctx context.Context, requestID uint) error) *MockWorkflowService_ExecuteWorkflowStep_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -221,6 +452,74 @@ func (_c *MockWorkflowService_GetWorkflow_Call) RunAndReturn(run func(name strin
 	return _c
 }
 
+// GetWorkflowMetadata provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) GetWorkflowMetadata(ctx context.Context, requestID uint) (*koanf.Koanf, error) {
+	ret := _mock.Called(ctx, requestID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWorkflowMetadata")
+	}
+
+	var r0 *koanf.Koanf
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) (*koanf.Koanf, error)); ok {
+		return returnFunc(ctx, requestID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) *koanf.Koanf); ok {
+		r0 = returnFunc(ctx, requestID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*koanf.Koanf)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint) error); ok {
+		r1 = returnFunc(ctx, requestID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockWorkflowService_GetWorkflowMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetWorkflowMetadata'
+type MockWorkflowService_GetWorkflowMetadata_Call struct {
+	*mock.Call
+}
+
+// GetWorkflowMetadata is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+func (_e *MockWorkflowService_Expecter) GetWorkflowMetadata(ctx interface{}, requestID interface{}) *MockWorkflowService_GetWorkflowMetadata_Call {
+	return &MockWorkflowService_GetWorkflowMetadata_Call{Call: _e.mock.On("GetWorkflowMetadata", ctx, requestID)}
+}
+
+func (_c *MockWorkflowService_GetWorkflowMetadata_Call) Run(run func(ctx context.Context, requestID uint)) *MockWorkflowService_GetWorkflowMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_GetWorkflowMetadata_Call) Return(koanf1 *koanf.Koanf, err error) *MockWorkflowService_GetWorkflowMetadata_Call {
+	_c.Call.Return(koanf1, err)
+	return _c
+}
+
+func (_c *MockWorkflowService_GetWorkflowMetadata_Call) RunAndReturn(run func(ctx context.Context, requestID uint) (*koanf.Koanf, error)) *MockWorkflowService_GetWorkflowMetadata_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetWorkflowStatus provides a mock function for the type MockWorkflowService
 func (_mock *MockWorkflowService) GetWorkflowStatus(ctx context.Context, requestID uint) (*core.WorkflowStatus, error) {
 	ret := _mock.Called(ctx, requestID)
@@ -285,6 +584,74 @@ func (_c *MockWorkflowService_GetWorkflowStatus_Call) Return(workflowStatus *cor
 }
 
 func (_c *MockWorkflowService_GetWorkflowStatus_Call) RunAndReturn(run func(ctx context.Context, requestID uint) (*core.WorkflowStatus, error)) *MockWorkflowService_GetWorkflowStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetWorkflowStepInfo provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) GetWorkflowStepInfo(ctx context.Context, requestID uint) (*core.WorkflowStepInfo, error) {
+	ret := _mock.Called(ctx, requestID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWorkflowStepInfo")
+	}
+
+	var r0 *core.WorkflowStepInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) (*core.WorkflowStepInfo, error)); ok {
+		return returnFunc(ctx, requestID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) *core.WorkflowStepInfo); ok {
+		r0 = returnFunc(ctx, requestID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.WorkflowStepInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint) error); ok {
+		r1 = returnFunc(ctx, requestID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockWorkflowService_GetWorkflowStepInfo_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetWorkflowStepInfo'
+type MockWorkflowService_GetWorkflowStepInfo_Call struct {
+	*mock.Call
+}
+
+// GetWorkflowStepInfo is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+func (_e *MockWorkflowService_Expecter) GetWorkflowStepInfo(ctx interface{}, requestID interface{}) *MockWorkflowService_GetWorkflowStepInfo_Call {
+	return &MockWorkflowService_GetWorkflowStepInfo_Call{Call: _e.mock.On("GetWorkflowStepInfo", ctx, requestID)}
+}
+
+func (_c *MockWorkflowService_GetWorkflowStepInfo_Call) Run(run func(ctx context.Context, requestID uint)) *MockWorkflowService_GetWorkflowStepInfo_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_GetWorkflowStepInfo_Call) Return(workflowStepInfo *core.WorkflowStepInfo, err error) *MockWorkflowService_GetWorkflowStepInfo_Call {
+	_c.Call.Return(workflowStepInfo, err)
+	return _c
+}
+
+func (_c *MockWorkflowService_GetWorkflowStepInfo_Call) RunAndReturn(run func(ctx context.Context, requestID uint) (*core.WorkflowStepInfo, error)) *MockWorkflowService_GetWorkflowStepInfo_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -437,8 +804,16 @@ func (_c *MockWorkflowService_RegisterWorkflow_Call) RunAndReturn(run func(name 
 }
 
 // StartWorkflow provides a mock function for the type MockWorkflowService
-func (_mock *MockWorkflowService) StartWorkflow(ctx context.Context, name string, initialData any) (*models.Request, error) {
-	ret := _mock.Called(ctx, name, initialData)
+func (_mock *MockWorkflowService) StartWorkflow(ctx context.Context, name string, opts ...core.WorkflowOption) (*models.Request, error) {
+	// core.WorkflowOption
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, name)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StartWorkflow")
@@ -446,18 +821,18 @@ func (_mock *MockWorkflowService) StartWorkflow(ctx context.Context, name string
 
 	var r0 *models.Request
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, any) (*models.Request, error)); ok {
-		return returnFunc(ctx, name, initialData)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...core.WorkflowOption) (*models.Request, error)); ok {
+		return returnFunc(ctx, name, opts...)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, any) *models.Request); ok {
-		r0 = returnFunc(ctx, name, initialData)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...core.WorkflowOption) *models.Request); ok {
+		r0 = returnFunc(ctx, name, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Request)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, any) error); ok {
-		r1 = returnFunc(ctx, name, initialData)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...core.WorkflowOption) error); ok {
+		r1 = returnFunc(ctx, name, opts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -472,12 +847,13 @@ type MockWorkflowService_StartWorkflow_Call struct {
 // StartWorkflow is a helper method to define mock.On call
 //   - ctx context.Context
 //   - name string
-//   - initialData any
-func (_e *MockWorkflowService_Expecter) StartWorkflow(ctx interface{}, name interface{}, initialData interface{}) *MockWorkflowService_StartWorkflow_Call {
-	return &MockWorkflowService_StartWorkflow_Call{Call: _e.mock.On("StartWorkflow", ctx, name, initialData)}
+//   - opts ...core.WorkflowOption
+func (_e *MockWorkflowService_Expecter) StartWorkflow(ctx interface{}, name interface{}, opts ...interface{}) *MockWorkflowService_StartWorkflow_Call {
+	return &MockWorkflowService_StartWorkflow_Call{Call: _e.mock.On("StartWorkflow",
+		append([]interface{}{ctx, name}, opts...)...)}
 }
 
-func (_c *MockWorkflowService_StartWorkflow_Call) Run(run func(ctx context.Context, name string, initialData any)) *MockWorkflowService_StartWorkflow_Call {
+func (_c *MockWorkflowService_StartWorkflow_Call) Run(run func(ctx context.Context, name string, opts ...core.WorkflowOption)) *MockWorkflowService_StartWorkflow_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -487,14 +863,18 @@ func (_c *MockWorkflowService_StartWorkflow_Call) Run(run func(ctx context.Conte
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 any
-		if args[2] != nil {
-			arg2 = args[2].(any)
+		var arg2 []core.WorkflowOption
+		variadicArgs := make([]core.WorkflowOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(core.WorkflowOption)
+			}
 		}
+		arg2 = variadicArgs
 		run(
 			arg0,
 			arg1,
-			arg2,
+			arg2...,
 		)
 	})
 	return _c
@@ -505,7 +885,139 @@ func (_c *MockWorkflowService_StartWorkflow_Call) Return(request *models.Request
 	return _c
 }
 
-func (_c *MockWorkflowService_StartWorkflow_Call) RunAndReturn(run func(ctx context.Context, name string, initialData any) (*models.Request, error)) *MockWorkflowService_StartWorkflow_Call {
+func (_c *MockWorkflowService_StartWorkflow_Call) RunAndReturn(run func(ctx context.Context, name string, opts ...core.WorkflowOption) (*models.Request, error)) *MockWorkflowService_StartWorkflow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateWorkflowData provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) UpdateWorkflowData(ctx context.Context, requestID uint, data map[string]any) error {
+	ret := _mock.Called(ctx, requestID, data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateWorkflowData")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, map[string]any) error); ok {
+		r0 = returnFunc(ctx, requestID, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowService_UpdateWorkflowData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateWorkflowData'
+type MockWorkflowService_UpdateWorkflowData_Call struct {
+	*mock.Call
+}
+
+// UpdateWorkflowData is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+//   - data map[string]any
+func (_e *MockWorkflowService_Expecter) UpdateWorkflowData(ctx interface{}, requestID interface{}, data interface{}) *MockWorkflowService_UpdateWorkflowData_Call {
+	return &MockWorkflowService_UpdateWorkflowData_Call{Call: _e.mock.On("UpdateWorkflowData", ctx, requestID, data)}
+}
+
+func (_c *MockWorkflowService_UpdateWorkflowData_Call) Run(run func(ctx context.Context, requestID uint, data map[string]any)) *MockWorkflowService_UpdateWorkflowData_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 map[string]any
+		if args[2] != nil {
+			arg2 = args[2].(map[string]any)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_UpdateWorkflowData_Call) Return(err error) *MockWorkflowService_UpdateWorkflowData_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowService_UpdateWorkflowData_Call) RunAndReturn(run func(ctx context.Context, requestID uint, data map[string]any) error) *MockWorkflowService_UpdateWorkflowData_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateWorkflowDataStruct provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) UpdateWorkflowDataStruct(ctx context.Context, requestID uint, data any, tag string) error {
+	ret := _mock.Called(ctx, requestID, data, tag)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateWorkflowDataStruct")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, any, string) error); ok {
+		r0 = returnFunc(ctx, requestID, data, tag)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowService_UpdateWorkflowDataStruct_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateWorkflowDataStruct'
+type MockWorkflowService_UpdateWorkflowDataStruct_Call struct {
+	*mock.Call
+}
+
+// UpdateWorkflowDataStruct is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+//   - data any
+//   - tag string
+func (_e *MockWorkflowService_Expecter) UpdateWorkflowDataStruct(ctx interface{}, requestID interface{}, data interface{}, tag interface{}) *MockWorkflowService_UpdateWorkflowDataStruct_Call {
+	return &MockWorkflowService_UpdateWorkflowDataStruct_Call{Call: _e.mock.On("UpdateWorkflowDataStruct", ctx, requestID, data, tag)}
+}
+
+func (_c *MockWorkflowService_UpdateWorkflowDataStruct_Call) Run(run func(ctx context.Context, requestID uint, data any, tag string)) *MockWorkflowService_UpdateWorkflowDataStruct_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 any
+		if args[2] != nil {
+			arg2 = args[2].(any)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_UpdateWorkflowDataStruct_Call) Return(err error) *MockWorkflowService_UpdateWorkflowDataStruct_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowService_UpdateWorkflowDataStruct_Call) RunAndReturn(run func(ctx context.Context, requestID uint, data any, tag string) error) *MockWorkflowService_UpdateWorkflowDataStruct_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/testing/protocol.go
+++ b/core/testing/protocol.go
@@ -18,6 +18,7 @@ type MockProtocol struct {
 	NameValue          string
 	ConfigValue        config.ProtocolConfig
 	OperationsValue    []core.Operation
+	WorkflowsValue     []core.WorkflowDefinition
 	EncodeFileNameFunc func(core.StorageHash) string
 	HashFunc           func(r io.Reader, size uint64) (core.StorageHash, error)
 	PinHandlerValue    core.ProtocolPinHandler
@@ -53,6 +54,10 @@ func (p *MockProtocol) PinHandler() core.ProtocolPinHandler {
 	return p.PinHandlerValue
 }
 
+func (p *MockProtocol) Workflows() []core.WorkflowDefinition {
+	return p.WorkflowsValue
+}
+
 // NewMockProtocol creates a new mock protocol with default mock implementations
 func NewMockProtocol(t testing.TB, name string) *MockProtocol {
 	// Create mock pin handler with default behavior
@@ -76,6 +81,7 @@ func NewMockProtocol(t testing.TB, name string) *MockProtocol {
 	return &MockProtocol{
 		NameValue:       name,
 		OperationsValue: []core.Operation{},
+		WorkflowsValue:  []core.WorkflowDefinition{},
 		PinHandlerValue: pinHandler,
 		HashFunc: func(r io.Reader, size uint64) (core.StorageHash, error) {
 			// Read all data from reader
@@ -111,5 +117,10 @@ func (p *MockProtocol) WithConfig(cfg config.ProtocolConfig) *MockProtocol {
 // WithPinHandler sets the pin handler for the mock protocol
 func (p *MockProtocol) WithPinHandler(handler core.ProtocolPinHandler) *MockProtocol {
 	p.PinHandlerValue = handler
+	return p
+}
+
+func (p *MockProtocol) WithWorkflows(workflows []core.WorkflowDefinition) *MockProtocol {
+	p.WorkflowsValue = workflows
 	return p
 }

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -1623,7 +1623,7 @@ func WithMockS3() TestContextBuilderOption {
 
 		// Channel to signal server is ready
 		ready := make(chan struct{})
-		
+
 		go func() {
 			close(ready) // Signal server is starting
 			if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
@@ -2081,6 +2081,11 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 		return fmt.Errorf("API route configuration failed: %w", err)
 	}
 
+	// Register workflows from all protocols
+	if err := ConfigureProtocolWorkflows(ctx); err != nil {
+		return fmt.Errorf("failed to configure protocol workflows: %w", err)
+	}
+
 	// Fire boot complete event if enabled
 	if tctx, ok := ctx.(*testContext); ok && tctx.FireBootComplete() {
 		if err := ctx.Fire(pevent.EVENT_BOOT_COMPLETE, pevent.NewBootCompleteEvent(ctx)); err != nil {
@@ -2265,6 +2270,19 @@ func WithCoreEvents() TestContextBuilderOption {
 
 		return ctx, nil
 	}
+}
+
+// ConfigureProtocolWorkflows registers all workflows from all protocols with the workflow service
+func ConfigureProtocolWorkflows(ctx core.Context) error {
+	workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+	for _, proto := range core.GetProtocols() {
+		for _, workflow := range proto.Workflows() {
+			if err := workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps); err != nil {
+				return fmt.Errorf("failed to register workflow %s for protocol %s: %w", workflow.Name, proto.Name(), err)
+			}
+		}
+	}
+	return nil
 }
 
 // registerServiceInstance registers a service instance both locally in the test context

--- a/portal.go
+++ b/portal.go
@@ -367,17 +367,20 @@ func (p *PortalImpl) initModels(_ core.Context, dbInst *gorm.DB) (ctxOpts []core
 }
 
 func (p *PortalImpl) initProtocols(ctx core.Context) (ctxOpts []core.ContextBuilderOption, err error) {
-	for name, _proto := range core.GetProtocols() {
-		err := ctx.Config().ConfigureProtocol(name, _proto.Config())
-		if err != nil {
-			ctx.Logger().Error("Error configuring protocol", zap.String("protocol", _proto.Name()), zap.Error(err))
-			return nil, err
+	for _, proto := range core.GetProtocols() {
+		if initProto, ok := proto.(core.ProtocolInit); ok {
+			if err := initProto.Init(ctx); err != nil {
+				ctx.Logger().Error("Error initializing protocol", zap.String("protocol", proto.Name()), zap.Error(err))
+				return nil, err
+			}
 		}
 
-		if initProto, ok := _proto.(core.ProtocolInit); ok {
-			if err := initProto.Init(ctx); err != nil {
-				ctx.Logger().Error("Error initializing protocol", zap.String("protocol", _proto.Name()), zap.Error(err))
-				return nil, err
+		workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+
+		// Register workflows for each protocol
+		for _, workflow := range proto.Workflows() {
+			if err := workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps); err != nil {
+				return nil, fmt.Errorf("failed to register workflow %s for protocol %s: %w", workflow.Name, proto.Name(), err)
 			}
 		}
 	}


### PR DESCRIPTION
- Added Workflows() method to Protocol interface in core/protocol.go
- Updated mock protocols in core/testing to support workflows
- Modified portal initialization to register protocol workflows
- Added helper function ConfigureProtocolWorkflows in core/testing
- Updated various mock files (auto-generated changes)

The changes enable protocols to define workflows that will be automatically registered during portal initialization. Mock protocols and their generated mocks were updated to support this new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and registering workflow definitions from protocols, enabling workflows to be managed and registered automatically.
  * Enhanced protocol and workflow initialization to ensure all workflows are registered with the workflow service during environment setup.

* **Tests**
  * Expanded mock services with new methods and improved flexibility for workflow-related operations.
  * Removed and updated certain mock methods to align with workflow and protocol enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->