### PR TITLE
fix(testing): ensure ConfigurePluginServices runs before ProcessStartupFuncs

### DIFF
--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -2156,13 +2156,13 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 
 	core.RegisterServicesFromPlugins()
 
+	if err = ConfigurePluginServices(ctx); err != nil {
+		return fmt.Errorf("service configuration failed: %w", err)
+	}
+
 	// Process startup functions (DB connection, etc)
 	if err = ProcessStartupFuncs(ctx); err != nil {
 		return fmt.Errorf("startup functions failed: %w", err)
-	}
-
-	if err = ConfigurePluginServices(ctx); err != nil {
-		return fmt.Errorf("service configuration failed: %w", err)
 	}
 
 	// Phase 2: Configuration


### PR DESCRIPTION
- Fixes potential issue where plugin services could miss startup registration
- Moves ConfigurePluginServices before ProcessStartupFuncs to ensure proper initialization order