### PR TITLE
refactor(cron,workflow): set default execution time for once jobs

### DIFF
--- a/service/internal/cron/schedule_registry.go
+++ b/service/internal/cron/schedule_registry.go
@@ -180,7 +180,7 @@ func (r *DefaultScheduleRegistry) createHourlyJob(def core.CronScheduleDefinitio
 
 func (r *DefaultScheduleRegistry) createOnceJob(def core.CronScheduleDefinition) (gocron.JobDefinition, error) {
 	if def.AtTime.IsZero() {
-		return nil, fmt.Errorf("once jobs require an execution time")
+		def.AtTime = time.Now().Add(10 * time.Second)
 	}
 
 	return gocron.OneTimeJob(gocron.OneTimeJobStartDateTime(def.AtTime)), nil

--- a/service/workflow_cron.go
+++ b/service/workflow_cron.go
@@ -20,7 +20,7 @@ func newWorkflowStepExecutorJob() *workflowStepExecutorJob {
 			core.JobOriginCore,
 			workflowStepExecutorJobType,
 			"Workflow Step Executor",
-			nil,
+			core.NewCronScheduleDefinition(core.CronScheduleTypeOnce),
 			nil,
 		),
 	}


### PR DESCRIPTION
- Modify DefaultScheduleRegistry to set a default execution time (now + 10s) when none is provided for once jobs
- Update workflow_cron.go to use CronScheduleTypeOnce for workflow step executor