### PR TITLE
refactor(request): add support for querying deleted requests

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -40,11 +40,11 @@ type RequestService interface {
 	UpdateRequestStatus(ctx context.Context, id uint, status models.RequestStatusType, message string) error
 	CompleteRequest(ctx context.Context, id uint) error
 	FailRequest(ctx context.Context, id uint, reason string) error
-	GetRequestStatus(ctx context.Context, id uint) (*RequestStatus, error)
+	GetRequestStatus(ctx context.Context, id uint, withDeleted bool) (*RequestStatus, error)
 
 	// Utility operations
 	RequestExists(ctx context.Context, id uint) (bool, error)
-
+	GetRequestWithDeleted(ctx context.Context, id uint) (*models.Request, error)
 	ExecuteRequest(ctx context.Context, id uint) error
 
 	Service

--- a/service/request.go
+++ b/service/request.go
@@ -188,10 +188,22 @@ func (r *RequestServiceDefault) ExecuteRequest(ctx context.Context, id uint) err
 }
 
 func (r *RequestServiceDefault) GetRequest(ctx context.Context, id uint) (*models.Request, error) {
+	return r.getRequest(ctx, id, false)
+}
+
+func (r *RequestServiceDefault) GetRequestWithDeleted(ctx context.Context, id uint) (*models.Request, error) {
+	return r.getRequest(ctx, id, true)
+}
+
+func (r *RequestServiceDefault) getRequest(ctx context.Context, id uint, withDeleted bool) (*models.Request, error) {
 	var req models.Request
 	err := r.db.Transaction(func(tx *gorm.DB) error {
 		return db.RetryOnLock(tx, func(db *gorm.DB) *gorm.DB {
-			return db.WithContext(ctx).First(&req, id)
+			query := db.WithContext(ctx)
+			if withDeleted {
+				query = query.Unscoped()
+			}
+			return query.First(&req, id)
 		})
 	})
 	if err != nil {
@@ -419,8 +431,15 @@ func (r *RequestServiceDefault) ValidateRequest(ctx context.Context, req *models
 	return nil
 }
 
-func (r *RequestServiceDefault) GetRequestStatus(ctx context.Context, id uint) (*core.RequestStatus, error) {
-	req, err := r.GetRequest(ctx, id)
+func (r *RequestServiceDefault) GetRequestStatus(ctx context.Context, id uint, withDeleted bool) (*core.RequestStatus, error) {
+	var req *models.Request
+	var err error
+	
+	if withDeleted {
+		req, err = r.GetRequestWithDeleted(ctx, id)
+	} else {
+		req, err = r.GetRequest(ctx, id)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/service/request_test.go
+++ b/service/request_test.go
@@ -187,7 +187,7 @@ func TestRequestServiceDefault_GetRequestStatus(t *testing.T) {
 		require.NoError(tb, err)
 
 		// 2. Get the request status
-		status, err := requestService.GetRequestStatus(context.Background(), req.ID)
+		status, err := requestService.GetRequestStatus(context.Background(), req.ID, true)
 		require.NoError(tb, err)
 		assert.NotNil(tb, status)
 		assert.Equal(tb, string(req.Status), status.State)

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -545,7 +545,7 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStatus(ctx context.Context, requ
 	}
 
 	// Get detailed request status
-	reqStatus, err := w.requestSvc.GetRequestStatus(ctx, requestID)
+	reqStatus, err := w.requestSvc.GetRequestStatus(ctx, requestID, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Added `withDeleted` parameter to `GetRequestStatus` method
- Added new `GetRequestWithDeleted` method to retrieve soft-deleted requests
- Updated `getRequest` helper to support querying deleted records
- Modified request service implementation to handle deleted records