### PR TITLE
fix(testing): bypass service dependency checks in ConfigurePluginServices

### DIFF
--- a/core/testing/testing.go
+++ b/core/testing/testing.go
@@ -2068,7 +2068,7 @@ func ConfigureServices(ctx TestContext) error {
 //   - Modifies the test context by applying service-specific context options
 //   - Services are registered both in the test context and globally via core.RegisterService
 func ConfigurePluginServices(ctx TestContext) error {
-	for _, svcInfo := range core.GetServices() {
+	for _, svcInfo := range core.Unsafe_GetServiceMap() {
 		if core.GetPluginForService(svcInfo.ID) != "" {
 			serviceInstance, ctxOpts, err := svcInfo.Factory()
 			if err != nil {


### PR DESCRIPTION
- Uses Unsafe_GetServiceMap() instead of GetServices() to avoid dependency validation
- Needed because GetServices() fails if any service has invalid dependencies
- Maintains existing plugin service registration behavior while being more permissive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the method for retrieving plugin services during test configuration to improve internal handling. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->