### PR TITLE
refactor(config): reorganize constants and improve plugin config file handling

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -4,12 +4,6 @@ const (
 	//
 	ENV_PREFIX    = "PORTAL__"
 	ENV_SEPARATOR = "__"
-
-	// Configuration keys and flags
-	CLUSTER_CONFIG_KEY = "config"
-	FLAG_SYNC          = "sync"
-	FLAG_VOLATILE      = "volatile"
-
 	// File extensions and names
 	CONFIG_EXTENSION  = ".yaml"
 	CoreConfigFile    = "core" + CONFIG_EXTENSION
@@ -22,13 +16,9 @@ const (
 	APIDir     = "api.d"
 
 	// Section specifiers
-	PluginSpecifier         = "plugin.%s"
-	ProtocolSpecifier       = "plugin.%s.protocol" 
-	APISpecifier           = "plugin.%s.api"
-	ServiceSpecifier       = "plugin.%s.service.%s"
-
-	// Struct tags
-	mapStructureTag = "config"
+	ProtocolSpecifier = "plugin.%s.protocol"
+	APISpecifier      = "plugin.%s.api"
+	ServiceSpecifier  = "plugin.%s.service.%s"
 )
 
 var (
@@ -39,7 +29,7 @@ var (
 func getDefaultConfigPaths() []string {
 	return []string{
 		"/etc/lumeweb/portal",
-		"$HOME/.lumeweb/portal", 
+		"$HOME/.lumeweb/portal",
 		"./portal.yaml",
 		"./",
 	}

--- a/config/manager.go
+++ b/config/manager.go
@@ -344,21 +344,40 @@ func (m *ManagerDefault) Config() *Config {
 	return cfg
 }
 
+func (m *ManagerDefault) getPluginConfigFile(pluginName, subDir string, configType string) (string, error) {
+	filePath := filepath.Join(m.configDir, PluginsDir, pluginName, subDir, SectionConfigFile)
+	configFile, err := findConfigFile(findConfigFileOptions{
+		Paths:           []string{filePath},
+		CreateIfMissing: true,
+		CheckWritable:   true,
+		fs:              m.fs,
+	}, m)
+	if err != nil {
+		return "", fmt.Errorf("failed to find/create config file for %s '%s': %w", configType, pluginName, err)
+	}
+	return configFile, nil
+}
+
 func (m *ManagerDefault) ConfigureProtocol(pluginName string, cfg ProtocolConfig) error {
 	if cfg == nil {
 		return nil
 	}
 
+	pluginName = strings.ToLower(pluginName)
 	key := fmt.Sprintf(ProtocolSpecifier, pluginName)
-	filePath := filepath.Join(m.configDir, PluginsDir, ProtoDir, pluginName+CONFIG_EXTENSION)
 
 	// Register the protocol config struct
 	if err := m.Manager.RegisterStruct(key, cfg); err != nil {
 		return fmt.Errorf("failed to register protocol config: %w", err)
 	}
 
+	configFile, err := m.getPluginConfigFile(pluginName, ProtoDir, "Protocol")
+	if err != nil {
+		return err
+	}
+
 	// Register namespace for this protocol
-	fsSource := source.NewFileSource(filePath)
+	fsSource := source.NewFileSource(configFile)
 	m.Manager.RegisterNamespace(key, fsSource)
 	m.Manager.RegisterSource(fsSource)
 
@@ -375,16 +394,21 @@ func (m *ManagerDefault) ConfigureAPI(pluginName string, cfg APIConfig) error {
 		return nil
 	}
 
+	pluginName = strings.ToLower(pluginName)
 	key := fmt.Sprintf(APISpecifier, pluginName)
-	filePath := filepath.Join(m.configDir, PluginsDir, APIDir, pluginName+CONFIG_EXTENSION)
 
 	// Register the API config struct
 	if err := m.Manager.RegisterStruct(key, cfg); err != nil {
 		return fmt.Errorf("failed to register API config: %w", err)
 	}
 
+	configFile, err := m.getPluginConfigFile(pluginName, APIDir, "API")
+	if err != nil {
+		return err
+	}
+
 	// Register namespace for this API
-	fsSource := source.NewFileSource(filePath)
+	fsSource := source.NewFileSource(configFile)
 	m.Manager.RegisterNamespace(key, fsSource)
 	m.Manager.RegisterSource(fsSource)
 
@@ -401,16 +425,27 @@ func (m *ManagerDefault) ConfigureService(pluginName string, serviceName string,
 		return nil
 	}
 
+	pluginName = strings.ToLower(pluginName)
 	key := fmt.Sprintf(ServiceSpecifier, pluginName, serviceName)
-	filePath := filepath.Join(m.configDir, PluginsDir, ServiceDir, pluginName+"_"+serviceName+CONFIG_EXTENSION)
+	filePath := filepath.Join(m.configDir, PluginsDir, pluginName, ServiceDir, serviceName+CONFIG_EXTENSION)
 
 	// Register the service config struct
 	if err := m.Manager.RegisterStruct(key, cfg); err != nil {
 		return fmt.Errorf("failed to register service config: %w", err)
 	}
 
+	configFile, err := findConfigFile(findConfigFileOptions{
+		Paths:           []string{filePath},
+		CreateIfMissing: true,
+		CheckWritable:   true,
+		fs:              m.fs,
+	}, m)
+	if err != nil {
+		return fmt.Errorf("failed to find/create config file for Service '%s/%s': %w", pluginName, serviceName, err)
+	}
+
 	// Register namespace for this service
-	fsSource := source.NewFileSource(filePath)
+	fsSource := source.NewFileSource(configFile)
 	m.Manager.RegisterNamespace(key, fsSource)
 	m.Manager.RegisterSource(fsSource)
 
@@ -426,6 +461,7 @@ func (m *ManagerDefault) ConfigureService(pluginName string, serviceName string,
 }
 
 func (m *ManagerDefault) GetService(pluginName string, serviceName string) ServiceConfig {
+	pluginName = strings.ToLower(pluginName)
 	key := fmt.Sprintf(ServiceSpecifier, pluginName, serviceName)
 
 	_, cfg, err := m.Manager.Get(key)


### PR DESCRIPTION
- Removed unused constants (CLUSTER_CONFIG_KEY, FLAG_SYNC, FLAG_VOLATILE, PluginSpecifier, mapStructureTag)
- Standardized plugin name case handling by converting to lowercase
- Added helper method `getPluginConfigFile` for consistent config file path resolution
- Updated service config paths to use plugin-specific subdirectories