### PR TITLE
feat(testing): add helper methods for workflow testing

### DIFF
--- a/core/testing/workflow.go
+++ b/core/testing/workflow.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"context"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal/core"
@@ -54,4 +56,50 @@ func (wt *WorkflowTest) AssertMetadataValue(requestID uint, key string, expected
 
 	actualValue := metadata.Get(key)
 	assert.Equal(wt.TB, expectedValue, actualValue, "metadata value mismatch for key %q", key)
+}
+
+// NewOperationWorkflow creates and registers a simple workflow with a single operation.
+func (wt *WorkflowTest) NewOperationWorkflow(operationName string) string {
+	workflowName := fmt.Sprintf("test-workflow-%s", operationName) // Unique name
+	steps := []core.OperationStep{{Operation: operationName, FailureBehavior: core.FailWorkflow, Foreground: true}}
+	wt.RegisterWorkflow(workflowName, steps, false) // Don't auto-trigger
+	return workflowName
+}
+
+// StartOperationWorkflow starts a workflow with the given operation and options.
+func (wt *WorkflowTest) StartOperationWorkflow(operationName string, opts ...core.WorkflowOption) *models.Request {
+	workflowName := wt.NewOperationWorkflow(operationName)
+	return wt.StartWorkflow(workflowName, opts...)
+}
+
+// AssertOperationSuccess asserts that the operation completed successfully.
+func (wt *WorkflowTest) AssertOperationSuccess(req *models.Request) {
+	wt.AssertRequestStatus(req.ID, models.RequestStatusCompleted)
+}
+
+// AssertOperationFailed asserts that the operation failed.
+func (wt *WorkflowTest) AssertOperationFailed(req *models.Request) {
+	wt.AssertRequestStatus(req.ID, models.RequestStatusFailed)
+}
+
+// AssertOperationStatusMessageContains asserts that the request status message contains the given string.
+func (wt *WorkflowTest) AssertOperationStatusMessageContains(req *models.Request, expectedMessage string) {
+	requestSvc := core.GetService[core.RequestService](wt.Ctx, core.REQUEST_SERVICE)
+	updatedReq, err := requestSvc.GetRequest(wt.Ctx, req.ID)
+	require.NoError(wt.TB, err)
+	assert.Contains(wt.TB, updatedReq.StatusMessage, expectedMessage)
+}
+
+// AssertOperationStatusProgress asserts that the request status progress is equal to the given value.
+func (wt *WorkflowTest) AssertOperationStatusProgress(req *models.Request, expectedProgress int) {
+	requestSvc := core.GetService[core.RequestService](wt.Ctx, core.REQUEST_SERVICE)
+	updatedReq, err := requestSvc.GetRequestStatus(wt.Ctx, req.ID)
+	require.NoError(wt.TB, err)
+	assert.Equal(wt.TB, expectedProgress, updatedReq.ProgressPercent)
+}
+
+// ExecuteWorkflowStep executes the workflow step for the given request.
+func (wt *WorkflowTest) ExecuteWorkflowStep(req *models.Request) {
+	err := wt.workflowSvc.ExecuteWorkflowStep(context.Background(), req.ID)
+	require.NoError(wt.TB, err)
 }


### PR DESCRIPTION
Added several utility methods to WorkflowTest to simplify workflow testing:
- NewOperationWorkflow - creates single-operation workflow
- StartOperationWorkflow - starts workflow with operation
- AssertOperationSuccess/Failed - status assertions
- AssertOperationStatusMessageContains - message validation
- AssertOperationStatusProgress - progress validation
- ExecuteWorkflowStep - executes workflow step

These methods provide a more convenient API for testing workflow operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced workflow testing capabilities with new helper methods for creating, starting, and asserting the status of operation workflows.
  * Added assertion methods to verify operation success, failure, status messages, and progress.
  * Introduced a method to execute workflow steps and ensure error-free execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->