### PR TITLE
refactor(core): migrate account errors to new error registry system

### DIFF
--- a/core/account_errors.go
+++ b/core/account_errors.go
@@ -1,134 +1,231 @@
 package core
 
 import (
-	"fmt"
 	"net/http"
 )
 
-type AccountErrorType string
+const accountErrorNamespace = "account"
+
+type AccountErrorType = ErrorType
 
 const (
 	// Account creation errors
-	ErrKeyAccountCreationFailed AccountErrorType = "ErrAccountCreationFailed"
-	ErrKeyEmailAlreadyExists    AccountErrorType = "ErrEmailAlreadyExists"
-	ErrKeyUpdatingSameEmail     AccountErrorType = "ErrUpdatingSameEmail"
-	ErrKeyPasswordHashingFailed AccountErrorType = "ErrPasswordHashingFailed"
+	ErrKeyAccountCreationFailed ErrorType = "ErrAccountCreationFailed"
+	ErrKeyEmailAlreadyExists    ErrorType = "ErrEmailAlreadyExists"
+	ErrKeyUpdatingSameEmail     ErrorType = "ErrUpdatingSameEmail"
+	ErrKeyPasswordHashingFailed ErrorType = "ErrPasswordHashingFailed"
 
 	// Account role errors
-	ErrKeyAssigningAdminRoleFailed AccountErrorType = "ErrAssigningAdminRoleFailed"
-	ErrorAssigningUserRoleFailed   AccountErrorType = "ErrorAssigningUserRoleFailed"
+	ErrKeyAssigningAdminRoleFailed ErrorType = "ErrAssigningAdminRoleFailed"
+	ErrKeyAssigningUserRoleFailed   ErrorType = "ErrAssigningUserRoleFailed"
 
 	// Account lookup and existence verification errors
-	ErrKeyUserNotFound      AccountErrorType = "ErrUserNotFound"
-	ErrKeyPublicKeyNotFound AccountErrorType = "ErrPublicKeyNotFound"
+	ErrKeyUserNotFound      ErrorType = "ErrUserNotFound"
+	ErrKeyPublicKeyNotFound ErrorType = "ErrPublicKeyNotFound"
 
 	// Account deletion errors
-	ErrKeyAccountDeletionRequestAlreadyExists AccountErrorType = "ErrAccountDeletionRequestAlreadyExists"
+	ErrKeyAccountDeletionRequestAlreadyExists ErrorType = "ErrAccountDeletionRequestAlreadyExists"
 
 	// Authentication and login errors
-	ErrKeyInvalidLogin           AccountErrorType = "ErrInvalidLogin"
-	ErrKeyInvalidPassword        AccountErrorType = "ErrInvalidPassword"
-	ErrKeyInvalidOTPCode         AccountErrorType = "ErrInvalidOTPCode"
-	ErrKeyOTPVerificationFailed  AccountErrorType = "ErrOTPVerificationFailed"
-	ErrKeyLoginFailed            AccountErrorType = "ErrLoginFailed"
-	ErrKeyHashingFailed          AccountErrorType = "ErrHashingFailed"
-	ErrKeyAccountPendingDeletion AccountErrorType = "ErrAccountPendingDeletion"
-	ErrKeyAccountNotVerified     AccountErrorType = "ErrAccountNotVerified"
+	ErrKeyInvalidLogin           ErrorType = "ErrInvalidLogin"
+	ErrKeyInvalidPassword        ErrorType = "ErrInvalidPassword"
+	ErrKeyInvalidOTPCode         ErrorType = "ErrInvalidOTPCode"
+	ErrKeyOTPVerificationFailed  ErrorType = "ErrOTPVerificationFailed"
+	ErrKeyLoginFailed            ErrorType = "ErrLoginFailed"
+	ErrKeyHashingFailed          ErrorType = "ErrHashingFailed"
+	ErrKeyAccountPendingDeletion ErrorType = "ErrAccountPendingDeletion"
+	ErrKeyAccountNotVerified     ErrorType = "ErrAccountNotVerified"
 
 	// Account update errors
-	ErrKeyAccountUpdateFailed    AccountErrorType = "ErrAccountUpdateFailed"
-	ErrKeyAccountAlreadyVerified AccountErrorType = "ErrAccountAlreadyVerified"
+	ErrKeyAccountUpdateFailed    ErrorType = "ErrAccountUpdateFailed"
+	ErrKeyAccountAlreadyVerified ErrorType = "ErrAccountAlreadyVerified"
 
 	// JWT generation errors
-	ErrKeyJWTGenerationFailed AccountErrorType = "ErrJWTGenerationFailed"
+	ErrKeyJWTGenerationFailed ErrorType = "ErrJWTGenerationFailed"
 
 	// OTP management errors
-	ErrKeyOTPGenerationFailed AccountErrorType = "ErrOTPGenerationFailed"
-	ErrKeyOTPEnableFailed     AccountErrorType = "ErrOTPEnableFailed"
-	ErrKeyOTPDisableFailed    AccountErrorType = "ErrOTPDisableFailed"
+	ErrKeyOTPGenerationFailed ErrorType = "ErrOTPGenerationFailed"
+	ErrKeyOTPEnableFailed     ErrorType = "ErrOTPEnableFailed"
+	ErrKeyOTPDisableFailed    ErrorType = "ErrOTPDisableFailed"
 
 	// Public key management errors
-	ErrKeyAddPublicKeyFailed AccountErrorType = "ErrAddPublicKeyFailed"
-	ErrKeyPublicKeyExists    AccountErrorType = "ErrPublicKeyExists"
+	ErrKeyAddPublicKeyFailed ErrorType = "ErrAddPublicKeyFailed"
+	ErrKeyPublicKeyExists    ErrorType = "ErrPublicKeyExists"
 
 	// Pin management errors
-	ErrKeyPinAddFailed        AccountErrorType = "ErrPinAddFailed"
-	ErrKeyPinDeleteFailed     AccountErrorType = "ErrPinDeleteFailed"
-	ErrKeyPinsRetrievalFailed AccountErrorType = "ErrPinsRetrievalFailed"
+	ErrKeyPinAddFailed        ErrorType = "ErrPinAddFailed"
+	ErrKeyPinDeleteFailed     ErrorType = "ErrPinDeleteFailed"
+	ErrKeyPinsRetrievalFailed ErrorType = "ErrPinsRetrievalFailed"
 
 	// General errors
-	ErrKeyDatabaseOperationFailed = "ErrDatabaseOperationFailed"
+	ErrKeyDatabaseOperationFailed ErrorType = "ErrDatabaseOperationFailed"
 
 	// Security token errors
-	ErrKeySecurityTokenExpired AccountErrorType = "ErrSecurityTokenExpired"
-	ErrKeySecurityInvalidToken AccountErrorType = "ErrSecurityInvalidToken"
+	ErrKeySecurityTokenExpired ErrorType = "ErrSecurityTokenExpired"
+	ErrKeySecurityInvalidToken ErrorType = "ErrSecurityInvalidToken"
 
 	// Internal errors
-	ErrKeyAccountSubdomainNotSet AccountErrorType = "ErrAccountSubdomainNotSet"
+	ErrKeyAccountSubdomainNotSet ErrorType = "ErrAccountSubdomainNotSet"
 )
 
