### PR TITLE
refactor(tus): standardize upload location to temporary uploads directory

### DIFF
--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -290,6 +290,7 @@ func (t *TusHandlerDefault) init(handlerConfig core.TUSHandlerConfig) error {
 	}
 
 	store := s3store.New(t.config.Config().Core.Storage.S3.BufferBucket, s3Client)
+	store.ObjectPrefix = fmt.Sprintf("%s/%s", core.TEMPORARY_UPLOADS_PATH, t.handlerConfig.Protocol.(core.StorageProtocol).Name())
 
 	composer := handler.NewStoreComposer()
 	store.UseIn(composer)


### PR DESCRIPTION
Align TUS upload storage location with other temporary uploads by:
- Setting ObjectPrefix to use core.TEMPORARY_UPLOADS_PATH
- Including protocol name in path for organization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the configuration for file uploads to use a specific storage path based on the protocol in use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->