### PR TITLE
fix(portal): correct context processing in PortalImpl.Init()

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -129,7 +129,7 @@ func (p *PortalImpl) Init() error {
 	ctxOpts = append(ctxOpts, opts...)
 
 	// Finalize context with all gathered options
-	newCtx, err = core.ProcessCtxOptions(ctx)
+	newCtx, err = core.ProcessCtxOptions(newCtx, ctxOpts...)
 	if err != nil {
 		ctx.Logger().Error("Error creating context", zap.Error(err))
 		return err


### PR DESCRIPTION
- Fixed parameter order in ProcessCtxOptions call
- Pass context options to ProcessCtxOptions instead of original context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal context handling for more consistent behavior during initialization. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->