-var defaultErrorMessages = map[AccountErrorType]string{
+var defaultAccountErrorMessages = map[ErrorType]ErrorDefinition{
 	// Account creation errors
-	ErrKeyAccountCreationFailed: "Account creation failed due to an internal error.",
-	ErrKeyEmailAlreadyExists:    "The email address provided is already in use.",
-	ErrKeyPasswordHashingFailed: "Failed to secure the password, please try again later.",
-	ErrKeyUpdatingSameEmail:     "The email address provided is the same as your current one.",
+	ErrKeyAccountCreationFailed: {
+		Key:     ErrKeyAccountCreationFailed,
+		Message: "Account creation failed due to an internal error.",
+	},
+	ErrKeyEmailAlreadyExists: {
+		Key:     ErrKeyEmailAlreadyExists,
+		Message: "The email address provided is already in use.",
+	},
+	ErrKeyPasswordHashingFailed: {
+		Key:     ErrKeyPasswordHashingFailed,
+		Message: "Failed to secure the password, please try again later.",
+	},
+	ErrKeyUpdatingSameEmail: {
+		Key:     ErrKeyUpdatingSameEmail,
+		Message: "The email address provided is the same as your current one.",
+	},
 
 	// Account role errors
-	ErrKeyAssigningAdminRoleFailed: "Failed to assign the admin role to the account.",
-	ErrorAssigningUserRoleFailed:   "Failed to assign the user role to the account.",
+	ErrKeyAssigningAdminRoleFailed: {
+		Key:     ErrKeyAssigningAdminRoleFailed,
+		Message: "Failed to assign the admin role to the account.",
+	},
+	ErrKeyAssigningUserRoleFailed: {
+		Key:     ErrKeyAssigningUserRoleFailed,
+		Message: "Failed to assign the user role to the account.",
+	},
 
 	// Account lookup and existence verification errors
-	ErrKeyUserNotFound:      "The requested user was not found.",
-	ErrKeyPublicKeyNotFound: "The specified public key was not found.",
-	ErrKeyHashingFailed:     "Failed to hash the password.",
+	ErrKeyUserNotFound: {
+		Key:     ErrKeyUserNotFound,
+		Message: "The requested user was not found.",
+	},
+	ErrKeyPublicKeyNotFound: {
+		Key:     ErrKeyPublicKeyNotFound,
+		Message: "The specified public key was not found.",
+	},
+	ErrKeyHashingFailed: {
+		Key:     ErrKeyHashingFailed,
+		Message: "Failed to hash the password.",
+	},
 
 	// Account deletion errors
-	ErrKeyAccountDeletionRequestAlreadyExists: "An account deletion request already exists for this account.",
+	ErrKeyAccountDeletionRequestAlreadyExists: {
+		Key:     ErrKeyAccountDeletionRequestAlreadyExists,
+		Message: "An account deletion request already exists for this account.",
+	},
 
 	// Authentication and login errors
-	ErrKeyInvalidLogin:           "The login credentials provided are invalid.",
-	ErrKeyInvalidPassword:        "The password provided is incorrect.",
-	ErrKeyInvalidOTPCode:         "The OTP code provided is invalid or expired.",
-	ErrKeyOTPVerificationFailed:  "OTP verification failed, please try again.",
-	ErrKeyLoginFailed:            "Login failed due to an internal error.",
-	ErrKeyAccountPendingDeletion: "This account is pending deletion.",
-	ErrKeyAccountNotVerified:     "The account is not verified.",
+	ErrKeyInvalidLogin: {
+		Key:     ErrKeyInvalidLogin,
+		Message: "The login credentials provided are invalid.",
+	},
+	ErrKeyInvalidPassword: {
+		Key:     ErrKeyInvalidPassword,
+		Message: "The password provided is incorrect.",
+	},
+	ErrKeyInvalidOTPCode: {
+		Key:     ErrKeyInvalidOTPCode,
+		Message: "The OTP code provided is invalid or expired.",
+	},
+	ErrKeyOTPVerificationFailed: {
+		Key:     ErrKeyOTPVerificationFailed,
+		Message: "OTP verification failed, please try again.",
+	},
+	ErrKeyLoginFailed: {
+		Key:     ErrKeyLoginFailed,
+		Message: "Login failed due to an internal error.",
+	},
+	ErrKeyAccountPendingDeletion: {
+		Key:     ErrKeyAccountPendingDeletion,
+		Message: "This account is pending deletion.",
+	},
+	ErrKeyAccountNotVerified: {
+		Key:     ErrKeyAccountNotVerified,
+		Message: "The account is not verified.",
+	},
 
 	// Account update errors
-	ErrKeyAccountUpdateFailed:    "Failed to update account information.",
-	ErrKeyAccountAlreadyVerified: "Account is already verified.",
+	ErrKeyAccountUpdateFailed: {
+		Key:     ErrKeyAccountUpdateFailed,
+		Message: "Failed to update account information.",
+	},
+	ErrKeyAccountAlreadyVerified: {
+		Key:     ErrKeyAccountAlreadyVerified,
+		Message: "Account is already verified.",
+	},
 
 	// JWT generation errors
-	ErrKeyJWTGenerationFailed: "Failed to generate a new JWT token.",
+	ErrKeyJWTGenerationFailed: {
+		Key:     ErrKeyJWTGenerationFailed,
+		Message: "Failed to generate a new JWT token.",
+	},
 
 	// OTP management errors
-	ErrKeyOTPGenerationFailed: "Failed to generate a new OTP secret.",
-	ErrKeyOTPEnableFailed:     "Enabling OTP authentication failed.",
-	ErrKeyOTPDisableFailed:    "Disabling OTP authentication failed.",
+	ErrKeyOTPGenerationFailed: {
+		Key:     ErrKeyOTPGenerationFailed,
+		Message: "Failed to generate a new OTP secret.",
+	},
+	ErrKeyOTPEnableFailed: {
+		Key:     ErrKeyOTPEnableFailed,
+		Message: "Enabling OTP authentication failed.",
+	},
+	ErrKeyOTPDisableFailed: {
+		Key:     ErrKeyOTPDisableFailed,
+		Message: "Disabling OTP authentication failed.",
+	},
 
 	// Public key management errors
-	ErrKeyAddPublicKeyFailed: "Adding the public key to the account failed.",
-	ErrKeyPublicKeyExists:    "The public key already exists for this account.",
+	ErrKeyAddPublicKeyFailed: {
+		Key:     ErrKeyAddPublicKeyFailed,
+		Message: "Adding the public key to the account failed.",
+	},
+	ErrKeyPublicKeyExists: {
+		Key:     ErrKeyPublicKeyExists,
+		Message: "The public key already exists for this account.",
+	},
 
 	// Pin management errors
-	ErrKeyPinAddFailed:        "Failed to add the pin.",
-	ErrKeyPinDeleteFailed:     "Failed to delete the pin.",
-	ErrKeyPinsRetrievalFailed: "Failed to retrieve pins.",
+	ErrKeyPinAddFailed: {
+		Key:     ErrKeyPinAddFailed,
+		Message: "Failed to add the pin.",
+	},
+	ErrKeyPinDeleteFailed: {
+		Key:     ErrKeyPinDeleteFailed,
+		Message: "Failed to delete the pin.",
+	},
+	ErrKeyPinsRetrievalFailed: {
+		Key:     ErrKeyPinsRetrievalFailed,
+		Message: "Failed to retrieve pins.",
+	},
 
 	// General errors
-	ErrKeyDatabaseOperationFailed: "A database operation failed.",
+	ErrKeyDatabaseOperationFailed: {
+		Key:     ErrKeyDatabaseOperationFailed,
+		Message: "A database operation failed.",
+	},
 
 	// Security token errors
-	ErrKeySecurityTokenExpired: "The security token has expired.",
-	ErrKeySecurityInvalidToken: "The security token is invalid.",
+	ErrKeySecurityTokenExpired: {
+		Key:     ErrKeySecurityTokenExpired,
+		Message: "The security token has expired.",
+	},
+	ErrKeySecurityInvalidToken: {
+		Key:     ErrKeySecurityInvalidToken,
+		Message: "The security token is invalid.",
+	},
 
 	// Internal errors
-	ErrKeyAccountSubdomainNotSet: "The account subdomain is not set.",
+	ErrKeyAccountSubdomainNotSet: {
+		Key:     ErrKeyAccountSubdomainNotSet,
+		Message: "The account subdomain is not set.",
+	},
 }
 
 var (
-	ErrorCodeToHttpStatus = map[AccountErrorType]int{
+	accountErrorCodeToHttpStatus = map[ErrorType]int{
 		// Account creation errors
 		ErrKeyAccountCreationFailed: http.StatusInternalServerError,
 		ErrKeyEmailAlreadyExists:    http.StatusConflict,
@@ -136,7 +233,7 @@ var (
 
 		// Account role errors
 		ErrKeyAssigningAdminRoleFailed: http.StatusInternalServerError,
-		ErrorAssigningUserRoleFailed:   http.StatusInternalServerError,
+		ErrKeyAssigningUserRoleFailed:   http.StatusInternalServerError,
 
 		// Account lookup and existence verification errors
 		ErrKeyUserNotFound:      http.StatusNotFound,
@@ -188,62 +285,23 @@ var (
 	}
 )
 
-type AccountError struct {
-	Key     AccountErrorType `json:"error"`   // A unique identifier for the error type
-	Message string           `json:"message"` // Human-readable error message
-	Err     error            `json:"-"`       // Underlying error, if any
+func init() {
+	MustRegisterNamespace(accountErrorNamespace)
+	MustRegisterDefaultErrorMessages(accountErrorNamespace, defaultAccountErrorMessages)
+	MustRegisterErrorCodes(accountErrorNamespace, accountErrorCodeToHttpStatus)
 }
 
-func (e *AccountError) Error() string {
-	if e.Err != nil {
-		return fmt.Sprintf("%s: %v", e.Message, e.Err)
-	}
-	return e.Message
+// NewAccountError creates a new Error instance using the core error registry.
+func NewAccountError(key ErrorType, err error, args ...interface{}) *Error {
+	return errorRegistry.NewError(accountErrorNamespace, key, err, args...)
 }
 
-func (e *AccountError) IsErrorType(key AccountErrorType) bool {
-	return e.Key == key
-}
-
-func (e *AccountError) HttpStatus() int {
-	if status, exists := ErrorCodeToHttpStatus[e.Key]; exists {
-		return status
-	}
-	return http.StatusInternalServerError
-}
-
-func NewAccountError(key AccountErrorType, err error, customMessage ...string) *AccountError {
-	message, exists := defaultErrorMessages[key]
-	if !exists {
-		message = "An unknown error occurred"
-	}
-	if len(customMessage) > 0 {
-		message = customMessage[0]
-	}
-	return &AccountError{
-		Key:     key,
-		Message: message,
-		Err:     err,
-	}
-}
-
+// IsAccountError checks if the error is an account error.
 func IsAccountError(err error) bool {
-	if err == nil {
-		return false
-	}
-	if _, ok := err.(*AccountError); ok {
-		return true
-	}
-
-	return false
+	return IsNamespaceError(err, accountErrorNamespace)
 }
 
-func AsAccountError(err error) *AccountError {
-	if err == nil {
-		return nil
-	}
-	if e, ok := err.(*AccountError); ok {
-		return e
-	}
-	return nil
+// AsAccountError casts the error to a Error if possible.
+func AsAccountError(err error) *Error {
+	return AsNamespaceError(err, accountErrorNamespace)
 }

--- a/core/context.go
+++ b/core/context.go
@@ -411,6 +411,7 @@ func ResetState() {
 	ResetAPIs()
 	ResetServices()
 	ResetHashAlgorithms()
+	ResetErrorRegistry()
 
 	// Reset plugins
 	pluginsMu.Lock()

--- a/core/errors.go
+++ b/core/errors.go
@@ -1,0 +1,278 @@
+package core
+
+import (
+	"fmt"
+	router "go.lumeweb.com/portal-router"
+	"net/http"
+	"sync"
+)
+
+const (
+	ErrUnknownErrorKey ErrorType = "ErrUnknownError"
+)
+
+var (
+	errorRegistry     = NewErrorRegistry()
+	errorRegistryMu   sync.RWMutex
+)
+
+var _ error = (*Error)(nil)
+var _ router.ResponseError = (*Error)(nil)
+
+// ErrorType is a string type for error keys.
+type ErrorType string
+
+// ErrorRegistry manages error types and their associated data.
+type ErrorRegistry struct {
+	mu                sync.RWMutex
+	namespaces        map[string]ErrorNamespace // Namespace -> ErrorNamespace
+}
+
+// ErrorNamespace holds the error definitions and HTTP status codes for a namespace.
+type ErrorNamespace struct {
+	errorDefinitions map[ErrorType]ErrorDefinition
+	errorCodes       map[ErrorType]int
+}
+
+// ErrorDefinition holds the data associated with an error type.  It no longer contains the HttpStatus.
+type ErrorDefinition struct {
+	Key         ErrorType
+	Message     string
+	DefaultArgs []interface{} // Optional default arguments for the error message
+}
+
+// Error is the error object that will be returned.
+type Error struct {
+	Key       ErrorType     `json:"error"`     // A unique identifier for the error type
+	Message   string        `json:"message"`   // Human-readable error message
+	Err       error         `json:"-"`         // Underlying error, if any
+	Args      []interface{} `json:"-"`         // Arguments used to format the error message
+	Namespace string        `json:"namespace"` // The namespace of the error
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Err)
+	}
+	return e.Message
+}
+
+// HttpStatus implements the router.ResponseError interface.
+func (e *Error) HttpStatus() int {
+	errorRegistryMu.RLock()
+	defer errorRegistryMu.RUnlock()
+	code, ok := errorRegistry.GetErrorCode(e.Namespace, e.Key)
+	if !ok {
+		return http.StatusInternalServerError
+	}
+	return code
+}
+
+// IsNamespace checks if the error belongs to the given namespace.
+func (e *Error) IsNamespace(namespace string) bool {
+	return e.Namespace == namespace
+}
+
+func (e *Error) IsErrorType(errType ErrorType) bool {
+	return e.Key == errType
+}
+
+// NewErrorRegistry creates a new ErrorRegistry.
+func NewErrorRegistry() *ErrorRegistry {
+	return &ErrorRegistry{
+		namespaces:        make(map[string]ErrorNamespace),
+	}
+}
+
+// RegisterNamespace creates a new namespace in the registry.
+func (r *ErrorRegistry) RegisterNamespace(namespace string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.namespaces[namespace]; exists {
+		return fmt.Errorf("namespace '%s' already exists", namespace)
+	}
+
+	r.namespaces[namespace] = ErrorNamespace{
+		errorDefinitions: make(map[ErrorType]ErrorDefinition),
+		errorCodes:       make(map[ErrorType]int),
+	}
+	return nil
+}
+
+// RegisterDefaultErrorMessages registers a map of error definitions within a namespace.
+func (r *ErrorRegistry) RegisterDefaultErrorMessages(namespace string, errorMap map[ErrorType]ErrorDefinition) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ns, exists := r.namespaces[namespace]
+	if !exists {
+		return fmt.Errorf("namespace '%s' does not exist", namespace)
+	}
+
+	for key, def := range errorMap {
+		if _, exists := ns.errorDefinitions[key]; exists {
+			return fmt.Errorf("error type '%s' already exists in namespace '%s'", key, namespace)
+		}
+		ns.errorDefinitions[key] = def
+	}
+
+	return nil
+}
+
+// RegisterErrorCodes registers a map of error codes (HTTP status codes) within a namespace.
+func (r *ErrorRegistry) RegisterErrorCodes(namespace string, errorCodeMap map[ErrorType]int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ns, exists := r.namespaces[namespace]
+	if !exists {
+		return fmt.Errorf("namespace '%s' does not exist", namespace)
+	}
+
+	for key, code := range errorCodeMap {
+		if _, exists := ns.errorCodes[key]; exists {
+			return fmt.Errorf("error code for type '%s' already exists in namespace '%s'", key, namespace)
+		}
+		ns.errorCodes[key] = code
+	}
+
+	return nil
+}
+
+// GetErrorDefinition retrieves the ErrorDefinition for a given namespace and error type.
+func (r *ErrorRegistry) GetErrorDefinition(namespace string, key ErrorType) (ErrorDefinition, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	ns, exists := r.namespaces[namespace]
+	if !exists {
+		return ErrorDefinition{}, false
+	}
+
+	def, exists := ns.errorDefinitions[key]
+	return def, exists
+}
+
+// GetErrorCode retrieves the HTTP status code for a given namespace and error type.
+func (r *ErrorRegistry) GetErrorCode(namespace string, key ErrorType) (int, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	ns, exists := r.namespaces[namespace]
+	if !exists {
+		return 0, false
+	}
+
+	code, exists := ns.errorCodes[key]
+	if !exists {
+		return http.StatusInternalServerError, false
+	}
+	return code, true
+}
+
+// NewError creates a new Error instance.  It formats the error message using the ErrorDefinition and provided arguments.
+func (r *ErrorRegistry) NewError(namespace string, key ErrorType, err error, args ...interface{}) *Error {
+	def, ok := r.GetErrorDefinition(namespace, key)
+	if !ok {
+		// Handle the case where the error type is not registered.  This is important!
+		return &Error{
+			Key:       ErrUnknownErrorKey,
+			Message:   fmt.Sprintf("Unknown error type: %s (namespace: %s)", key, namespace),
+			Err:       err,
+			Namespace: namespace, // Set the namespace here
+		}
+	}
+
+	// Use default arguments if none are provided
+	if len(args) == 0 && len(def.DefaultArgs) > 0 {
+		args = def.DefaultArgs
+	}
+
+	message := def.Message
+	if len(args) > 0 {
+		message = fmt.Sprintf(def.Message, args...) // Format the message
+	}
+
+	return &Error{
+		Key:       key,
+		Message:   message,
+		Err:       err,
+		Args:      args,
+		Namespace: namespace,
+	}
+}
+
+func RegisterNamespace(namespace string) error {
+	errorRegistryMu.Lock()
+	defer errorRegistryMu.Unlock()
+	return errorRegistry.RegisterNamespace(namespace)
+}
+
+func RegisterErrorCodes(namespace string, errorCodeMap map[ErrorType]int) error {
+	errorRegistryMu.Lock()
+	defer errorRegistryMu.Unlock()
+	return errorRegistry.RegisterErrorCodes(namespace, errorCodeMap)
+}
+
+func RegisterDefaultErrorMessages(namespace string, errorMap map[ErrorType]ErrorDefinition) error {
+	errorRegistryMu.Lock()
+	defer errorRegistryMu.Unlock()
+	return errorRegistry.RegisterDefaultErrorMessages(namespace, errorMap)
+}
+
+// MustRegisterNamespace registers a namespace and panics if an error occurs.
+func MustRegisterNamespace(namespace string) {
+	if err := RegisterNamespace(namespace); err != nil {
+		panic(fmt.Sprintf("Failed to register namespace '%s': %v", namespace, err))
+	}
+}
+
+// MustRegisterDefaultErrorMessages registers default error messages and panics if an error occurs.
+func MustRegisterDefaultErrorMessages(namespace string, errorMap map[ErrorType]ErrorDefinition) {
+	if err := RegisterDefaultErrorMessages(namespace, errorMap); err != nil {
+		panic(fmt.Sprintf("Failed to register default error messages for namespace '%s': %v", namespace, err))
+	}
+}
+
+// MustRegisterErrorCodes registers error codes and panics if an error occurs.
+func MustRegisterErrorCodes(namespace string, errorCodeMap map[ErrorType]int) {
+	if err := RegisterErrorCodes(namespace, errorCodeMap); err != nil {
+		panic(fmt.Sprintf("Failed to register error codes for namespace '%s': %v", namespace, err))
+	}
+}
+
+// IsNamespaceError checks if the error is an error of the specified namespace.
+func IsNamespaceError(err error, namespace string) bool {
+	if err == nil {
+		return false
+	}
+
+	namespacedError := AsNamespaceError(err, namespace)
+	return namespacedError != nil
+}
+
+// AsNamespaceError casts the error to a *Error if possible and checks if it belongs to the specified namespace.
+func AsNamespaceError(err error, namespace string) *Error {
+	if err == nil {
+		return nil
+	}
+
+	e, ok := err.(*Error)
+	if !ok {
+		return nil
+	}
+
+	if !e.IsNamespace(namespace) {
+		return nil
+	}
+
+	return e
+}
+
+func ResetErrorRegistry() {
+	errorRegistryMu.Lock()
+	defer errorRegistryMu.Unlock()
+	errorRegistry = NewErrorRegistry()
+}

--- a/service/user.go
+++ b/service/user.go
@@ -194,7 +194,7 @@ func (u UserServiceDefault) CreateAccount(email string, password string, verifyE
 	}
 
 	if err := u.access.AssignRoleToUser(_user.ID, core.ACCESS_USER_ROLE); err != nil {
-		return nil, core.NewAccountError(core.ErrorAssigningUserRoleFailed, err)
+		return nil, core.NewAccountError(core.ErrKeyAssigningUserRoleFailed, err)
 	}
 
 	if err := u.ctx.Fire(event.EVENT_USER_CREATED, event.NewUserCreatedEvent(&_user)); err != nil {


### PR DESCRIPTION
- Replaced AccountError with new Error type that supports namespaces
- Added ErrorRegistry for centralized error management
- Updated account error definitions to use ErrorDefinition struct
- Added ResetErrorRegistry() to core state reset
- Implemented namespace-based error checking utilities
- Maintained backward compatibility with IsAccountError/AsAccountError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized error handling system with support for error namespaces, structured error types, and customizable error messages.
  * Errors now include associated HTTP status codes and can be managed and formatted globally.

* **Refactor**
  * Unified account error handling under the new centralized error registry, removing local error struct definitions and methods.
  * Updated global state reset to also clear the error registry for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->