### PR TITLE
fix(testing): WorkflowTest.AssertOperationStatusProgress should take a float

### DIFF
--- a/core/testing/workflow.go
+++ b/core/testing/workflow.go
@@ -91,7 +91,7 @@ func (wt *WorkflowTest) AssertOperationStatusMessageContains(req *models.Request
 }
 
 // AssertOperationStatusProgress asserts that the request status progress is equal to the given value.
-func (wt *WorkflowTest) AssertOperationStatusProgress(req *models.Request, expectedProgress int) {
+func (wt *WorkflowTest) AssertOperationStatusProgress(req *models.Request, expectedProgress float64) {
 	requestSvc := core.GetService[core.RequestService](wt.Ctx, core.REQUEST_SERVICE)
 	updatedReq, err := requestSvc.GetRequestStatus(wt.Ctx, req.ID)
 	require.NoError(wt.TB, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved progress assertion in workflow tests to support floating-point values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->