### PR TITLE
refactor(tus, core): rename ProtocolTusHandler to APITusHandler and update references

### DIFF
--- a/core/tus.go
+++ b/core/tus.go
@@ -11,8 +11,8 @@ import (
 // TUS_SERVICE is the service identifier for the TUS upload service
 const TUS_SERVICE = "tus"
 
-// ProtocolTusHandler defines an interface for protocols that support TUS uploads
-type ProtocolTusHandler interface {
+// APITusHandler defines an interface for apis that support TUS uploads
+type APITusHandler interface {
 	// GetTusHandler returns the TUS handler for the protocol
 	GetTusHandler() TusHandler
 }

--- a/service/tus.go
+++ b/service/tus.go
@@ -350,13 +350,15 @@ func (h *TUSOperationHandler) Cleanup(ctx context.Context, req *models.Request) 
 		return errors.New("invalid request data type")
 	}
 
-	proto := h.Protocol()
+	apiName := h.Protocol().Name()
 
-	if _, ok := proto.(core.ProtocolTusHandler); !ok {
-		return fmt.Errorf("Protocol %T does not implement core.ProtocolTusHandler")
+	api := core.GetAPI(apiName)
+
+	if _, ok := api.(core.APITusHandler); !ok {
+		return fmt.Errorf("API %T does not implement core.APITusHandler")
 	}
 
-	tusProto, _ := proto.(core.ProtocolTusHandler)
+	tusProto, _ := api.(core.APITusHandler)
 
 	err = tusProto.GetTusHandler().DeleteUpload(ctx, tusReq.TUSUploadID)
 	if err != nil {


### PR DESCRIPTION
- Renamed ProtocolTusHandler interface to APITusHandler to better reflect its purpose
- Updated all references to use the new interface name
- Modified TUS operation handler to work with API instances instead of protocols

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated interface naming and related comments for improved clarity in TUS upload handling.
  * Adjusted internal logic to reference APIs instead of protocols when managing TUS uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->