### PR TITLE
refactor(testing): change MockPluginBuilder methods to return builder instance and use TestContext

### DIFF
--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -103,7 +103,7 @@ func (b *MockPluginBuilder) WithTargetApps(targetApps ...string) *MockPluginBuil
 }
 
 // Build returns the constructed PluginInfo.
-func (b *MockPluginBuilder) Build() core.PluginInfo {
+func (b *MockPluginBuilder) Build() *MockPluginBuilder {
 	if len(b.extensions) > 0 {
 		b.plugin.APIExtensions = func(context core.Context) ([]core.APIExtensionFactory, error) {
 			return b.extensions, nil
@@ -116,12 +116,12 @@ func (b *MockPluginBuilder) Build() core.PluginInfo {
 		}
 	}
 
-	return b.plugin
+	return b
 }
 
 // PluginOption returns a ContextBuilderOption that registers the built plugin.
-func (b *MockPluginBuilder) BuilderOption() core.ContextBuilderOption {
-	return func(ctx core.Context) (core.Context, error) {
+func (b *MockPluginBuilder) BuilderOption() TestContextBuilderOption {
+	return func(ctx TestContext) (TestContext, error) {
 		core.RegisterPlugin(b.plugin)
 		return ctx, nil
 	}


### PR DESCRIPTION
- Modify Build() to return *MockPluginBuilder instead of PluginInfo
- Change BuilderOption() to use TestContext instead of core.Context
- Allows method chaining and better test context typing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the plugin builder's API to improve usability and support further chaining or inspection during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->