### PR TITLE
refactor(testing): simplify MockRenterService implementation

### DIFF
--- a/core/testing/mock_renter.go
+++ b/core/testing/mock_renter.go
@@ -2,85 +2,72 @@ package testing
 
 import (
 	"bytes"
+	"context"
+	"crypto/md5"
 	"fmt"
 	"go.lumeweb.com/portal/core"
-	"go.lumeweb.com/portal/core/testing/mocks"
+	"go.lumeweb.com/portal/db/models"
 	"go.sia.tech/renterd/v2/api"
 	"io"
 	"sync"
-
-	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
 )
+
+var _ core.RenterService = (*MockRenterService)(nil)
 
 // MockRenterService provides a higher-level abstraction for mocking the RenterService.
 type MockRenterService struct {
-	mockRenter *mocks.MockRenterService
-	uploaded   map[string][]byte // bucket/filename -> data
-	mu         sync.RWMutex
+	uploaded map[string][]byte // bucket/filename -> data
+	buckets  map[string]bool   // track created buckets
+	mu       sync.RWMutex
+	t        testing.TB
+}
+
+func (h *MockRenterService) ID() string {
+	return core.RENTER_SERVICE
 }
 
 // NewMockRenterService creates a new MockRenterService.
 func NewMockRenterService(t TB) *MockRenterService {
-	mockRenter := mocks.NewMockRenterService(t)
 	return &MockRenterService{
-		mockRenter: mockRenter,
-		uploaded:   make(map[string][]byte),
+		uploaded: make(map[string][]byte),
+		buckets:  make(map[string]bool),
+		t:        t,
 	}
 }
 
-// Mock returns the underlying MockRenterService.
-func (h *MockRenterService) Mock() *mocks.MockRenterService {
-	return h.mockRenter
-}
-
 // UploadObject mocks the UploadObject method and stores the uploaded data.
-func (h *MockRenterService) UploadObject(bucket string, fileName string, data []byte, err error) {
+func (h *MockRenterService) UploadObject(_ context.Context, file io.Reader, bucket string, fileName string) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	key := fmt.Sprintf("%s/%s", bucket, fileName)
 
-	// Set expectation on the mock
-	h.mockRenter.On("UploadObject",
-		mock.AnythingOfType("*context.emptyCtx"),
-		mock.MatchedBy(func(r io.Reader) bool {
-			// Read the data from the reader
-			buf := new(bytes.Buffer)
-			_, readErr := buf.ReadFrom(r)
-			if readErr != nil {
-				return false // Indicate that the reader could not be read
-			}
-			return bytes.Equal(buf.Bytes(), data) // Compare the data
-		}),
-		bucket,
-		fileName,
-	).Return(err)
-
-	if err == nil {
-		h.uploaded[key] = data
+	// Read the data from the reader
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return err
 	}
+
+	h.uploaded[key] = data
+	return nil
 }
 
 // GetObject mocks the GetObject method and returns the stored data.
