### PR TITLE
fix(config): we can't do a read lock inside a read lock

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -251,7 +251,6 @@ func (m *ManagerDefault) Init() error {
 func (m *ManagerDefault) persistFullDefaults() error {
 	// Ensure per-plugin directories exist
 	var dirs []string
-	m.lock.RLock()
 	for pluginName := range m.configuredPlugins {
 		dirs = append(dirs,
 			filepath.Join(m.configDir, PluginsDir, pluginName, ProtoDir),
@@ -259,7 +258,6 @@ func (m *ManagerDefault) persistFullDefaults() error {
 			filepath.Join(m.configDir, PluginsDir, pluginName, ServiceDir),
 		)
 	}
-	m.lock.RUnlock()
 
 	for _, dir := range dirs {
 		if err := m.fs.MkdirAll(dir, 0755); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of configuration persistence for plugins. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->