### PR TITLE
fix(core): use go-base32 for multibase encoding/decoding

### DIFF
--- a/core/internal/core_tests/storage_hash_test.go
+++ b/core/internal/core_tests/storage_hash_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"encoding/base64"
+	b32 "github.com/multiformats/go-base32"
 	"testing"
 
 	mb "github.com/multiformats/go-multibase"
@@ -232,25 +233,25 @@ func TestParseStorageHash_Base32(t *testing.T) {
 		{
 			name: "Multibase Base32",
 			encodeFn: func(b []byte) string {
-				return string(mb.Base32) + base32.StdEncoding.EncodeToString(b)
+				return string(mb.Base32) + b32.RawStdEncoding.EncodeToString(b)
 			},
 		},
 		{
 			name: "Multibase Base32 Upper",
 			encodeFn: func(b []byte) string {
-				return string(mb.Base32Upper) + base32.StdEncoding.EncodeToString(b)
+				return string(mb.Base32Upper) + b32.RawStdEncoding.EncodeToString(b)
 			},
 		},
 		{
 			name: "Multibase Base32 Pad",
 			encodeFn: func(b []byte) string {
-				return string(mb.Base32pad) + base32.StdEncoding.EncodeToString(b)
+				return string(mb.Base32pad) + b32.StdEncoding.EncodeToString(b)
 			},
 		},
 		{
 			name: "Multibase Base32 Pad Upper",
 			encodeFn: func(b []byte) string {
-				return string(mb.Base32padUpper) + base32.StdEncoding.EncodeToString(b)
+				return string(mb.Base32padUpper) + b32.StdEncoding.EncodeToString(b)
 			},
 		},
 	}

--- a/core/storage_hash.go
+++ b/core/storage_hash.go
@@ -375,7 +375,13 @@ func (p *CoreBase32Parser) TryParse(s string) (StorageHash, bool, error) {
 	var decodeErr error
 
 	switch enc {
-	case multibase.Base32, multibase.Base32Upper, multibase.Base32pad, multibase.Base32padUpper:
+	case multibase.Base32, multibase.Base32Upper:
+		// Decode with multibase prefix
+		decodedBytes, decodeErr = b32.RawStdEncoding.DecodeString(s[1:])
+		if decodeErr != nil {
+			return nil, true, fmt.Errorf("failed to decode multibase Base32 string: %w", decodeErr)
+		}
+	case multibase.Base32pad, multibase.Base32padUpper:
 		// Decode with multibase prefix
 		decodedBytes, decodeErr = b32.StdEncoding.DecodeString(s[1:])
 		if decodeErr != nil {


### PR DESCRIPTION
- Replace standard base32 encoding with go-base32's RawStdEncoding for Base32/Base32Upper
- Maintain StdEncoding for padded variants (Base32pad/Base32padUpper)
- Update tests to reflect new encoding approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Base32 decoding logic for multibase-encoded strings to better handle variants with and without padding, ensuring more accurate parsing and error handling.

* **Tests**
  * Updated tests to use a more robust Base32 encoding library for multibase Base32 variants, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->