### PR TITLE
feat(storage): add S3 upload, download and delete operations

### DIFF
--- a/core/storage.go
+++ b/core/storage.go
@@ -115,6 +115,8 @@ func StorageDownloadWithSkipMetadataCheck(skip bool) StorageOptionFunc {
 
 type StorageService interface {
 	UploadObject(ctx context.Context, request StorageUploadRequest) (*models.Upload, error)
+	S3Upload(ctx context.Context, bucket string, key string, data io.Reader) error
+	S3Delete(ctx context.Context, bucket string, key string) error
 	UploadObjectProof(ctx context.Context, protocol StorageProtocol, data io.ReadSeeker, proof StorageHash, size uint64) error
 	DownloadObject(ctx context.Context, protocol StorageProtocol, objectHash StorageHash, start int64) (io.ReadCloser, error)
 	DownloadObjectWithOptions(ctx context.Context, protocol StorageProtocol, objectHash StorageHash, opts ...StorageOptionFunc) (io.ReadCloser, error)
@@ -122,6 +124,7 @@ type StorageService interface {
 	DeleteObject(ctx context.Context, protocol StorageProtocol, objectHash StorageHash) error
 	DeleteObjectProof(ctx context.Context, protocol StorageProtocol, objectHash StorageHash) error
 	S3Client(ctx context.Context) (*s3.Client, error)
+	S3Download(ctx context.Context, bucket string, key string) (io.ReadCloser, error)
 	S3MultipartUpload(ctx context.Context, data io.ReadCloser, bucket, key string, size uint64) error
 	S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol StorageProtocol) (string, error)
 	S3GetTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) (io.ReadCloser, error)

--- a/service/storage.go
+++ b/service/storage.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"strings"
 	"context"
 	"errors"
 	"fmt"
@@ -391,6 +392,116 @@ func (s StorageServiceDefault) DeleteObjectProof(ctx context.Context, protocol c
 	return nil
 }
 
+// S3Upload uploads an object to S3 storage.
+// bucket: The S3 bucket name
+// key: The object key/path
+// data: The data to upload
+// Returns error if upload fails
+func (s StorageServiceDefault) S3Upload(ctx context.Context, bucket string, key string, data io.Reader) error {
+	return s.s3PutObject(ctx, bucket, key, data, 0)
+}
+
+// S3Delete deletes an object from S3 storage.
+// bucket: The S3 bucket name  
+// key: The object key/path to delete
+// Returns error if deletion fails
+func (s StorageServiceDefault) S3Delete(ctx context.Context, bucket string, key string) error {
+	return s.s3DeleteObject(ctx, bucket, key)
+}
+
+// S3Download downloads an object from S3 storage.
+// bucket: The S3 bucket name
+// key: The object key/path to download  
+// Returns io.ReadCloser for the object data (caller must close it) and error if download fails
+func (s StorageServiceDefault) S3Download(ctx context.Context, bucket string, key string) (io.ReadCloser, error) {
+	return s.s3GetObject(ctx, bucket, key)
+}
+
+// s3PutObject is an internal helper for putting objects to S3 storage.
+// bucket: The S3 bucket name
+// key: The object key/path
+// data: The data to upload  
+// size: The size of the data in bytes
+// Returns error if put operation fails
+func (s StorageServiceDefault) s3PutObject(ctx context.Context, bucket string, key string, data io.Reader, size int64) error {
+	client, err := s.S3Client(ctx)
+	if err != nil {
+		return err
+	}
+
+	input := &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   data,
+	}
+
+	// Set ContentLength if size is known or can be determined
+	if size > 0 {
+		input.ContentLength = aws.Int64(size)
+	} else {
+		switch r := data.(type) {
+		case *bytes.Reader:
+			input.ContentLength = aws.Int64(r.Size())
+		case *strings.Reader:
+			input.ContentLength = aws.Int64(r.Size())
+		}
+	}
+
+	// Try to detect content type if available
+	if seeker, ok := data.(io.ReadSeeker); ok {
+		if _, err := seeker.Seek(0, io.SeekStart); err == nil {
+			if mime, err := s.detectMimeType(seeker); err == nil {
+				input.ContentType = aws.String(mime.String())
+			}
+			// Reset reader position
+			_, _ = seeker.Seek(0, io.SeekStart)
+		}
+	}
+
+	_, err = client.PutObject(ctx, input)
+	return err
+}
+
+// s3GetObject is an internal helper for getting objects from S3 storage.
+// bucket: The S3 bucket name
+// key: The object key/path  
+// Returns io.ReadCloser for the object data and error if get operation fails
+func (s StorageServiceDefault) s3GetObject(ctx context.Context, bucket string, key string) (io.ReadCloser, error) {
+	client, err := s.S3Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return output.Body, nil
+}
+
+// s3DeleteObject is an internal helper for deleting objects from S3 storage.
+// bucket: The S3 bucket name
+// key: The object key/path to delete
+// Returns error if delete operation fails
+func (s StorageServiceDefault) s3DeleteObject(ctx context.Context, bucket string, key string) error {
+	client, err := s.S3Client(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	return err
+}
+
+// S3Client creates and returns a new S3 client instance.
+// Returns configured *s3.Client and error if client creation fails
 func (s StorageServiceDefault) S3Client(ctx context.Context) (*s3.Client, error) {
 	cfg, err := awsConfig.LoadDefaultConfig(ctx,
 		awsConfig.WithRegion(s.config.Config().Core.Storage.S3.Region),
@@ -410,6 +521,12 @@ func (s StorageServiceDefault) S3Client(ctx context.Context) (*s3.Client, error)
 	}), nil
 }
 
