### PR TITLE
feat(storage): add methods for temporary upload paths and update S3 handling

### DIFF
--- a/core/storage.go
+++ b/core/storage.go
@@ -127,6 +127,8 @@ type StorageService interface {
 	S3GetTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) (io.ReadCloser, error)
 	S3DeleteTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) error
 	UploadStatus(ctx context.Context, protocol StorageProtocol, objectName string) (StorageUploadStatus, *time.Time, error)
+	GetTemporaryUploadDir(protocol StorageProtocol) string
+	GetTemporaryUploadPath(protocol StorageProtocol, uploadId string) string
 
 	Service
 }

--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -243,12 +243,12 @@ func (t *TusHandlerDefault) DeleteUpload(ctx context.Context, id string) error {
 		// Check main file
 		_, err := t.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
 			Bucket: aws.String(t.config.Config().Core.Storage.S3.BufferBucket),
-			Key:    aws.String(deleteId),
+			Key:    aws.String(t.storage.GetTemporaryUploadPath(t.handlerConfig.Protocol.(core.StorageProtocol), deleteId)),
 		})
 		if err == nil {
 			_, err = t.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 				Bucket: aws.String(t.config.Config().Core.Storage.S3.BufferBucket),
-				Key:    aws.String(deleteId),
+				Key:    aws.String(t.storage.GetTemporaryUploadPath(t.handlerConfig.Protocol.(core.StorageProtocol), deleteId)),
 			})
 			if err != nil {
 				t.logger.Error("failed to delete upload object", zap.Error(err))
@@ -258,12 +258,12 @@ func (t *TusHandlerDefault) DeleteUpload(ctx context.Context, id string) error {
 		// Check info file
 		_, err = t.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
 			Bucket: aws.String(t.config.Config().Core.Storage.S3.BufferBucket),
-			Key:    aws.String(deleteId + ".info"),
+			Key:    aws.String(t.storage.GetTemporaryUploadPath(t.handlerConfig.Protocol.(core.StorageProtocol), deleteId+".info")),
 		})
 		if err == nil {
 			_, err = t.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 				Bucket: aws.String(t.config.Config().Core.Storage.S3.BufferBucket),
-				Key:    aws.String(deleteId + ".info"),
+				Key:    aws.String(t.storage.GetTemporaryUploadPath(t.handlerConfig.Protocol.(core.StorageProtocol), deleteId+".info")),
 			})
 			if err != nil {
 				t.logger.Error("failed to delete upload metadata", zap.Error(err))
@@ -290,7 +290,7 @@ func (t *TusHandlerDefault) init(handlerConfig core.TUSHandlerConfig) error {
 	}
 
 	store := s3store.New(t.config.Config().Core.Storage.S3.BufferBucket, s3Client)
-	store.ObjectPrefix = fmt.Sprintf("%s/%s", core.TEMPORARY_UPLOADS_PATH, t.handlerConfig.Protocol.(core.StorageProtocol).Name())
+	store.ObjectPrefix = t.storage.GetTemporaryUploadDir(t.handlerConfig.Protocol.(core.StorageProtocol))
 
 	composer := handler.NewStoreComposer()
 	store.UseIn(composer)

--- a/service/storage.go
+++ b/service/storage.go
@@ -588,7 +588,7 @@ func (s StorageServiceDefault) UploadStatus(ctx context.Context, protocol core.S
 
 func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol core.StorageProtocol) (string, error) {
 	uploadId := uuid.NewString()
-	key := s.getTempUploadPath(protocol, uploadId)
+	key := s.GetTemporaryUploadPath(protocol, uploadId)
 
 	defer func(data io.ReadCloser) {
 		err := data.Close()
@@ -617,7 +617,7 @@ func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.Re
 }
 
 func (s StorageServiceDefault) S3GetTemporaryUpload(ctx context.Context, protocol core.StorageProtocol, uploadId string) (io.ReadCloser, error) {
-	key := s.getTempUploadPath(protocol, uploadId)
+	key := s.GetTemporaryUploadPath(protocol, uploadId)
 
 	client, err := s.S3Client(ctx)
 	if err != nil {
@@ -637,7 +637,7 @@ func (s StorageServiceDefault) S3GetTemporaryUpload(ctx context.Context, protoco
 }
 
 func (s StorageServiceDefault) S3DeleteTemporaryUpload(ctx context.Context, protocol core.StorageProtocol, uploadId string) error {
-	key := s.getTempUploadPath(protocol, uploadId)
+	key := s.GetTemporaryUploadPath(protocol, uploadId)
 
 	client, err := s.S3Client(ctx)
 	if err != nil {
@@ -660,9 +660,13 @@ func (s StorageServiceDefault) getProofPath(protocol core.StorageProtocol, objec
 	return fmt.Sprintf("%s%s", protocol.EncodeFileName(objectHash), core.PROOF_EXTENSION)
 }
 
-func (s StorageServiceDefault) getTempUploadPath(protocol core.StorageProtocol, uploadId string) string {
-	return fmt.Sprintf("%s/%s/%s", core.TEMPORARY_UPLOADS_PATH, protocol.Name(), uploadId)
+func (s StorageServiceDefault) GetTemporaryUploadPath(protocol core.StorageProtocol, uploadId string) string {
+	return fmt.Sprintf("%s/%s", s.GetTemporaryUploadDir(protocol), uploadId)
 }
+func (s StorageServiceDefault) GetTemporaryUploadDir(protocol core.StorageProtocol) string {
+	return fmt.Sprintf("%s/%s", core.TEMPORARY_UPLOADS_PATH, protocol.Name())
+}
+
 func ensureHttpPrefix(url string) string {
 	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 		return "http://" + url


### PR DESCRIPTION
- Added `GetTemporaryUploadDir` and `GetTemporaryUploadPath` methods to `StorageService` interface
- Updated S3 temporary upload handling to use the new path methods consistently
- Refactored path construction logic in `service/storage.go`