### PR TITLE
refactor(http, testing): simplify web bundle caching and improve manifest handling

### DIFF
--- a/service/content_scan_integration_test.go
+++ b/service/content_scan_integration_test.go
@@ -195,3 +195,7 @@ func (s *testStorageHash) Type() uint64 {
 func (s *testStorageHash) String() string {
 	return string(s.hash)
 }
+
+func (s *testStorageHash) Bytes() []byte {
+	return s.hash
+}

--- a/service/cron_integration_test.go
+++ b/service/cron_integration_test.go
@@ -69,7 +69,7 @@ func TestCronServiceDefault_RegisterJob_Integration(t *testing.T) {
 		testJob := newSimpleTestJob(core.JobOriginCore, integrationTestJobSourceId, &core.CronScheduleDefinition{Type: core.CronScheduleTypeDaily}, nil)
 
 		// Register the job
-		err := cronService.RegisterJob(testJob)
+		err := cronService.RegisterJob(testJob, nil)
 		require.NoError(t, err)
 
 		// Verify that the job was created in the database
@@ -118,7 +118,7 @@ func TestCronServiceDefault_RunJob_Integration(t *testing.T) {
 		job, err := cronService.JobFactory().CreateJob(integrationTestJobType)
 		require.NoError(t, err)
 
-		err = cronService.RegisterJob(job)
+		err = cronService.RegisterJob(job, nil)
 		require.NoError(t, err)
 
 		// Start the cron service
@@ -267,7 +267,7 @@ func TestCronServiceDefault_StateMachine_Integration(t *testing.T) {
 		testJob := newSimpleTestJob(core.JobOriginCore, integrationTestJobSourceId, &core.CronScheduleDefinition{Type: core.CronScheduleTypeDaily}, nil)
 
 		// Register the job
-		err := cronService.RegisterJob(testJob)
+		err := cronService.RegisterJob(testJob, nil)
 		require.NoError(t, err)
 
 		// Get the state machine

--- a/service/cron_test.go
+++ b/service/cron_test.go
@@ -50,7 +50,7 @@ func TestCronServiceDefault_RegisterJob(t *testing.T) {
 		cronService.coordinator = mockCoordinator
 
 		// Register the job
-		err := cronService.RegisterJob(mockJob)
+		err := cronService.RegisterJob(mockJob, nil)
 		require.NoError(t, err)
 
 		// Verify that the job was created in the database
@@ -84,7 +84,7 @@ func TestCronServiceDefault_RegisterJob_InvalidOrigin(t *testing.T) {
 		mockJob.EXPECT().Origin().Return("invalid-origin")
 
 		// Register the job
-		err := cronService.RegisterJob(mockJob)
+		err := cronService.RegisterJob(mockJob, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid job origin")
 	})

--- a/service/http.go
+++ b/service/http.go
@@ -311,27 +311,13 @@ func (h *HTTPServiceDefault) apiMetaHandler(e echo.Context) error {
 		}
 	}
 
-	ctx.Encode(metaBuilder.Build())
+	_ = ctx.Encode(metaBuilder.Build())
 
 	return nil
 }
 
 func (h *HTTPServiceDefault) generateWebBundleURI(pluginID string, bundleIndex int) string {
 	return fmt.Sprintf(webBundleBasePath, pluginID, strconv.Itoa(bundleIndex))
-}
-
-// getCachedManifest retrieves a cached manifest if it exists
-func (h *HTTPServiceDefault) getCachedManifest(key string) (*web_manifest.Manifest, bool) {
-	cached, ok := h.bundleCache.Load(key)
-	if !ok {
-		return nil, false
-	}
-	return cached.(*web_manifest.Manifest), true
-}
-
-// storeCachedManifest stores a manifest in the cache
-func (h *HTTPServiceDefault) storeCachedManifest(key string, manifest *web_manifest.Manifest) {
-	h.bundleCache.Store(key, manifest)
 }
 
 // getOrCreateBundleFilesystem atomically gets or creates a cached filesystem
@@ -359,12 +345,6 @@ func (h *HTTPServiceDefault) getWebBundleManifestName(pluginID string, bundleInd
 }
 
 func (h *HTTPServiceDefault) getProcessedManifest(plugin *core.PluginInfo, bundle *core.WebBundle, index int) (*web_manifest.Manifest, error) {
-	// Check cache first
-	cacheKey := fmt.Sprintf("%s-%d", plugin.ID, index)
-	if manifest, ok := h.getCachedManifest(cacheKey); ok {
-		return manifest, nil
-	}
-
 	// Get or create cached filesystem
 	fs := h.getOrCreateBundleFilesystem(plugin.ID, index, bundle)
 
@@ -375,7 +355,6 @@ func (h *HTTPServiceDefault) getProcessedManifest(plugin *core.PluginInfo, bundl
 	defer file.Close()
 
 	manifestData, err := io.ReadAll(file)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to read manifest: %w", err)
 	}
@@ -388,9 +367,6 @@ func (h *HTTPServiceDefault) getProcessedManifest(plugin *core.PluginInfo, bundl
 	// Update public path
 	baseURL := fmt.Sprintf(webBundleBasePath, plugin.ID, strconv.Itoa(index))
 	manifest.MetaData.PublicPath = baseURL
-
-	// Cache the processed manifest
-	h.storeCachedManifest(cacheKey, &manifest)
 
 	return &manifest, nil
 }

--- a/service/http_integration_test.go
+++ b/service/http_integration_test.go
@@ -2,13 +2,17 @@ package service
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.lumeweb.com/portal/core/web_manifest"
+	"go.lumeweb.com/portal/service/internal/http/testdata/embed_bundle"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -96,6 +100,118 @@ func TestHTTPService_apiPluginWebBundleFileServerHandler_Integration(t *testing.
 
 		// Test with non-existent file
 		req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/meta/plugin/%s/bundle/0/missing.html", pluginID), nil)
+		rec = httptest.NewRecorder()
+		httpService.Router().ServeHTTP(rec, req)
+		assert.Equal(tb, http.StatusNotFound, rec.Code)
+
+	}, coreTesting.WithServiceFactory(core.HTTP_SERVICE, NewHTTPService), coreTesting.WithAPIID(""))
+}
+
+func TestHTTPService_apiPluginWebBundleFileServerHandler_ServeManifest_Integration(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		httpService := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE)
+		require.NotNil(tb, httpService)
+
+		// 1. Create a test plugin with a web bundle
+		pluginID := "testplugin"
+		var manifest web_manifest.Manifest
+		manifest.MetaData.PublicPath = "/api/meta/plugin/testplugin/bundle/0/"
+		bundleContentBytes, err := json.Marshal(&manifest)
+		require.NoError(t, err)
+		bundleContent := string(bundleContentBytes)
+
+		pluginInfo := core.PluginInfo{
+			ID: pluginID,
+			WebBundles: []*core.WebBundle{
+				core.NewWebBundle(
+					testWebBundleFS,
+					core.WithWebBundlePrefix("internal/http/testdata/web_bundle"),
+				),
+			},
+		}
+		core.RegisterPlugin(pluginInfo)
+
+		// 2. Create a test request
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/meta/plugin/%s/bundle/0/mf-manifest.json", pluginID), nil)
+		rec := httptest.NewRecorder()
+
+		// 3. Serve the request through the router
+		httpService.Router().ServeHTTP(rec, req)
+
+		// 4. Assertions
+		assert.Equal(tb, http.StatusOK, rec.Code)
+		assert.Equal(tb, bundleContent, strings.Trim(rec.Body.String(), "\n"))
+		assert.Equal(tb, "public, max-age=3600", rec.Header().Get("Cache-Control"))
+
+		// Test with non-existent plugin
+		req = httptest.NewRequest(http.MethodGet, "/api/meta/plugin/nonexistent/bundle/0/mf-manifest.json", nil)
+		rec = httptest.NewRecorder()
+		httpService.Router().ServeHTTP(rec, req)
+		assert.Equal(tb, http.StatusNotFound, rec.Code)
+
+		// Test with invalid bundle ID
+		req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/meta/plugin/%s/bundle/invalid/mf-manifest.json", pluginID), nil)
+		rec = httptest.NewRecorder()
+		httpService.Router().ServeHTTP(rec, req)
+		assert.Equal(tb, http.StatusBadRequest, rec.Code)
+
+		// Test with non-existent file
+		req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/meta/plugin/%s/bundle/0/mf-manifest1.json", pluginID), nil)
+		rec = httptest.NewRecorder()
+		httpService.Router().ServeHTTP(rec, req)
+		assert.Equal(tb, http.StatusNotFound, rec.Code)
+
+	}, coreTesting.WithServiceFactory(core.HTTP_SERVICE, NewHTTPService), coreTesting.WithAPIID(""))
+}
+
+func TestHTTPService_apiPluginWebBundleFileServerHandler_ServeManifest_EmbedBundle_Integration(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		httpService := core.GetService[core.HTTPService](ctx, core.HTTP_SERVICE)
+		require.NotNil(tb, httpService)
+
+		// 1. Create a test plugin with a web bundle
+		pluginID := "testplugin"
+		var manifest web_manifest.Manifest
+		manifest.MetaData.PublicPath = "/api/meta/plugin/testplugin/bundle/0/"
+		bundleContentBytes, err := json.Marshal(&manifest)
+		require.NoError(t, err)
+		bundleContent := string(bundleContentBytes)
+		pluginInfo := core.PluginInfo{
+			ID: pluginID,
+			WebBundles: []*core.WebBundle{
+				core.NewWebBundle(
+					embed_bundle.GetFS(),
+				),
+			},
+		}
+		core.RegisterPlugin(pluginInfo)
+
+		// 2. Create a test request
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/meta/plugin/%s/bundle/0/mf-manifest.json", pluginID), nil)
+		rec := httptest.NewRecorder()
+
+		// 3. Serve the request through the router
+		httpService.Router().ServeHTTP(rec, req)
+
+		// 4. Assertions
+		assert.Equal(tb, http.StatusOK, rec.Code)
+		assert.Equal(tb, bundleContent, strings.Trim(rec.Body.String(), "\n"))
+		assert.Equal(tb, "public, max-age=3600", rec.Header().Get("Cache-Control"))
+
+		// Test with non-existent plugin
+		req = httptest.NewRequest(http.MethodGet, "/api/meta/plugin/nonexistent/bundle/0/mf-manifest.json", nil)
+		rec = httptest.NewRecorder()
+		httpService.Router().ServeHTTP(rec, req)
+		assert.Equal(tb, http.StatusNotFound, rec.Code)
+
+		// Test with invalid bundle ID
+		req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/meta/plugin/%s/bundle/invalid/mf-manifest.json", pluginID), nil)
+		rec = httptest.NewRecorder()
+		httpService.Router().ServeHTTP(rec, req)
+		assert.Equal(tb, http.StatusBadRequest, rec.Code)
+
+		// Test with non-existent file
+		req = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/meta/plugin/%s/bundle/0/mf-manifest1.json", pluginID), nil)
 		rec = httptest.NewRecorder()
 		httpService.Router().ServeHTTP(rec, req)
 		assert.Equal(tb, http.StatusNotFound, rec.Code)

--- a/service/internal/http/bundle_fs.go
+++ b/service/internal/http/bundle_fs.go
@@ -46,6 +46,7 @@ func (fs *BundleFileSystem) Open(name string) (http.File, error) {
 
 	// Join with prefix
 	fullPath := path.Join(fs.prefix, name)
+	fullPath = strings.TrimPrefix(fullPath, "/")
 
 	file, err := fs.bundle.Files.Open(fullPath)
 	if err != nil {

--- a/service/internal/http/testdata/embed_bundle/build/mf-manifest.json
+++ b/service/internal/http/testdata/embed_bundle/build/mf-manifest.json
@@ -1,0 +1,32 @@
+{
+  "id" : "",
+  "name" : "",
+  "metaData" : {
+    "name" : "",
+    "type" : "",
+    "buildInfo" : {
+      "buildVersion" : "",
+      "buildName" : ""
+    },
+    "remoteEntry" : {
+      "name" : "",
+      "path" : "",
+      "type" : ""
+    },
+    "ssrRemoteEntry" : {
+      "name" : "",
+      "path" : "",
+      "type" : ""
+    },
+    "types" : {
+      "path" : "",
+      "name" : ""
+    },
+    "globalName" : "",
+    "pluginVersion" : "",
+    "publicPath" : "/api/meta/plugin/testplugin/bundle/0/"
+  },
+  "shared" : null,
+  "remotes" : null,
+  "exposes" : null
+}

--- a/service/internal/http/testdata/embed_bundle/handler.go
+++ b/service/internal/http/testdata/embed_bundle/handler.go
@@ -1,0 +1,15 @@
+package embed_bundle
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:build/*
+var appFs embed.FS
+
+func GetFS() fs.FS {
+	appFiles, _ := fs.Sub(appFs, "build")
+
+	return appFiles
+}

--- a/service/internal/http/testdata/web_bundle/mf-manifest.json
+++ b/service/internal/http/testdata/web_bundle/mf-manifest.json
@@ -1,0 +1,32 @@
+{
+  "id" : "",
+  "name" : "",
+  "metaData" : {
+    "name" : "",
+    "type" : "",
+    "buildInfo" : {
+      "buildVersion" : "",
+      "buildName" : ""
+    },
+    "remoteEntry" : {
+      "name" : "",
+      "path" : "",
+      "type" : ""
+    },
+    "ssrRemoteEntry" : {
+      "name" : "",
+      "path" : "",
+      "type" : ""
+    },
+    "types" : {
+      "path" : "",
+      "name" : ""
+    },
+    "globalName" : "",
+    "pluginVersion" : "",
+    "publicPath" : "/api/meta/plugin/testplugin/bundle/0/"
+  },
+  "shared" : null,
+  "remotes" : null,
+  "exposes" : null
+}

--- a/service/tus.go
+++ b/service/tus.go
@@ -369,7 +369,7 @@ func (h *TUSOperationHandler) Cleanup(ctx context.Context, req *models.Request) 
 	api := core.GetAPI(apiName)
 
 	if _, ok := api.(core.APITusHandler); !ok {
-		return fmt.Errorf("API %T does not implement core.APITusHandler")
+		return fmt.Errorf("API %T does not implement core.APITusHandler", api)
 	}
 
 	tusProto, _ := api.(core.APITusHandler)
@@ -379,7 +379,7 @@ func (h *TUSOperationHandler) Cleanup(ctx context.Context, req *models.Request) 
 	proto := h.Protocol()
 	sproto, ok := proto.(core.StorageProtocol)
 	if !ok {
-		return fmt.Errorf("Protocol %T does not implement core.StorageProtocol")
+		return fmt.Errorf("Protocol %T does not implement core.StorageProtocol", proto)
 	}
 
 	err = tusSvc.UploadCompleted(ctx, sproto, tusReq.TUSUploadID)

--- a/service/tus_test.go
+++ b/service/tus_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"errors"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
@@ -24,7 +23,7 @@ func TestTUSService_UploadExists(t *testing.T) {
 		require.NotNil(tb, requestService)
 
 		// Setup mock expectations
-		requestService.On("RegisterRequestModel", models.RequestOperationTusUpload, &models.TUSRequest{}).Return()
+		requestService.EXPECT().RegisterRequestModel(core.TUSUploadOperationName("test"), &models.TUSRequest{}).Return()
 
 		// Create a test TUSRequest
 		tusRequest := &models.TUSRequest{
@@ -33,7 +32,7 @@ func TestTUSService_UploadExists(t *testing.T) {
 
 		// Create a test Request
 		request := &models.Request{
-			Operation: models.RequestOperationTusUpload,
+			Operation: core.TUSUploadOperationName("test"),
 		}
 
 		// Create the request in the database
@@ -47,13 +46,15 @@ func TestTUSService_UploadExists(t *testing.T) {
 		err = ctx.DB().Create(tusRequest).Error
 		require.NoError(tb, err)
 
+		mockProto := coreTesting.NewMockStorageProtocol("test")
+
 		// Test upload exists
-		exists, retrievedTUSRequest := tusService.UploadExists(context.Background(), "test_upload_id")
+		exists, retrievedTUSRequest := tusService.UploadExists(ctx, mockProto, "test_upload_id")
 		assert.True(tb, exists)
 		assert.Equal(tb, tusRequest.TUSUploadID, retrievedTUSRequest.TUSUploadID)
 
 		// Test upload does not exist
-		exists, _ = tusService.UploadExists(context.Background(), "nonexistent_upload_id")
+		exists, _ = tusService.UploadExists(ctx, mockProto, "nonexistent_upload_id")
 		assert.False(tb, exists)
 
 	}, coreTesting.WithServiceFactory(core.TUS_SERVICE, NewTUSService),
@@ -72,7 +73,7 @@ func TestTUSService_UploadProcessing(t *testing.T) {
 
 		// Create a test Request
 		request := &models.Request{
-			Operation: models.RequestOperationTusUpload,
+			Operation: core.TUSUploadOperationName("test"),
 			Status:    models.RequestStatusPending,
 		}
 
@@ -87,8 +88,10 @@ func TestTUSService_UploadProcessing(t *testing.T) {
 		err = ctx.DB().Create(tusRequest).Error
 		require.NoError(tb, err)
 
+		mockProto := coreTesting.NewMockStorageProtocol("test")
+
 		// Test upload processing
-		err = tusService.UploadProcessing(context.Background(), "test_upload_id")
+		err = tusService.UploadProcessing(ctx, mockProto, "test_upload_id")
 		assert.NoError(tb, err)
 
 		// Verify that the request status is updated
@@ -98,7 +101,7 @@ func TestTUSService_UploadProcessing(t *testing.T) {
 		assert.Equal(tb, models.RequestStatusProcessing, updatedRequest.Status)
 
 		// Test upload does not exist
-		err = tusService.UploadProcessing(context.Background(), "nonexistent_upload_id")
+		err = tusService.UploadProcessing(ctx, mockProto, "nonexistent_upload_id")
 		assert.Error(tb, err)
 		assert.Equal(tb, core.ErrUploadNotFound, err)
 
@@ -116,7 +119,7 @@ func TestTUSService_UploadCompleted(t *testing.T) {
 		require.NotNil(tb, requestService)
 
 		// Setup mock expectations
-		requestService.On("RegisterRequestModel", models.RequestOperationTusUpload, &models.TUSRequest{}).Return()
+		requestService.On("RegisterRequestModel", core.TUSUploadOperationName("test"), &models.TUSRequest{}).Return()
 
 		// Create a test TUSRequest
 		tusRequest := &models.TUSRequest{
@@ -125,7 +128,7 @@ func TestTUSService_UploadCompleted(t *testing.T) {
 
 		// Create a test Request
 		request := &models.Request{
-			Operation: models.RequestOperationTusUpload,
+			Operation: core.TUSUploadOperationName("test"),
 			Status:    models.RequestStatusProcessing,
 		}
 
@@ -140,8 +143,10 @@ func TestTUSService_UploadCompleted(t *testing.T) {
 		err = ctx.DB().Create(tusRequest).Error
 		require.NoError(tb, err)
 
+		mockProto := coreTesting.NewMockStorageProtocol("test")
+
 		// Test upload completed
-		err = tusService.UploadCompleted(context.Background(), "test_upload_id")
+		err = tusService.UploadCompleted(ctx, mockProto, "test_upload_id")
 		assert.NoError(tb, err)
 
 		// Verify that the request status is updated
@@ -151,7 +156,7 @@ func TestTUSService_UploadCompleted(t *testing.T) {
 		assert.Equal(tb, models.RequestStatusCompleted, updatedRequest.Status)
 
 		// Test upload does not exist
-		err = tusService.UploadCompleted(context.Background(), "nonexistent_upload_id")
+		err = tusService.UploadCompleted(ctx, mockProto, "nonexistent_upload_id")
 		assert.Error(tb, err)
 		assert.Equal(tb, core.ErrUploadNotFound, err)
 
@@ -169,7 +174,7 @@ func TestTUSService_DeleteUpload(t *testing.T) {
 		require.NotNil(tb, requestService)
 
 		// Setup mock expectations
-		requestService.On("RegisterRequestModel", models.RequestOperationTusUpload, &models.TUSRequest{}).Return()
+		requestService.On("RegisterRequestModel", core.TUSUploadOperationName("test"), &models.TUSRequest{}).Return()
 
 		// Create a test TUSRequest
 		tusRequest := &models.TUSRequest{
@@ -178,7 +183,7 @@ func TestTUSService_DeleteUpload(t *testing.T) {
 
 		// Create a test Request
 		request := &models.Request{
-			Operation: models.RequestOperationTusUpload,
+			Operation: core.TUSUploadOperationName("test"),
 		}
 
 		// Create the request in the database
@@ -192,8 +197,10 @@ func TestTUSService_DeleteUpload(t *testing.T) {
 		err = ctx.DB().Create(tusRequest).Error
 		require.NoError(tb, err)
 
+		mockProto := coreTesting.NewMockStorageProtocol("test")
+
 		// Test delete upload
-		err = tusService.DeleteUpload(context.Background(), "test_upload_id")
+		err = tusService.DeleteUpload(ctx, mockProto, "test_upload_id")
 		assert.NoError(tb, err)
 
 		// Verify that the request is deleted
@@ -203,7 +210,7 @@ func TestTUSService_DeleteUpload(t *testing.T) {
 		assert.True(tb, errors.Is(err, gorm.ErrRecordNotFound))
 
 		// Test upload does not exist
-		err = tusService.DeleteUpload(context.Background(), "nonexistent_upload_id")
+		err = tusService.DeleteUpload(ctx, mockProto, "nonexistent_upload_id")
 		assert.Error(tb, err)
 		assert.Equal(tb, core.ErrUploadNotFound, err)
 


### PR DESCRIPTION
- Streamlined filesystem caching in getOrCreateBundleFilesystem()
- Removed redundant manifest caching layer while keeping getProcessedManifest
- Added Bytes() method to testStorageHash for better test coverage
- Updated RegisterJob calls to accept optional parameters
- Fixed error message formatting in TUS service
- Added integration tests for web bundle manifest serving
- Improved path handling in BundleFileSystem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration tests to verify manifest file serving for plugin web bundles, including cache-control headers and error handling.
  * Introduced utility to provide access to embedded test bundles.

* **Bug Fixes**
  * Improved file path handling in bundle file system to ensure compatibility with embedded resources.

* **Refactor**
  * Removed caching mechanism for web bundle manifests in the HTTP service.
  * Enhanced error messages in TUS operation handler for better debugging.

* **Tests**
  * Updated test calls and setup for cron and TUS service methods to reflect recent changes.
  * Added new manifest JSON files as test data for web and embedded bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->