### PR TITLE
refactor(testing): replace mock config with concrete implementation

### DIFF
--- a/core/testing/mock_config.go
+++ b/core/testing/mock_config.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"context"
 	"fmt"
+	z "github.com/Oudwins/zog"
 	"os"
 	"reflect"
 	"strconv"
@@ -26,6 +27,20 @@ const (
 )
 
 const mapStructureTag = "config"
+
+var _ config.Defaults = (*mockConfigEntry)(nil)
+var _ config.ConfigSchemaProvider = (*mockConfigEntry)(nil)
+
+type mockConfigEntry struct {
+}
+
+func (c mockConfigEntry) Schema() z.ZogSchema {
+	return nil
+}
+
+func (c mockConfigEntry) Defaults() map[string]any {
+	return make(map[string]any)
+}
 
 // MockConfigManager implements config.Manager for testing
 // It builds on top of the mockery-generated mock and adds state tracking

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -1192,13 +1192,12 @@ func WithAPIExtension(extFactory core.APIExtensionFactory) TestContextBuilderOpt
 		// Create mock API for the target
 		mockAPI := coreMocks.NewMockAPI(tb)
 
-		cfg := config.NewMockDefaults(ctx.T())
-		cfg.EXPECT().Defaults().Maybe()
+		cfg := &mockConfigEntry{}
 
 		// Configure basic mock API expectations
 		mockAPI.On("Name").Return(targetAPI).Maybe()
 		mockAPI.On("Subdomain").Return(targetAPI).Maybe()
-		mockAPI.On("AuthTokenName").Return(targetAPI + "_token").Maybe()
+		mockAPI.On("AuthTokenName").Return(core.AUTH_TOKEN_NAME).Maybe()
 		mockAPI.On("Config").Return(cfg).Maybe()
 		mockAPI.On("OpenAPIInfo").Return(router.APIInfo()).Maybe()
 		mockAPI.On("Configure", mock.Anything, mock.Anything).Return(nil).Maybe()


### PR DESCRIPTION
- Add mockConfigEntry struct implementing config.Defaults and ConfigSchemaProvider
- Replace mock config usage in testing.go with new mockConfigEntry
- Update auth token name to use core.AUTH_TOKEN_NAME constant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup by introducing a minimal mock configuration for use in test scenarios.
  * Standardized the authentication token name in test mocks for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->