### PR TITLE
refactor(tus): add slog bridge for version compatibility

### DIFF
--- a/service/internal/tus/slog_bridge.go
+++ b/service/internal/tus/slog_bridge.go
@@ -1,0 +1,97 @@
+package tus
+
+import (
+	"context"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap/exp/zapslog"
+	"golang.org/x/exp/slog"
+	newSlog "log/slog"
+)
+
+// SlogBridge bridges between the old and new slog versions
+type SlogBridge struct {
+	logger *newSlog.Logger // new slog.Logger
+}
+
+// NewSlogBridge creates a new bridge between slog versions
+func NewSlogBridge(logger *core.Logger) *SlogBridge {
+	// Convert zap logger to new slog.Logger
+	newSlogger := newSlog.New(zapslog.NewHandler(logger.Core()))
+	return &SlogBridge{
+		logger: newSlogger,
+	}
+}
+
+// Handler returns a handler compatible with the old slog version
+func (b *SlogBridge) Handler() slog.Handler {
+	return &handlerBridge{newHandler: b.logger.Handler()}
+}
+
+func convertAttr(attr slog.Attr) newSlog.Attr {
+	switch attr.Value.Kind() {
+	case slog.KindBool:
+		return newSlog.Bool(attr.Key, attr.Value.Bool())
+	case slog.KindDuration:
+		return newSlog.Duration(attr.Key, attr.Value.Duration())
+	case slog.KindFloat64:
+		return newSlog.Float64(attr.Key, attr.Value.Float64())
+	case slog.KindInt64:
+		return newSlog.Int64(attr.Key, attr.Value.Int64())
+	case slog.KindString:
+		return newSlog.String(attr.Key, attr.Value.String())
+	case slog.KindTime:
+		return newSlog.Time(attr.Key, attr.Value.Time())
+	case slog.KindUint64:
+		return newSlog.Uint64(attr.Key, attr.Value.Uint64())
+	case slog.KindGroup:
+		group := attr.Value.Group()
+		attrs := make([]any, len(group))
+		for i, a := range group {
+			attrs[i] = convertAttr(a)
+		}
+		return newSlog.Group(attr.Key, attrs...)
+	case slog.KindLogValuer:
+		return convertAttr(slog.Attr{
+			Key:   attr.Key,
+			Value: attr.Value.Resolve(),
+		})
+	default:
+		return newSlog.Any(attr.Key, attr.Value.Any())
+	}
+}
+
+// handlerBridge implements the old slog.Handler interface using the new slog.Handler
+type handlerBridge struct {
+	newHandler newSlog.Handler
+}
+
+func (h *handlerBridge) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.newHandler.Enabled(ctx, newSlog.Level(level))
+}
+
+func (h *handlerBridge) Handle(ctx context.Context, r slog.Record) error {
+	// Convert old Record to new Record
+	newRecord := newSlog.NewRecord(
+		r.Time,
+		newSlog.Level(r.Level),
+		r.Message,
+		r.PC,
+	)
+	r.Attrs(func(attr slog.Attr) bool {
+		newRecord.Add(convertAttr(attr))
+		return true
+	})
+	return h.newHandler.Handle(ctx, newRecord)
+}
+
+func (h *handlerBridge) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newAttrs := make([]newSlog.Attr, len(attrs))
+	for i, attr := range attrs {
+		newAttrs[i] = convertAttr(attr)
+	}
+	return &handlerBridge{newHandler: h.newHandler.WithAttrs(newAttrs)}
+}
+
+func (h *handlerBridge) WithGroup(name string) slog.Handler {
+	return &handlerBridge{newHandler: h.newHandler.WithGroup(name)}
+}

--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -15,10 +15,9 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 	"go.uber.org/zap"
-	"go.uber.org/zap/exp/zapslog"
+	"golang.org/x/exp/slog"
 	"gorm.io/gorm"
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 )
@@ -539,7 +538,14 @@ func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUplo
 	}
 }
 func loggerToSlog(logger *core.Logger) *slog.Logger {
-	return slog.New(zapslog.NewHandler(logger.Core()))
+	// Create a bridge
+	bridge := NewSlogBridge(logger)
+
+	// Create a handler that wraps the new slog handler but presents the old interface
+	oldHandler := bridge.Handler()
+
+	// Create an old-style logger with this handler
+	return slog.New(oldHandler)
 }
 
 func splitIds(id string) (objectId, multipartId string) {


### PR DESCRIPTION
- Introduced SlogBridge to handle conversion between old and new slog versions
- Updated loggerToSlog function to use new bridge implementation
- Removed direct zapslog dependency in favor of bridge pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced compatibility for logging by bridging between different versions of the slog logging library.

* **Refactor**
  * Updated internal logging integration to use a new bridge, improving interoperability with the latest slog logging interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->