### PR TITLE
fix(testing): correct plugin configuration key formats

### DIFF
--- a/core/testing/mock_config.go
+++ b/core/testing/mock_config.go
@@ -19,10 +19,10 @@ import (
 
 const (
 	// Key format constants for configuration
-	ProtocolKeyFormat = "%s.protocol"   // Format for protocol configuration keys
-	APIKeyFormat      = "%s.api"        // Format for API configuration keys
-	ServiceKeyFormat  = "%s.service.%s" // Format for service configuration keys
-	CoreKeyFormat     = "core"          // Core configuration key
+	ProtocolKeyFormat = "plugin.%s.protocol"   // Format for protocol configuration keys
+	APIKeyFormat      = "plugin.%s.api"        // Format for API configuration keys
+	ServiceKeyFormat  = "plugin.%s.service.%s" // Format for service configuration keys
+	CoreKeyFormat     = "core"                 // Core configuration key
 )
 
 const mapStructureTag = "config"


### PR DESCRIPTION
- Changed ProtocolKeyFormat to "plugin.%s.protocol"
- Changed APIKeyFormat to "plugin.%s.api"
- Changed ServiceKeyFormat to "plugin.%s.service.%s"
- Maintained CoreKeyFormat as "core"

This fixes inconsistent naming conventions for plugin configuration keys by properly prefixing them with 'plugin.' to match expected format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the naming convention for configuration keys to use a "plugin." prefix, improving clarity and consistency in configuration management. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->