### PR TITLE
refactor(request, db): add `SetRequest` and `SetPin` methods to data models to ensure gorm doesn't create superficial records

### DIFF
--- a/db/models/data_models/data_models.go
+++ b/db/models/data_models/data_models.go
@@ -6,6 +6,7 @@ type RequestDataModel interface {
 	NewInstance() RequestDataModel
 	SetRequestID(id uint)
 	GetRequestID() uint
+	SetRequest(req any)
 }
 
 type PinDataModel interface {
@@ -14,4 +15,5 @@ type PinDataModel interface {
 	NewInstance() PinDataModel
 	SetPinID(id uint)
 	GetPinID() uint
+	SetPin(req any)
 }

--- a/db/models/tus_request.go
+++ b/db/models/tus_request.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	"fmt"
 	mh "github.com/multiformats/go-multihash"
 	"go.lumeweb.com/portal/db/models/data_models"
 	"gorm.io/gorm"
@@ -10,6 +11,8 @@ import (
 func init() {
 	registerModel(&TUSRequest{})
 }
+
+var _ data_models.RequestDataModel = (*TUSRequest)(nil)
 
 type TUSRequest struct {
 	gorm.Model
@@ -41,4 +44,16 @@ func (t *TUSRequest) SetRequestID(id uint) {
 
 func (t *TUSRequest) GetRequestID() uint {
 	return t.RequestID
+}
+
+func (t *TUSRequest) SetRequest(req any) {
+	if _mreq, ok := req.(*Request); ok {
+		t.Request = *_mreq
+		return
+	}
+	if _mreq, ok := req.(Request); ok {
+		t.Request = _mreq
+		return
+	}
+	panic(fmt.Sprintf("invalid request type %T, expected *Request or Request", req))
 }

--- a/service/pin.go
+++ b/service/pin.go
@@ -424,6 +424,7 @@ func (p *PinServiceDefault) UpdatePinData(ctx context.Context, pin *models.Pin, 
 
 	// Set pin ID
 	model.SetPinID(pin.ID)
+	model.SetPin(pin)
 
 	// Validate
 	if err := model.Validate(); err != nil {

--- a/service/request.go
+++ b/service/request.go
@@ -115,6 +115,7 @@ func (r *RequestServiceDefault) CreateRequest(ctx context.Context, req *models.R
 
 			// Set request ID
 			model.SetRequestID(newReq.ID)
+			model.SetRequest(newReq)
 
 			// Validate
 			if err := model.Validate(); err != nil {
@@ -458,6 +459,7 @@ func (r *RequestServiceDefault) UpdateRequestData(ctx context.Context, req *mode
 
 	// Set request ID
 	model.SetRequestID(req.ID)
+	model.SetRequest(req)
 
 	// Validate
 	if err := model.Validate(); err != nil {


### PR DESCRIPTION
- Added `SetRequest(req any)` method to `RequestDataModel` interface and implemented it in `TUSRequest`.
- Added `SetPin(req any)` method to `PinDataModel` interface and integrated it into `PinService` and `RequestService`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced data handling by allowing request and pin models to incorporate complete request or pin objects during creation and updates, improving data validation and consistency throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->