### PR TITLE
refactor(testing): use core.Fire to preserve type information

### DIFF
--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -2158,7 +2158,7 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 
 	// Fire boot complete event if enabled
 	if tctx, ok := ctx.(*testContext); ok && tctx.FireBootComplete() {
-		if err := ctx.Fire(pevent.EVENT_BOOT_COMPLETE, pevent.NewBootCompleteEvent(ctx)); err != nil {
+		if err := core.Fire(ctx, pevent.EVENT_BOOT_COMPLETE, pevent.NewBootCompleteEvent(ctx)); err != nil {
 			return fmt.Errorf("failed to fire boot complete event: %w", err)
 		}
 	}


### PR DESCRIPTION
- Fixes type info loss from direct ctx.Fire calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal process for firing the "boot complete" event during test environment boot. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->