### PR TITLE
core(testing): add temp dir support to mock config manager

### DIFF
--- a/core/testing/mock_config.go
+++ b/core/testing/mock_config.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"os"
 	"testing"
 	"time"
 
@@ -141,6 +142,17 @@ func NewMockConfigManager(t *testing.T) *MockConfigManager {
 	mockManager.EXPECT().GetRegisteredStructs().
 		Maybe().
 		Return(map[string]reflect.Type{})
+
+	tempDir, err := os.MkdirTemp("", "portal-test-")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create temp dir: %v", err))
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
+	mockManager.EXPECT().ConfigDir().
+		Maybe().
+		Return(tempDir, nil)
 
 	return manager
 }


### PR DESCRIPTION
- Added temporary directory creation/cleanup in NewMockConfigManager
- Configured mock to return temp dir path for ConfigDir() calls
- Ensures tests have isolated config directory space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by creating and cleaning up a temporary directory during tests.
  * Enhanced mock behavior to simulate configuration directory access within tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->