### PR TITLE
feat(workflow): add autoTriggerFirstStep to workflow registration

### DIFF
--- a/core/testing/mocks/WorkflowCoordinator.go
+++ b/core/testing/mocks/WorkflowCoordinator.go
@@ -443,16 +443,16 @@ func (_c *MockWorkflowCoordinator_ListWorkflows_Call) RunAndReturn(run func() []
 }
 
 // RegisterWorkflow provides a mock function for the type MockWorkflowCoordinator
-func (_mock *MockWorkflowCoordinator) RegisterWorkflow(name string, steps []core.OperationStep) error {
-	ret := _mock.Called(name, steps)
+func (_mock *MockWorkflowCoordinator) RegisterWorkflow(name string, steps []core.OperationStep, autoTriggerFirstStep bool) error {
+	ret := _mock.Called(name, steps, autoTriggerFirstStep)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RegisterWorkflow")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []core.OperationStep) error); ok {
-		r0 = returnFunc(name, steps)
+	if returnFunc, ok := ret.Get(0).(func(string, []core.OperationStep, bool) error); ok {
+		r0 = returnFunc(name, steps, autoTriggerFirstStep)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -467,11 +467,12 @@ type MockWorkflowCoordinator_RegisterWorkflow_Call struct {
 // RegisterWorkflow is a helper method to define mock.On call
 //   - name string
 //   - steps []core.OperationStep
-func (_e *MockWorkflowCoordinator_Expecter) RegisterWorkflow(name interface{}, steps interface{}) *MockWorkflowCoordinator_RegisterWorkflow_Call {
-	return &MockWorkflowCoordinator_RegisterWorkflow_Call{Call: _e.mock.On("RegisterWorkflow", name, steps)}
+//   - autoTriggerFirstStep bool
+func (_e *MockWorkflowCoordinator_Expecter) RegisterWorkflow(name interface{}, steps interface{}, autoTriggerFirstStep interface{}) *MockWorkflowCoordinator_RegisterWorkflow_Call {
+	return &MockWorkflowCoordinator_RegisterWorkflow_Call{Call: _e.mock.On("RegisterWorkflow", name, steps, autoTriggerFirstStep)}
 }
 
-func (_c *MockWorkflowCoordinator_RegisterWorkflow_Call) Run(run func(name string, steps []core.OperationStep)) *MockWorkflowCoordinator_RegisterWorkflow_Call {
+func (_c *MockWorkflowCoordinator_RegisterWorkflow_Call) Run(run func(name string, steps []core.OperationStep, autoTriggerFirstStep bool)) *MockWorkflowCoordinator_RegisterWorkflow_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -481,9 +482,14 @@ func (_c *MockWorkflowCoordinator_RegisterWorkflow_Call) Run(run func(name strin
 		if args[1] != nil {
 			arg1 = args[1].([]core.OperationStep)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -494,7 +500,7 @@ func (_c *MockWorkflowCoordinator_RegisterWorkflow_Call) Return(err error) *Mock
 	return _c
 }
 
-func (_c *MockWorkflowCoordinator_RegisterWorkflow_Call) RunAndReturn(run func(name string, steps []core.OperationStep) error) *MockWorkflowCoordinator_RegisterWorkflow_Call {
+func (_c *MockWorkflowCoordinator_RegisterWorkflow_Call) RunAndReturn(run func(name string, steps []core.OperationStep, autoTriggerFirstStep bool) error) *MockWorkflowCoordinator_RegisterWorkflow_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/testing/mocks/WorkflowService.go
+++ b/core/testing/mocks/WorkflowService.go
@@ -747,16 +747,16 @@ func (_c *MockWorkflowService_ListWorkflows_Call) RunAndReturn(run func() []stri
 }
 
 // RegisterWorkflow provides a mock function for the type MockWorkflowService
-func (_mock *MockWorkflowService) RegisterWorkflow(name string, steps []core.OperationStep) error {
-	ret := _mock.Called(name, steps)
+func (_mock *MockWorkflowService) RegisterWorkflow(name string, steps []core.OperationStep, autoTriggerFirstStep bool) error {
+	ret := _mock.Called(name, steps, autoTriggerFirstStep)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RegisterWorkflow")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []core.OperationStep) error); ok {
-		r0 = returnFunc(name, steps)
+	if returnFunc, ok := ret.Get(0).(func(string, []core.OperationStep, bool) error); ok {
+		r0 = returnFunc(name, steps, autoTriggerFirstStep)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -771,11 +771,12 @@ type MockWorkflowService_RegisterWorkflow_Call struct {
 // RegisterWorkflow is a helper method to define mock.On call
 //   - name string
 //   - steps []core.OperationStep
-func (_e *MockWorkflowService_Expecter) RegisterWorkflow(name interface{}, steps interface{}) *MockWorkflowService_RegisterWorkflow_Call {
-	return &MockWorkflowService_RegisterWorkflow_Call{Call: _e.mock.On("RegisterWorkflow", name, steps)}
+//   - autoTriggerFirstStep bool
+func (_e *MockWorkflowService_Expecter) RegisterWorkflow(name interface{}, steps interface{}, autoTriggerFirstStep interface{}) *MockWorkflowService_RegisterWorkflow_Call {
+	return &MockWorkflowService_RegisterWorkflow_Call{Call: _e.mock.On("RegisterWorkflow", name, steps, autoTriggerFirstStep)}
 }
 
-func (_c *MockWorkflowService_RegisterWorkflow_Call) Run(run func(name string, steps []core.OperationStep)) *MockWorkflowService_RegisterWorkflow_Call {
+func (_c *MockWorkflowService_RegisterWorkflow_Call) Run(run func(name string, steps []core.OperationStep, autoTriggerFirstStep bool)) *MockWorkflowService_RegisterWorkflow_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -785,9 +786,14 @@ func (_c *MockWorkflowService_RegisterWorkflow_Call) Run(run func(name string, s
 		if args[1] != nil {
 			arg1 = args[1].([]core.OperationStep)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -798,7 +804,7 @@ func (_c *MockWorkflowService_RegisterWorkflow_Call) Return(err error) *MockWork
 	return _c
 }
 
-func (_c *MockWorkflowService_RegisterWorkflow_Call) RunAndReturn(run func(name string, steps []core.OperationStep) error) *MockWorkflowService_RegisterWorkflow_Call {
+func (_c *MockWorkflowService_RegisterWorkflow_Call) RunAndReturn(run func(name string, steps []core.OperationStep, autoTriggerFirstStep bool) error) *MockWorkflowService_RegisterWorkflow_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -2277,7 +2277,7 @@ func ConfigureProtocolWorkflows(ctx core.Context) error {
 	workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
 	for _, proto := range core.GetProtocols() {
 		for _, workflow := range proto.Workflows() {
-			if err := workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps); err != nil {
+			if err := workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps, workflow.AutoTriggerFirstStep); err != nil {
 				return fmt.Errorf("failed to register workflow %s for protocol %s: %w", workflow.Name, proto.Name(), err)
 			}
 		}

--- a/core/workflow.go
+++ b/core/workflow.go
@@ -16,7 +16,7 @@ const WORKFLOW_SERVICE = "workflow"
 // WorkflowCoordinator orchestrates multi-step operations across protocols
 type WorkflowCoordinator interface {
 	// Register a new workflow with specified steps
-	RegisterWorkflow(name string, steps []OperationStep) error
+	RegisterWorkflow(name string, steps []OperationStep, autoTriggerFirstStep bool) error
 
 	// Get a registered workflow by name
 	GetWorkflow(name string) (*WorkflowDefinition, error)

--- a/portal.go
+++ b/portal.go
@@ -379,7 +379,7 @@ func (p *PortalImpl) initProtocols(ctx core.Context) (ctxOpts []core.ContextBuil
 
 		// Register workflows for each protocol
 		for _, workflow := range proto.Workflows() {
-			if err := workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps); err != nil {
+			if err := workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps, workflow.AutoTriggerFirstStep); err != nil {
 				return nil, fmt.Errorf("failed to register workflow %s for protocol %s: %w", workflow.Name, proto.Name(), err)
 			}
 		}

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -173,7 +173,7 @@ func (w *WorkflowCoordinatorDefault) ID() string {
 }
 
 // RegisterWorkflow registers a new workflow
-func (w *WorkflowCoordinatorDefault) RegisterWorkflow(name string, steps []core.OperationStep) error {
+func (w *WorkflowCoordinatorDefault) RegisterWorkflow(name string, steps []core.OperationStep, autoTriggerFirstStep bool) error {
 	w.workflowsMu.Lock()
 	defer w.workflowsMu.Unlock()
 
@@ -181,15 +181,16 @@ func (w *WorkflowCoordinatorDefault) RegisterWorkflow(name string, steps []core.
 		return fmt.Errorf("workflow '%s' already exists", name)
 	}
 
-
 	w.workflows[name] = &core.WorkflowDefinition{
-		Name:  name,
-		Steps: steps,
+		Name:                 name,
+		Steps:                steps,
+		AutoTriggerFirstStep: autoTriggerFirstStep,
 	}
 
 	w.logger.Debug("Registered workflow",
 		zap.String("name", name),
-		zap.Int("steps", len(steps)))
+		zap.Int("steps", len(steps)),
+		zap.Bool("autoTriggerFirstStep", autoTriggerFirstStep))
 
 	return nil
 }


### PR DESCRIPTION
Modified RegisterWorkflow method to accept autoTriggerFirstStep parameter and include it in workflow definitions. Updated all calls to RegisterWorkflow across:
- core/testing/testing.go
- portal.go
- service/workflow.go

The change allows controlling whether first workflow steps should be automatically triggered when workflows are registered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically triggering the first step of a workflow during registration.

* **Bug Fixes**
  * No user-facing bugs were addressed in this update.

* **Refactor**
  * Improved workflow registration to accept an option for auto-triggering the first step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->