### PR TITLE
refactor(testing): add boot complete event control options

### DIFF
--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -304,6 +304,7 @@ func RunTestCase(t TB, testFunc func(tb TB, ctx TestContext), opts ...TestContex
 	// Phase 1: Registration
 	// Add test case specific options
 	if len(opts) > 0 {
+		AddTestCaseContextOptions(WithFireBootComplete(false))
 		AddTestCaseContextOptions(opts...)
 	}
 
@@ -1289,6 +1290,7 @@ func DefaultTestContextOptions(tb TB) []TestContextBuilderOption {
 		WithMockTUSService(),
 		WithMockUserService(),
 		WithMockWorkflowService(),
+		WithFireBootComplete(true),
 	)
 
 	return opts
@@ -2097,14 +2099,10 @@ func ConfigureAPIRoutes(ctx TestContext) error {
 	return nil
 }
 
-// BootEnvironment creates and initializes a TestContext with common services and configurations.
-// It handles resetting state, creating the context, applying options, and booting the environment.
-// This function is called internally by RunTestCase and RunTestCaseWithDB.
-// WithNoFireBootCompleteEvent disables automatic firing of boot complete event
-func WithNoFireBootCompleteEvent() TestContextBuilderOption {
+func WithFireBootComplete(fire bool) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
 		if tctx, ok := ctx.(*testContext); ok {
-			tctx.SetFireBootComplete(false)
+			tctx.SetFireBootComplete(fire)
 		}
 		return ctx, nil
 	}


### PR DESCRIPTION
- Added `WithFireBootComplete` option to explicitly control boot complete event firing
- Updated default test context options to fire boot complete event by default
- Modified test case execution to disable boot complete event during registration phase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to control whether the boot complete event is fired during test environment initialization, allowing for more flexible test setup.

* **Refactor**
  * Replaced the previous option for disabling the boot complete event with a more general option that can both enable and disable the event. 
  * Default behavior now explicitly enables the boot complete event unless overridden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->