+// S3MultipartUpload performs a multipart upload to S3 storage.
+// data: The data to upload
+// bucket: The S3 bucket name
+// key: The object key/path  
+// size: The total size of the data in bytes
+// Returns error if upload fails
 func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.ReadCloser, bucket, key string, size uint64) error {
 	client, err := s.S3Client(ctx)
 	if err != nil {
@@ -538,8 +655,18 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 
 		eta := time.Duration(int(currentAverageDuration) * (totalParts - partNum))
 
-		s.logger.Debug("Completed part", zap.Int("partNum", partNum), zap.Int("totalParts", totalParts), zap.Uint64("partSize", partSize), zap.Int("readSize", readSize), zap.Int("size", int(size)), zap.Int("totalParts", totalParts), zap.Int("partNum", partNum), zap.String("key", key), zap.String("bucket", bucket), zap.Duration("durationMs", partDuration),
-			zap.Duration("currentAverageDurationMs", currentAverageDuration), zap.Duration("eta", eta))
+		s.logger.Debug("Completed part",
+			zap.Int("partNum", partNum),
+			zap.Int("totalParts", totalParts),
+			zap.Uint64("partSize", partSize),
+			zap.Int("readSize", readSize),
+			zap.Uint64("size", size),
+			zap.String("key", key),
+			zap.String("bucket", bucket),
+			zap.Duration("duration", partDuration),
+			zap.Duration("currentAverageDuration", currentAverageDuration),
+			zap.Duration("eta", eta),
+		)
 	}
 
 	// Ensure parts are ordered by part number before completing the upload
@@ -586,6 +713,11 @@ func (s StorageServiceDefault) UploadStatus(ctx context.Context, protocol core.S
 
 }
 
+// S3TemporaryUpload uploads data to temporary S3 storage.
+// data: The data to upload
+// size: The size of the data in bytes  
+// protocol: The storage protocol being used
+// Returns upload ID and error if upload fails
 func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol core.StorageProtocol) (string, error) {
 	uploadId := uuid.NewString()
 	key := s.GetTemporaryUploadPath(protocol, uploadId)
@@ -597,18 +729,7 @@ func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.Re
 		}
 	}(data)
 
