### PR TITLE
feat(core): add reader passthrough functionality

### DIFF
--- a/core/internal/core_tests/multihasher_test.go
+++ b/core/internal/core_tests/multihasher_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"hash"
+	"io"
 	"testing"
 
 	mh "github.com/multiformats/go-multihash"
@@ -13,6 +14,18 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/core/testing/mocks"
 )
+
+type failingSeeker struct {
+	buf *bytes.Buffer
+}
+
+func (f *failingSeeker) Read(p []byte) (n int, err error) {
+	return f.buf.Read(p)
+}
+
+func (f *failingSeeker) Seek(offset int64, whence int) (int64, error) {
+	return 0, errors.New("seek error")
+}
 
 func TestNewMultiHasher_CreateMode(t *testing.T) {
 	core.ResetState()
@@ -741,6 +754,113 @@ func TestMultiHasher_MultipleWrites(t *testing.T) {
 	mockFactory.AssertExpectations(t)
 	mockHash1.AssertExpectations(t)
 	mockHash2.AssertExpectations(t)
+}
+
+func TestNewMultiHasherFromReader_BasicReader(t *testing.T) {
+	core.ResetState()
+	defer core.ResetState()
+
+	// Register mock hash algorithms
+	mockAlgo := core.HashAlgorithm{Type: 0x12, Name: "SHA-256", Priority: 100, Protocol: "test"} // SHA2-256
+	registry := core.GetHashRegistry()
+	err := registry.RegisterHashAlgorithm(mockAlgo)
+	require.NoError(t, err)
+
+	// Create a test reader
+	testData := []byte("test data")
+	reader := bytes.NewReader(testData)
+
+	// Create hasher from reader
+	hasher, err := core.NewMultiHasherFromReader(reader)
+	require.NoError(t, err)
+	defer hasher.Close()
+
+	// Read all data through the hasher
+	readBuf := make([]byte, len(testData))
+	n, err := hasher.Read(readBuf)
+	require.NoError(t, err)
+	assert.Equal(t, len(testData), n)
+	assert.Equal(t, testData, readBuf)
+
+	// Verify the hasher processed the data
+	sums := hasher.Sums()
+	assert.NotEmpty(t, sums)
+}
+
+func TestNewMultiHasherFromReader_SeekableReader(t *testing.T) {
+	core.ResetState()
+	defer core.ResetState()
+
+	// Register mock hash algorithms
+	mockAlgo := core.HashAlgorithm{Type: 0x12, Name: "SHA-256", Priority: 100, Protocol: "test"} // SHA2-256
+	registry := core.GetHashRegistry()
+	err := registry.RegisterHashAlgorithm(mockAlgo)
+	require.NoError(t, err)
+
+	// Create a test reader
+	testData := []byte("test data")
+	reader := bytes.NewReader(testData)
+
+	// Create hasher from reader
+	hasher, err := core.NewMultiHasherFromReader(reader)
+	require.NoError(t, err)
+	defer hasher.Close()
+
+	// Verify seek position was reset to start
+	pos, err := reader.Seek(0, io.SeekCurrent)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), pos)
+
+	// Read partial data
+	partialBuf := make([]byte, 4)
+	n, err := hasher.Read(partialBuf)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, testData[:4], partialBuf)
+
+	// Read remaining data
+	remainingBuf := make([]byte, len(testData)-4)
+	n, err = hasher.Read(remainingBuf)
+	require.NoError(t, err)
+	assert.Equal(t, len(testData)-4, n)
+	assert.Equal(t, testData[4:], remainingBuf)
+
+	// Verify all data was hashed
+	sums := hasher.Sums()
+	assert.NotEmpty(t, sums)
+}
+
+func TestNewMultiHasherFromReader_ErrorCases(t *testing.T) {
+	core.ResetState()
+	defer core.ResetState()
+
+	t.Run("SeekError", func(t *testing.T) {
+		// Create a reader that fails Seek
+		failingReader := &failingSeeker{buf: bytes.NewBufferString("test data")}
+		hasher, err := core.NewMultiHasherFromReader(failingReader)
+		assert.Error(t, err)
+		assert.Nil(t, hasher)
+	})
+
+	t.Run("ReadError", func(t *testing.T) {
+		testData := []byte("test data")
+		reader := bytes.NewReader(testData)
+
+		hasher, err := core.NewMultiHasherFromReader(reader)
+		require.NoError(t, err)
+		defer hasher.Close()
+
+		// Mock the Write to fail
+		mockHash := mocks.NewMockTestingHashWithProof(t)
+		mockHash.On("Write", mock.Anything).Return(0, errors.New("write error")).Once()
+		hasher.SetHashes([]hash.Hash{mockHash})
+		hasher.SetWriters([]io.Writer{mockHash})
+
+		buf := make([]byte, 4)
+		_, err = hasher.Read(buf)
+		assert.Error(t, err)
+		mockHash.AssertExpectations(t)
+	})
 }
 
 func TestMultiHasher_NoRegisteredAlgorithms(t *testing.T) {

--- a/core/multihasher.go
+++ b/core/multihasher.go
@@ -39,6 +39,7 @@ type MultiHasher struct {
 	verifying   bool       // If true, we're in verify mode
 	verifyReqs  []*VerifyRequest // Store verify requests for Sums()
 	hashFactory HashFactory // Injected dependency for creating hashers
+	source      io.Reader  // Source reader for passthrough mode
 }
 
 type HashResult struct {
@@ -61,6 +62,25 @@ type VerifyRequest struct {
 // An optional HashFactory can be provided for testing purposes.
 func NewMultiHasher(verifyReqs ...*VerifyRequest) *MultiHasher {
 	return NewMultiHasherWithFactory(DefaultHashFactory{}, verifyReqs...)
+}
+
+// NewMultiHasherFromReader creates a new MultiHasher that will hash data as it's read from the provided reader.
+// The returned MultiHasher implements io.Reader and can be used as a passthrough.
+func NewMultiHasherFromReader(r io.Reader) (*MultiHasher, error) {
+	hasher := NewMultiHasher()
+	
+	// If the input is seekable, ensure we start from the beginning
+	if seeker, ok := r.(io.ReadSeeker); ok {
+		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+			hasher.Close()
+			return nil, err
+		}
+	}
+
+	// Store the source reader
+	hasher.source = r
+	
+	return hasher, nil
 }
 
 // NewMultiHasherWithFactory creates a new MultiHasher with a specific HashFactory.
@@ -244,10 +264,42 @@ func (m *MultiHasher) Sums() []HashResult {
 	return results
 }
 
+func (m *MultiHasher) Read(p []byte) (n int, err error) {
+	if m.source == nil {
+		return 0, io.EOF
+	}
+
+	n, err = m.source.Read(p)
+	if n > 0 {
+		// Hash the data we just read
+		if _, writeErr := m.Write(p[:n]); writeErr != nil {
+			return n, writeErr
+		}
+	}
+	return n, err
+}
+
 func (m *MultiHasher) Close() {
 	// StopWait waits for all submitted tasks to complete.
-	// If we want to allow cancelling ongoing writes, we might need a context.
 	m.pool.StopWait()
+}
+
+// SetHashes sets the internal hash implementations.
+// This method is primarily intended for testing purposes to inject mock hashers.
+// It should not be used in production code.
+func (m *MultiHasher) SetHashes(hashes []hash.Hash) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.hashes = hashes
+}
+
+// SetWriters sets the internal writer implementations.
+// This method is primarily intended for testing purposes to inject mock writers.
+// It should not be used in production code.
+func (m *MultiHasher) SetWriters(writers []io.Writer) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.writers = writers
 }
 
 // HashProofGenerator represents a hash implementation that generates proofs during hashing


### PR DESCRIPTION
* Added `NewMultiHasherFromReader` constructor to create hasher from io.Reader
* Implemented io.Reader interface on MultiHasher for passthrough hashing
* Added seek position reset for seekable readers
* Added test cases for reader functionality and error handling
* Added helper methods SetHashes and SetWriters for testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating a multi-hasher directly from a data stream, enabling hashing while reading.
  * Multi-hasher now supports reading data and updating hashes on-the-fly.
  * New methods allow advanced configuration of internal hashers and writers.

* **Tests**
  * Introduced comprehensive tests for multi-hasher creation from readers, covering basic, seekable, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->