### PR TITLE
refactor(testing): add mock plugin builder and cleanup unused code

### DIFF
--- a/core/plugin.go
+++ b/core/plugin.go
@@ -103,26 +103,6 @@ func GetProtocol(id string) Protocol {
 	return protocol
 }
 
-/*func UninstallPlugin(name string) error {
-	pluginsMu.Lock()
-	defer pluginsMu.Unlock()
-
-	if _, exists := plugins[name]; !exists {
-		return fmt.Errorf("plugin %s not found", name)
-	}
-
-	// Clean up plugin jobs first
-	ctx := GetContext() // Get global context
-	if cron := GetService[CronService](ctx, CRON_SERVICE); cron != nil {
-		if _, err := cron.CleanupOrphanedJobs(); err != nil {
-			return fmt.Errorf("failed to clean up plugin jobs: %w", err)
-		}
-	}
-
-	delete(plugins, name)
-	return nil
-}*/
-
 func ProtocolExists(id string) bool {
 	protocolsMu.RLock()
 	defer protocolsMu.RUnlock()

--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -1,0 +1,112 @@
+package testing
+
+import (
+	"go.lumeweb.com/portal/build"
+	"go.lumeweb.com/portal/core"
+)
+
+// MockPluginBuilder is a builder for creating PluginInfo structs for testing.
+type MockPluginBuilder struct {
+	plugin core.PluginInfo
+}
+
+// NewMockPluginBuilder creates a new MockPluginBuilder with a default ID.
+func NewMockPluginBuilder(id string) *MockPluginBuilder {
+	return &MockPluginBuilder{
+		plugin: core.PluginInfo{
+			ID:      id,
+			Version: build.New("", "", "", "", "", "", ""),
+		},
+	}
+}
+
+// WithVersion sets the version of the plugin.
+func (b *MockPluginBuilder) WithVersion(version string) *MockPluginBuilder {
+	b.plugin.Version = build.New(version, "", "", "", "", "", "")
+	return b
+}
+
+// WithMeta sets the MetaFactory of the plugin.
+func (b *MockPluginBuilder) WithMeta(meta core.MetaFactory) *MockPluginBuilder {
+	b.plugin.Meta = meta
+	return b
+}
+
+// WithAPI sets the APIFactory of the plugin.
+func (b *MockPluginBuilder) WithAPI(api core.APIFactory) *MockPluginBuilder {
+	b.plugin.API = api
+	return b
+}
+
+// WithProtocol sets the ProtocolFactory of the plugin.
+func (b *MockPluginBuilder) WithProtocol(protocol core.ProtocolFactory) *MockPluginBuilder {
+	b.plugin.Protocol = protocol
+	return b
+}
+
+// WithServices sets the ServicesFactory of the plugin.
+func (b *MockPluginBuilder) WithServices(services core.ServicesFactory) *MockPluginBuilder {
+	b.plugin.Services = services
+	return b
+}
+
+// WithAPIExtensions sets the APIExtensionsFactory of the plugin.
+func (b *MockPluginBuilder) WithAPIExtensions(extensions core.APIExtensionsFactory) *MockPluginBuilder {
+	b.plugin.APIExtensions = extensions
+	return b
+}
+
+// WithModels sets the Models of the plugin.
+func (b *MockPluginBuilder) WithModels(models []any) *MockPluginBuilder {
+	b.plugin.Models = models
+	return b
+}
+
+// WithMigrations sets the Migrations of the plugin.
+func (b *MockPluginBuilder) WithMigrations(migrations core.DBMigration) *MockPluginBuilder {
+	b.plugin.Migrations = migrations
+	return b
+}
+
+// WithDepends sets the Depends of the plugin.
+func (b *MockPluginBuilder) WithDepends(depends []string) *MockPluginBuilder {
+	b.plugin.Depends = depends
+	return b
+}
+
+// WithCronJobs sets the CronJobs of the plugin.
+func (b *MockPluginBuilder) WithCronJobs(cronJobs []core.PluginCronJob) *MockPluginBuilder {
+	b.plugin.CronJobs = cronJobs
+	return b
+}
+
+// WithMailerTemplates sets the MailerTemplates of the plugin.
+func (b *MockPluginBuilder) WithMailerTemplates(mailerTemplates core.MailerTemplates) *MockPluginBuilder {
+	b.plugin.MailerTemplates = mailerTemplates
+	return b
+}
+
+// WithWebBundles sets the WebBundles of the plugin.
+func (b *MockPluginBuilder) WithWebBundles(webBundles []*core.WebBundle) *MockPluginBuilder {
+	b.plugin.WebBundles = webBundles
+	return b
+}
+
+// WithTargetApps sets the TargetApps of the plugin.
+func (b *MockPluginBuilder) WithTargetApps(targetApps []string) *MockPluginBuilder {
+	b.plugin.TargetApps = targetApps
+	return b
+}
+
+// Build returns the constructed PluginInfo.
+func (b *MockPluginBuilder) Build() core.PluginInfo {
+	return b.plugin
+}
+
+// PluginOption returns a ContextBuilderOption that registers the built plugin.
+func (b *MockPluginBuilder) BuilderOption() core.ContextBuilderOption {
+	return func(ctx core.Context) (core.Context, error) {
+		core.RegisterPlugin(b.plugin)
+		return ctx, nil
+	}
+}

--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -2133,6 +2133,8 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 		return fmt.Errorf("API configuration failed: %w", err)
 	}
 
+	core.RegisterServicesFromPlugins()
+
 	if err := ConfigureServices(ctx); err != nil {
 		return fmt.Errorf("service configuration failed: %w", err)
 	}


### PR DESCRIPTION
- Added new MockPluginBuilder in core/testing/mock_plugin.go for easier test plugin creation
- Removed commented-out UninstallPlugin function from core/plugin.go
- Added service registration call in BootEnvironment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a builder tool to simplify the creation of plugins for testing purposes.

* **Chores**
  * Enhanced the test environment setup to ensure plugin-provided services are registered during testing.

* **Refactor**
  * Removed obsolete, commented-out code related to plugin uninstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->