-	client, err := s.S3Client(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	_, err = client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:        aws.String(s.config.Config().Core.Storage.S3.BufferBucket),
-		Key:           aws.String(key),
-		Body:          data,
-		ContentLength: aws.Int64(int64(size)),
-	})
-
+	err := s.s3PutObject(ctx, s.config.Config().Core.Storage.S3.BufferBucket, key, data, int64(size))
 	if err != nil {
 		return "", err
 	}
@@ -616,39 +737,22 @@ func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.Re
 	return uploadId, nil
 }
 
+// S3GetTemporaryUpload retrieves a temporary upload from S3 storage.
+// protocol: The storage protocol being used
+// uploadId: The ID of the temporary upload
+// Returns io.ReadCloser for the upload data and error if retrieval fails  
 func (s StorageServiceDefault) S3GetTemporaryUpload(ctx context.Context, protocol core.StorageProtocol, uploadId string) (io.ReadCloser, error) {
-	key := s.GetTemporaryUploadPath(protocol, uploadId)
-
-	client, err := s.S3Client(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	output, err := client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(s.config.Config().Core.Storage.S3.BufferBucket),
-		Key:    aws.String(key),
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return output.Body, nil
+	return s.s3GetObject(ctx, s.config.Config().Core.Storage.S3.BufferBucket, s.GetTemporaryUploadPath(protocol, uploadId))
 }
 
+// S3DeleteTemporaryUpload deletes a temporary upload from S3 storage.
+// protocol: The storage protocol being used  
+// uploadId: The ID of the temporary upload to delete
+// Returns error if deletion fails
 func (s StorageServiceDefault) S3DeleteTemporaryUpload(ctx context.Context, protocol core.StorageProtocol, uploadId string) error {
 	key := s.GetTemporaryUploadPath(protocol, uploadId)
 
-	client, err := s.S3Client(ctx)
-	if err != nil {
-		return err
-	}
-
-	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(s.config.Config().Core.Storage.S3.BufferBucket),
-		Key:    aws.String(key),
-	})
-
+	err := s.s3DeleteObject(ctx, s.config.Config().Core.Storage.S3.BufferBucket, key)
 	if err != nil {
 		return err
 	}

