### PR TITLE
fix(db): remove indexes for columns that no longer exist

### DIFF
--- a/db/migrations/sqlite/20250308183521_init.sql
+++ b/db/migrations/sqlite/20250308183521_init.sql
@@ -181,9 +181,7 @@ CREATE TABLE `requests`
     CONSTRAINT `fk_requests_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 );
 CREATE INDEX `idx_requests_hash` ON `requests` (`hash`);
-CREATE INDEX `idx_request_operation_system` ON `requests` (`operation`, `system`);
 CREATE INDEX `idx_requests_deleted_at` ON `requests` (`deleted_at`);
-CREATE INDEX `idx_requests_upload_hash` ON `requests` (`upload_hash`);
 
 -- 4. Tables that depend on primary tables
 CREATE TABLE `account_deletions`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed two database indexes related to the requests table to streamline data storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->