### PR TITLE
feat(workflow): add workflow enable/disable functionality

### DIFF
--- a/core/testing/mocks/WorkflowCoordinator.go
+++ b/core/testing/mocks/WorkflowCoordinator.go
@@ -203,6 +203,108 @@ func (_c *MockWorkflowCoordinator_ConvertRequestToWorkflow_Call) RunAndReturn(ru
 	return _c
 }
 
+// DisableWorkflow provides a mock function for the type MockWorkflowCoordinator
+func (_mock *MockWorkflowCoordinator) DisableWorkflow(name string) error {
+	ret := _mock.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DisableWorkflow")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowCoordinator_DisableWorkflow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DisableWorkflow'
+type MockWorkflowCoordinator_DisableWorkflow_Call struct {
+	*mock.Call
+}
+
+// DisableWorkflow is a helper method to define mock.On call
+//   - name string
+func (_e *MockWorkflowCoordinator_Expecter) DisableWorkflow(name interface{}) *MockWorkflowCoordinator_DisableWorkflow_Call {
+	return &MockWorkflowCoordinator_DisableWorkflow_Call{Call: _e.mock.On("DisableWorkflow", name)}
+}
+
+func (_c *MockWorkflowCoordinator_DisableWorkflow_Call) Run(run func(name string)) *MockWorkflowCoordinator_DisableWorkflow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowCoordinator_DisableWorkflow_Call) Return(err error) *MockWorkflowCoordinator_DisableWorkflow_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowCoordinator_DisableWorkflow_Call) RunAndReturn(run func(name string) error) *MockWorkflowCoordinator_DisableWorkflow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// EnableWorkflow provides a mock function for the type MockWorkflowCoordinator
+func (_mock *MockWorkflowCoordinator) EnableWorkflow(name string) error {
+	ret := _mock.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnableWorkflow")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowCoordinator_EnableWorkflow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnableWorkflow'
+type MockWorkflowCoordinator_EnableWorkflow_Call struct {
+	*mock.Call
+}
+
+// EnableWorkflow is a helper method to define mock.On call
+//   - name string
+func (_e *MockWorkflowCoordinator_Expecter) EnableWorkflow(name interface{}) *MockWorkflowCoordinator_EnableWorkflow_Call {
+	return &MockWorkflowCoordinator_EnableWorkflow_Call{Call: _e.mock.On("EnableWorkflow", name)}
+}
+
+func (_c *MockWorkflowCoordinator_EnableWorkflow_Call) Run(run func(name string)) *MockWorkflowCoordinator_EnableWorkflow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowCoordinator_EnableWorkflow_Call) Return(err error) *MockWorkflowCoordinator_EnableWorkflow_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowCoordinator_EnableWorkflow_Call) RunAndReturn(run func(name string) error) *MockWorkflowCoordinator_EnableWorkflow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FailWorkflowStep provides a mock function for the type MockWorkflowCoordinator
 func (_mock *MockWorkflowCoordinator) FailWorkflowStep(ctx context.Context, requestID uint, reason string) error {
 	ret := _mock.Called(ctx, requestID, reason)

--- a/core/testing/mocks/WorkflowService.go
+++ b/core/testing/mocks/WorkflowService.go
@@ -270,6 +270,108 @@ func (_c *MockWorkflowService_ConvertRequestToWorkflow_Call) RunAndReturn(run fu
 	return _c
 }
 
+// DisableWorkflow provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) DisableWorkflow(name string) error {
+	ret := _mock.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DisableWorkflow")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowService_DisableWorkflow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DisableWorkflow'
+type MockWorkflowService_DisableWorkflow_Call struct {
+	*mock.Call
+}
+
+// DisableWorkflow is a helper method to define mock.On call
+//   - name string
+func (_e *MockWorkflowService_Expecter) DisableWorkflow(name interface{}) *MockWorkflowService_DisableWorkflow_Call {
+	return &MockWorkflowService_DisableWorkflow_Call{Call: _e.mock.On("DisableWorkflow", name)}
+}
+
+func (_c *MockWorkflowService_DisableWorkflow_Call) Run(run func(name string)) *MockWorkflowService_DisableWorkflow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_DisableWorkflow_Call) Return(err error) *MockWorkflowService_DisableWorkflow_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowService_DisableWorkflow_Call) RunAndReturn(run func(name string) error) *MockWorkflowService_DisableWorkflow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// EnableWorkflow provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) EnableWorkflow(name string) error {
+	ret := _mock.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EnableWorkflow")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowService_EnableWorkflow_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EnableWorkflow'
+type MockWorkflowService_EnableWorkflow_Call struct {
+	*mock.Call
+}
+
+// EnableWorkflow is a helper method to define mock.On call
+//   - name string
+func (_e *MockWorkflowService_Expecter) EnableWorkflow(name interface{}) *MockWorkflowService_EnableWorkflow_Call {
+	return &MockWorkflowService_EnableWorkflow_Call{Call: _e.mock.On("EnableWorkflow", name)}
+}
+
+func (_c *MockWorkflowService_EnableWorkflow_Call) Run(run func(name string)) *MockWorkflowService_EnableWorkflow_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_EnableWorkflow_Call) Return(err error) *MockWorkflowService_EnableWorkflow_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowService_EnableWorkflow_Call) RunAndReturn(run func(name string) error) *MockWorkflowService_EnableWorkflow_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ExecuteWorkflowStep provides a mock function for the type MockWorkflowService
 func (_mock *MockWorkflowService) ExecuteWorkflowStep(ctx context.Context, requestID uint) error {
 	ret := _mock.Called(ctx, requestID)

--- a/core/testing/workflow.go
+++ b/core/testing/workflow.go
@@ -103,3 +103,15 @@ func (wt *WorkflowTest) ExecuteWorkflowStep(req *models.Request) {
 	err := wt.workflowSvc.ExecuteWorkflowStep(context.Background(), req.ID)
 	require.NoError(wt.TB, err)
 }
+
+// DisableWorkflow disables the workflow with the given name.
+func (wt *WorkflowTest) DisableWorkflow(workflowName string) {
+	err := wt.workflowSvc.DisableWorkflow(workflowName)
+	require.NoError(wt.TB, err)
+}
+
+// EnableWorkflow enables the workflow with the given name.
+func (wt *WorkflowTest) EnableWorkflow(workflowName string) {
+	err := wt.workflowSvc.EnableWorkflow(workflowName)
+	require.NoError(wt.TB, err)
+}

--- a/core/workflow.go
+++ b/core/workflow.go
@@ -24,6 +24,12 @@ type WorkflowCoordinator interface {
 	// List all registered workflows
 	ListWorkflows() []string
 
+	// Disable a workflow by name (primarily for testing)
+	DisableWorkflow(name string) error
+
+	// Enable a workflow by name (primarily for testing) 
+	EnableWorkflow(name string) error
+
 	// Start a new workflow instance
 	StartWorkflow(ctx context.Context, name string, opts ...WorkflowOption) (*models.Request, error)
 

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -127,6 +127,7 @@ type WorkflowCoordinatorDefault struct {
 	cronService core.CronService
 	db          *gorm.DB
 	workflows   map[string]*core.WorkflowDefinition
+	disabled    map[string]bool
 	workflowsMu sync.RWMutex
 }
 
@@ -149,6 +150,7 @@ func (w *WorkflowCoordinatorDefault) ScheduleJobs(_ core.CronService) error {
 func NewWorkflowCoordinator() (core.Service, []core.ContextBuilderOption, error) {
 	coordinator := &WorkflowCoordinatorDefault{
 		workflows: make(map[string]*core.WorkflowDefinition),
+		disabled:  make(map[string]bool),
 	}
 
 	opts := core.ContextOptions(
@@ -208,6 +210,32 @@ func (w *WorkflowCoordinatorDefault) GetWorkflow(name string) (*core.WorkflowDef
 	return wf, nil
 }
 
+func (w *WorkflowCoordinatorDefault) DisableWorkflow(name string) error {
+	w.workflowsMu.Lock()
+	defer w.workflowsMu.Unlock()
+
+	if _, exists := w.workflows[name]; !exists {
+		return fmt.Errorf("workflow '%s' not found", name)
+	}
+
+	w.disabled[name] = true
+	w.logger.Debug("Disabled workflow", zap.String("name", name))
+	return nil
+}
+
+func (w *WorkflowCoordinatorDefault) EnableWorkflow(name string) error {
+	w.workflowsMu.Lock()
+	defer w.workflowsMu.Unlock()
+
+	if _, exists := w.workflows[name]; !exists {
+		return fmt.Errorf("workflow '%s' not found", name)
+	}
+
+	delete(w.disabled, name)
+	w.logger.Debug("Enabled workflow", zap.String("name", name))
+	return nil
+}
+
 // ListWorkflows returns all registered workflow names
 func (w *WorkflowCoordinatorDefault) ListWorkflows() []string {
 	w.workflowsMu.RLock()
@@ -227,6 +255,16 @@ func (w *WorkflowCoordinatorDefault) StartWorkflow(ctx context.Context, name str
 	workflow, err := w.GetWorkflow(name)
 	if err != nil {
 		return nil, err
+	}
+
+	w.workflowsMu.RLock()
+	disabled := w.disabled[name]
+	w.workflowsMu.RUnlock()
+
+	if disabled {
+		w.logger.Warn("Attempted to start disabled workflow",
+			zap.String("workflow", name))
+		return nil, nil
 	}
 
 	if len(workflow.Steps) == 0 {
@@ -304,6 +342,20 @@ func (w *WorkflowCoordinatorDefault) StartWorkflow(ctx context.Context, name str
 }
 
 // CompleteWorkflowStep completes the current step and advances to the next
+func (w *WorkflowCoordinatorDefault) isDisabled(name string) bool {
+	w.workflowsMu.RLock()
+	defer w.workflowsMu.RUnlock()
+	return w.disabled[name]
+}
+
+func (w *WorkflowCoordinatorDefault) parseWorkflowMetadata(metadataJSON datatypes.JSON) (WorkflowMetadata, error) {
+	var metadata WorkflowMetadata
+	if err := json.Unmarshal(metadataJSON, &metadata); err != nil {
+		return metadata, fmt.Errorf("invalid workflow meta %w", err)
+	}
+	return metadata, nil
+}
+
 func (w *WorkflowCoordinatorDefault) CompleteWorkflowStep(ctx context.Context, requestID uint, opts ...core.WorkflowOption) error {
 	// Get current request
 	currentReq, err := w.requestSvc.GetRequest(ctx, requestID)
@@ -312,9 +364,16 @@ func (w *WorkflowCoordinatorDefault) CompleteWorkflowStep(ctx context.Context, r
 	}
 
 	// Parse metadata
-	var metadata WorkflowMetadata
-	if err := json.Unmarshal(currentReq.Metadata, &metadata); err != nil {
-		return fmt.Errorf("invalid workflow meta %w", err)
+	metadata, err := w.parseWorkflowMetadata(currentReq.Metadata)
+	if err != nil {
+		return err
+	}
+
+	if w.isDisabled(metadata.WorkflowName) {
+		w.logger.Warn("Attempted to complete step in disabled workflow",
+			zap.String("workflow", metadata.WorkflowName),
+			zap.Uint("requestID", requestID))
+		return nil
 	}
 
 	workflow, err := w.GetWorkflow(metadata.WorkflowName)
@@ -416,9 +475,16 @@ func (w *WorkflowCoordinatorDefault) FailWorkflowStep(ctx context.Context, reque
 	}
 
 	// Parse metadata
-	var metadata WorkflowMetadata
-	if err := json.Unmarshal(currentReq.Metadata, &metadata); err != nil {
-		return fmt.Errorf("invalid workflow meta %w", err)
+	metadata, err := w.parseWorkflowMetadata(currentReq.Metadata)
+	if err != nil {
+		return err
+	}
+
+	if w.isDisabled(metadata.WorkflowName) {
+		w.logger.Warn("Attempted to fail step in disabled workflow",
+			zap.String("workflow", metadata.WorkflowName),
+			zap.Uint("requestID", requestID))
+		return nil
 	}
 
 	// Get workflow and current step
@@ -464,9 +530,9 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStatus(ctx context.Context, requ
 	}
 
 	// Parse metadata
-	var metadata WorkflowMetadata
-	if err := json.Unmarshal(req.Metadata, &metadata); err != nil {
-		return nil, fmt.Errorf("invalid workflow meta %w", err)
+	metadata, err := w.parseWorkflowMetadata(req.Metadata)
+	if err != nil {
+		return nil, err
 	}
 
 	// Build status
@@ -528,10 +594,17 @@ func (w *WorkflowCoordinatorDefault) ExecuteWorkflowStep(ctx context.Context, re
 		return fmt.Errorf("failed to get request: %w", err)
 	}
 
-	// Get workflow metadata
-	var metadata WorkflowMetadata
-	if err := json.Unmarshal(req.Metadata, &metadata); err != nil {
-		return fmt.Errorf("invalid workflow meta %w", err)
+	// Parse metadata
+	metadata, err := w.parseWorkflowMetadata(req.Metadata)
+	if err != nil {
+		return err
+	}
+
+	if w.isDisabled(metadata.WorkflowName) {
+		w.logger.Warn("Attempted to execute step in disabled workflow",
+			zap.String("workflow", metadata.WorkflowName),
+			zap.Uint("requestID", requestID))
+		return nil
 	}
 
 	// Get workflow and current step
@@ -580,9 +653,9 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStepInfo(ctx context.Context, re
 	}
 
 	// Parse metadata
-	var metadata WorkflowMetadata
-	if err := json.Unmarshal(req.Metadata, &metadata); err != nil {
-		return nil, fmt.Errorf("invalid workflow meta %w", err)
+	metadata, err := w.parseWorkflowMetadata(req.Metadata)
+	if err != nil {
+		return nil, err
 	}
 
 	workflow, err := w.GetWorkflow(metadata.WorkflowName)
@@ -703,6 +776,13 @@ func (w *WorkflowCoordinatorDefault) jsonToKoanf(jsonStr string) (*koanf.Koanf, 
 }
 
 func (w *WorkflowCoordinatorDefault) ConvertRequestToWorkflow(ctx context.Context, requestID uint, workflowName string, startStep int, opts ...core.WorkflowOption) error {
+	if w.isDisabled(workflowName) {
+		w.logger.Warn("Attempted to convert request to disabled workflow",
+			zap.String("workflow", workflowName),
+			zap.Uint("requestID", requestID))
+		return nil
+	}
+
 	// Get the existing request
 	req, err := w.requestSvc.GetRequest(ctx, requestID)
 	if err != nil {


### PR DESCRIPTION
- Added DisableWorkflow and EnableWorkflow methods to WorkflowCoordinator interface
- Implemented workflow disable/enable in WorkflowCoordinatorDefault with:
  - disabled map to track disabled workflows
  - isDisabled helper method
  - proper locking
- Added checks for disabled workflows in all workflow operations:
  - StartWorkflow
  - CompleteWorkflowStep
  - FailWorkflowStep
  - ExecuteWorkflowStep
  - ConvertRequestToWorkflow
- Added parseWorkflowMetadata helper method
- Added test helpers in WorkflowTest for disable/enable
- Added logging for workflow state changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to dynamically disable or enable workflows by name. Disabled workflows will not start, execute, complete, or fail until re-enabled.
* **Bug Fixes**
  * Improved handling to prevent operations on disabled workflows, ensuring they are skipped safely.
* **Tests**
  * Enhanced test utilities to support enabling and disabling workflows during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->