--- a/service/storage_test.go
+++ b/service/storage_test.go
@@ -3,13 +3,17 @@ package service
 import (
 	"bytes"
 	"context"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal/core"
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	coreMocks "go.lumeweb.com/portal/core/testing/mocks"
 	"go.lumeweb.com/portal/db/models"
 	"go.sia.tech/renterd/v2/api"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -98,6 +102,94 @@ func TestStorageService_DeleteObject(t *testing.T) {
 
 		// Call DeleteObject
 		err := storageService.DeleteObject(context.Background(), mockProtocol, mockStorageHash)
+		assert.NoError(tb, err)
+
+	}, coreTesting.WithServiceFactory(core.STORAGE_SERVICE, NewStorageService),
+		coreTesting.WithServiceFactory(core.USER_SERVICE, NewUserService))
+}
+
+func TestStorageService_S3Upload(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		storageService := core.GetService[core.StorageService](ctx, core.STORAGE_SERVICE)
+		require.NotNil(tb, storageService)
+
+		// Mock S3 client
+		mockS3 := coreTesting.NewMockS3Client()
+		mockS3.EXPECT().PutObject(mock.Anything, mock.Anything).Return(&s3.PutObjectOutput{}, nil)
+
+		// Test data
+		testData := bytes.NewReader([]byte("test data"))
+
+		// Test upload
+		err := storageService.S3Upload(context.Background(), "test-bucket", "test-key", testData)
+		assert.NoError(tb, err)
+
+	}, coreTesting.WithServiceFactory(core.STORAGE_SERVICE, NewStorageService),
+		coreTesting.WithServiceFactory(core.USER_SERVICE, NewUserService))
+}
+
+func TestStorageService_S3Download(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		storageService := core.GetService[core.StorageService](ctx, core.STORAGE_SERVICE)
+		require.NotNil(tb, storageService)
+
+		// Mock S3 client
+		mockS3 := coreTesting.NewMockS3Client()
+		mockS3.EXPECT().GetObject(mock.Anything, mock.Anything).Return(&s3.GetObjectOutput{
+			Body: io.NopCloser(bytes.NewReader([]byte("test data"))),
+		}, nil)
+
+		// Test download
+		reader, err := storageService.S3Download(context.Background(), "test-bucket", "test-key")
+		assert.NoError(tb, err)
+		assert.NotNil(tb, reader)
+		defer reader.Close()
+
+		data, err := io.ReadAll(reader)
+		assert.NoError(tb, err)
+		assert.Equal(t, []byte("test data"), data)
+
+	}, coreTesting.WithServiceFactory(core.STORAGE_SERVICE, NewStorageService),
+		coreTesting.WithServiceFactory(core.USER_SERVICE, NewUserService))
+}
+
+func TestStorageService_S3Delete(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		storageService := core.GetService[core.StorageService](ctx, core.STORAGE_SERVICE)
+		require.NotNil(tb, storageService)
+
+		// Mock S3 client
+		mockS3 := coreTesting.NewMockS3Client()
+		mockS3.EXPECT().DeleteObject(mock.Anything, mock.Anything).Return(&s3.DeleteObjectOutput{}, nil)
+
+		// Test delete
+		err := storageService.S3Delete(context.Background(), "test-bucket", "test-key")
+		assert.NoError(tb, err)
+
+	}, coreTesting.WithServiceFactory(core.STORAGE_SERVICE, NewStorageService),
+		coreTesting.WithServiceFactory(core.USER_SERVICE, NewUserService))
+}
+
+func TestStorageService_S3MultipartUpload(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		storageService := core.GetService[core.StorageService](ctx, core.STORAGE_SERVICE)
+		require.NotNil(tb, storageService)
+
+		// Mock S3 client
+		mockS3 := coreTesting.NewMockS3Client()
+		mockS3.EXPECT().CreateMultipartUpload(mock.Anything, mock.Anything).Return(&s3.CreateMultipartUploadOutput{
+			UploadId: aws.String("test-upload-id"),
+		}, nil)
+		mockS3.EXPECT().UploadPart(mock.Anything, mock.Anything).Return(&s3.UploadPartOutput{
+			ETag: aws.String("test-etag"),
+		}, nil)
+		mockS3.EXPECT().CompleteMultipartUpload(mock.Anything, mock.Anything).Return(&s3.CompleteMultipartUploadOutput{}, nil)
+
+		// Test data
+		testData := io.NopCloser(bytes.NewReader([]byte("test data")))
+
+		// Test multipart upload
+		err := storageService.S3MultipartUpload(context.Background(), testData, "test-bucket", "test-key", 9)
 		assert.NoError(tb, err)
 
 	}, coreTesting.WithServiceFactory(core.STORAGE_SERVICE, NewStorageService),


### PR DESCRIPTION
- Added S3Upload, S3Download and S3Delete methods to StorageService interface
- Implemented corresponding methods in StorageServiceDefault
- Added helper methods s3PutObject, s3GetObject and s3DeleteObject
- Refactored existing S3 operations to use new helper methods
- Added comprehensive tests for all new S3 operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added direct S3 upload, download, and delete capabilities.
  - Introduced multipart uploads for large files.
  - Added temporary uploads with create/retrieve/delete lifecycle.

- Refactor
  - Standardized S3 interactions for improved consistency and reliability.

- Documentation
  - Clarified usage and behavior of new S3-related methods.

- Tests
  - Added test coverage for S3 upload, download, delete, and multipart upload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->