-func (h *MockRenterService) GetObject(bucket string, fileName string, data []byte, err error) {
+func (h *MockRenterService) GetObject(_ context.Context, bucket string, fileName string, options api.DownloadObjectOptions) (*api.GetObjectResponse, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
 	key := fmt.Sprintf("%s/%s", bucket, fileName)
-
-	// Set expectation on the mock
-	h.mockRenter.On("GetObject",
-		mock.AnythingOfType("*context.emptyCtx"),
-		bucket,
-		fileName,
-		api.DownloadObjectOptions{},
-	).Return(&api.GetObjectResponse{
-		Content: io.NopCloser(bytes.NewReader(data)),
-	}, err)
-
-	if err == nil {
-		h.uploaded[key] = data
+	data, exists := h.uploaded[key]
+	if !exists {
+		return nil, fmt.Errorf("object not found")
 	}
+
+	return &api.GetObjectResponse{
+		Content: io.NopCloser(bytes.NewReader(data)),
+	}, nil
 }
 
 // AssertUploadExists asserts that an upload exists for the given bucket and filename.
@@ -103,51 +90,134 @@ func (h *MockRenterService) GetUploadedData(bucket string, fileName string) []by
 }
 
 // CreateBucketIfNotExists mocks the CreateBucketIfNotExists method.
-func (h *MockRenterService) CreateBucketIfNotExists(bucket string, err error) {
-	h.mockRenter.On("CreateBucketIfNotExists", bucket).Return(err)
+func (h *MockRenterService) CreateBucketIfNotExists(bucket string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.buckets[bucket] = true
+	return nil
 }
 
 // DeleteObject mocks the DeleteObject method.
-func (h *MockRenterService) DeleteObject(bucket string, fileName string, err error) {
-	h.mockRenter.On("DeleteObject", bucket, fileName).Return(err)
+func (h *MockRenterService) DeleteObject(_ context.Context, bucket string, fileName string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	key := fmt.Sprintf("%s/%s", bucket, fileName)
+	delete(h.uploaded, key)
+
+	return nil
 }
 
 // UploadObjectMultipart mocks the UploadObjectMultipart method.
-func (h *MockRenterService) UploadObjectMultipart(params *core.MultipartUploadParams, err error) {
-	h.mockRenter.On("UploadObjectMultipart", mock.AnythingOfType("*context.emptyCtx"), params).Return(err)
+func (h *MockRenterService) UploadObjectMultipart(_ context.Context, params *core.MultipartUploadParams) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Simulate storing the uploaded data
+	if params != nil && params.ReaderFactory != nil {
+		reader, err := params.ReaderFactory(0, uint(params.Size))
+		if err != nil {
+			return err
+		}
+		defer func(reader io.ReadCloser) {
+			err = reader.Close()
+			if err != nil {
+				h.t.Errorf("failed to close multipart upload reader: %v", err)
+			}
+		}(reader)
+
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return err
+		}
+
+		key := fmt.Sprintf("%s/%s", params.Bucket, params.FileName)
+		h.uploaded[key] = data
+	}
+
+	return nil
 }
 
 // UploadExists mocks the UploadExists method.
-func (h *MockRenterService) UploadExists(bucket string, fileName string, exists bool, upload *interface{}, err error) {
-	h.mockRenter.On("UploadExists", mock.AnythingOfType("*context.emptyCtx"), bucket, fileName).Return(exists, upload, err)
+func (h *MockRenterService) UploadExists(_ context.Context, bucket string, fileName string) (bool, *models.SiaUpload, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	key := fmt.Sprintf("%s/%s", bucket, fileName)
+	_, exists := h.uploaded[key]
+
+	return exists, &models.SiaUpload{
+		UploadID: fileName,
+		Bucket:   bucket,
+		Key:      fileName,
+	}, nil
 }
 
 // GetObjectMetadata mocks the GetObjectMetadata method.
-func (h *MockRenterService) GetObjectMetadata(bucket string, fileName string, object *api.Object, err error) {
-	h.mockRenter.On("GetObjectMetadata", mock.AnythingOfType("*context.emptyCtx"), bucket, fileName).Return(object, err)
+func (h *MockRenterService) GetObjectMetadata(_ context.Context, bucket string, fileName string) (*api.Object, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	key := fmt.Sprintf("%s/%s", bucket, fileName)
+	data, exists := h.uploaded[key]
+	if !exists {
+		return nil, fmt.Errorf("object not found")
+	}
+
+	// Create a proper object metadata response based on stored data
+	obj := &api.Object{
+		ObjectMetadata: api.ObjectMetadata{
+			Key:     fileName,
+			Size:    int64(len(data)),
+			ETag:    fmt.Sprintf("%x", md5.Sum(data)),
+			ModTime: api.TimeRFC3339(time.Now()),
+			Bucket:  bucket,
+		},
+	}
+
+	return obj, nil
+}
+
+// BucketExists returns whether a bucket has been created
+func (h *MockRenterService) BucketExists(bucket string) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.buckets[bucket]
 }
 
 // DeleteObjectMetadata mocks the DeleteObjectMetadata method.
-func (h *MockRenterService) DeleteObjectMetadata(bucket string, fileName string, err error) {
-	h.mockRenter.On("DeleteObjectMetadata", mock.AnythingOfType("*context.emptyCtx"), bucket, fileName).Return(err)
+func (h *MockRenterService) DeleteObjectMetadata(_ context.Context, bucket string, fileName string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	key := fmt.Sprintf("%s/%s", bucket, fileName)
+	delete(h.uploaded, key)
+
+	return nil
 }
 
 // UpdateGougingSettings mocks the UpdateGougingSettings method.
-func (h *MockRenterService) UpdateGougingSettings(settings api.GougingSettings, err error) {
-	h.mockRenter.On("UpdateGougingSettings", mock.AnythingOfType("*context.emptyCtx"), settings).Return(err)
+func (h *MockRenterService) UpdateGougingSettings(_ context.Context, settings api.GougingSettings) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return nil
 }
 
 // GougingSettings mocks the GougingSettings method.
-func (h *MockRenterService) GougingSettings(settings api.GougingSettings, err error) {
-	h.mockRenter.On("GougingSettings", mock.AnythingOfType("*context.emptyCtx")).Return(settings, err)
+func (h *MockRenterService) GougingSettings(_ context.Context) (api.GougingSettings, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return api.GougingSettings{}, nil
 }
 
 // SlabSize mocks the SlabSize method.
-func (h *MockRenterService) SlabSize(size uint64, err error) {
-	h.mockRenter.On("SlabSize", mock.AnythingOfType("*context.emptyCtx")).Return(size, err)
-}
+func (h *MockRenterService) SlabSize(_ context.Context) (uint64, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 
-// AssertExpectations asserts that all expectations have been met.
-func (h *MockRenterService) AssertExpectations(t TB) {
-	h.mockRenter.AssertExpectations(t)
+	// Default slab size of 4MB
+	return uint64(4 * 1024 * 1024), nil
 }

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -1076,6 +1076,13 @@ func WithMockRequestService() TestContextBuilderOption {
 // WithMockRenterService adds a mock RenterService to the test context.
 func WithMockRenterService() TestContextBuilderOption {
 	return WithMockService(core.RENTER_SERVICE, func(tb TB, _ TestContext) any {
+		return mocks.NewMockRenterService(tb)
+	})
+}
+
+// WithStatefulMockRenterService adds a stateful mock RenterService to the test context.
+func WithStatefulMockRenterService() TestContextBuilderOption {
+	return WithMockService(core.RENTER_SERVICE, func(tb TB, _ TestContext) any {
 		return NewMockRenterService(tb)
 	})
 }


### PR DESCRIPTION
- Removed dependency on testify/mock and implemented direct mock behavior
- Changed methods to match core.RenterService interface signatures
- Added proper context parameter support
- Implemented actual storage behavior for uploaded objects
- Added proper error handling and return values
- Removed Mock() helper method since we no longer use testify mock
- Added test.TB field for better error reporting
- Implemented all required RenterService methods with proper behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to use either a stateless or stateful mock RenterService in test setups, enhancing testing flexibility.

* **Refactor**
  * Improved the mock RenterService with a thread-safe, in-memory implementation for more realistic and reliable test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->