### PR TITLE
feat(storage): add S3Exists method to check object existence

### DIFF
--- a/core/storage.go
+++ b/core/storage.go
@@ -129,6 +129,7 @@ type StorageService interface {
 	S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol StorageProtocol) (string, error)
 	S3GetTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) (io.ReadCloser, error)
 	S3DeleteTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) error
+	S3Exists(ctx context.Context, bucket string, key string) (bool, error)
 	UploadStatus(ctx context.Context, protocol StorageProtocol, objectName string) (StorageUploadStatus, *time.Time, error)
 	GetTemporaryUploadDir(protocol StorageProtocol) string
 	GetTemporaryUploadPath(protocol StorageProtocol, uploadId string) string

--- a/core/testing/mocks/StorageService.go
+++ b/core/testing/mocks/StorageService.go
@@ -629,6 +629,69 @@ func (_c *MockStorageService_S3Client_Call) RunAndReturn(run func(ctx context.Co
 	return _c
 }
 
+// S3Delete provides a mock function for the type MockStorageService
+func (_mock *MockStorageService) S3Delete(ctx context.Context, bucket string, key string) error {
+	ret := _mock.Called(ctx, bucket, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for S3Delete")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, bucket, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStorageService_S3Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'S3Delete'
+type MockStorageService_S3Delete_Call struct {
+	*mock.Call
+}
+
+// S3Delete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bucket string
+//   - key string
+func (_e *MockStorageService_Expecter) S3Delete(ctx interface{}, bucket interface{}, key interface{}) *MockStorageService_S3Delete_Call {
+	return &MockStorageService_S3Delete_Call{Call: _e.mock.On("S3Delete", ctx, bucket, key)}
+}
+
+func (_c *MockStorageService_S3Delete_Call) Run(run func(ctx context.Context, bucket string, key string)) *MockStorageService_S3Delete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStorageService_S3Delete_Call) Return(err error) *MockStorageService_S3Delete_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStorageService_S3Delete_Call) RunAndReturn(run func(ctx context.Context, bucket string, key string) error) *MockStorageService_S3Delete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // S3DeleteTemporaryUpload provides a mock function for the type MockStorageService
 func (_mock *MockStorageService) S3DeleteTemporaryUpload(ctx context.Context, protocol core.StorageProtocol, uploadId string) error {
 	ret := _mock.Called(ctx, protocol, uploadId)
@@ -688,6 +751,152 @@ func (_c *MockStorageService_S3DeleteTemporaryUpload_Call) Return(err error) *Mo
 }
 
 func (_c *MockStorageService_S3DeleteTemporaryUpload_Call) RunAndReturn(run func(ctx context.Context, protocol core.StorageProtocol, uploadId string) error) *MockStorageService_S3DeleteTemporaryUpload_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// S3Download provides a mock function for the type MockStorageService
+func (_mock *MockStorageService) S3Download(ctx context.Context, bucket string, key string) (io.ReadCloser, error) {
+	ret := _mock.Called(ctx, bucket, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for S3Download")
+	}
+
+	var r0 io.ReadCloser
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (io.ReadCloser, error)); ok {
+		return returnFunc(ctx, bucket, key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) io.ReadCloser); ok {
+		r0 = returnFunc(ctx, bucket, key)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(io.ReadCloser)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, bucket, key)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStorageService_S3Download_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'S3Download'
+type MockStorageService_S3Download_Call struct {
+	*mock.Call
+}
+
+// S3Download is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bucket string
+//   - key string
+func (_e *MockStorageService_Expecter) S3Download(ctx interface{}, bucket interface{}, key interface{}) *MockStorageService_S3Download_Call {
+	return &MockStorageService_S3Download_Call{Call: _e.mock.On("S3Download", ctx, bucket, key)}
+}
+
+func (_c *MockStorageService_S3Download_Call) Run(run func(ctx context.Context, bucket string, key string)) *MockStorageService_S3Download_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStorageService_S3Download_Call) Return(readCloser io.ReadCloser, err error) *MockStorageService_S3Download_Call {
+	_c.Call.Return(readCloser, err)
+	return _c
+}
+
+func (_c *MockStorageService_S3Download_Call) RunAndReturn(run func(ctx context.Context, bucket string, key string) (io.ReadCloser, error)) *MockStorageService_S3Download_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// S3Exists provides a mock function for the type MockStorageService
+func (_mock *MockStorageService) S3Exists(ctx context.Context, bucket string, key string) (bool, error) {
+	ret := _mock.Called(ctx, bucket, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for S3Exists")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, bucket, key)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, bucket, key)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, bucket, key)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStorageService_S3Exists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'S3Exists'
+type MockStorageService_S3Exists_Call struct {
+	*mock.Call
+}
+
+// S3Exists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bucket string
+//   - key string
+func (_e *MockStorageService_Expecter) S3Exists(ctx interface{}, bucket interface{}, key interface{}) *MockStorageService_S3Exists_Call {
+	return &MockStorageService_S3Exists_Call{Call: _e.mock.On("S3Exists", ctx, bucket, key)}
+}
+
+func (_c *MockStorageService_S3Exists_Call) Run(run func(ctx context.Context, bucket string, key string)) *MockStorageService_S3Exists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStorageService_S3Exists_Call) Return(b bool, err error) *MockStorageService_S3Exists_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockStorageService_S3Exists_Call) RunAndReturn(run func(ctx context.Context, bucket string, key string) (bool, error)) *MockStorageService_S3Exists_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -915,6 +1124,75 @@ func (_c *MockStorageService_S3TemporaryUpload_Call) Return(s string, err error)
 }
 
 func (_c *MockStorageService_S3TemporaryUpload_Call) RunAndReturn(run func(ctx context.Context, data io.ReadCloser, size uint64, protocol core.StorageProtocol) (string, error)) *MockStorageService_S3TemporaryUpload_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// S3Upload provides a mock function for the type MockStorageService
+func (_mock *MockStorageService) S3Upload(ctx context.Context, bucket string, key string, data io.Reader) error {
+	ret := _mock.Called(ctx, bucket, key, data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for S3Upload")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, io.Reader) error); ok {
+		r0 = returnFunc(ctx, bucket, key, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStorageService_S3Upload_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'S3Upload'
+type MockStorageService_S3Upload_Call struct {
+	*mock.Call
+}
+
+// S3Upload is a helper method to define mock.On call
+//   - ctx context.Context
+//   - bucket string
+//   - key string
+//   - data io.Reader
+func (_e *MockStorageService_Expecter) S3Upload(ctx interface{}, bucket interface{}, key interface{}, data interface{}) *MockStorageService_S3Upload_Call {
+	return &MockStorageService_S3Upload_Call{Call: _e.mock.On("S3Upload", ctx, bucket, key, data)}
+}
+
+func (_c *MockStorageService_S3Upload_Call) Run(run func(ctx context.Context, bucket string, key string, data io.Reader)) *MockStorageService_S3Upload_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 io.Reader
+		if args[3] != nil {
+			arg3 = args[3].(io.Reader)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStorageService_S3Upload_Call) Return(err error) *MockStorageService_S3Upload_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStorageService_S3Upload_Call) RunAndReturn(run func(ctx context.Context, bucket string, key string, data io.Reader) error) *MockStorageService_S3Upload_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.0
+	github.com/aws/smithy-go v1.22.5
 	github.com/casbin/casbin/v2 v2.120.0
 	github.com/casbin/gorm-adapter/v3 v3.36.0
 	github.com/docker/go-units v0.5.0
@@ -48,6 +49,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.6.4
 	go.lumeweb.com/configmanager v0.3.19
 	go.lumeweb.com/event/v2 v2.1.0
+	go.lumeweb.com/gswagger v0.20.8
 	go.lumeweb.com/httputil v0.5.3
 	go.lumeweb.com/portal-middleware v0.2.10
 	go.lumeweb.com/portal-router v0.6.3
@@ -156,7 +158,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.28.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.37.0 // indirect
-	github.com/aws/smithy-go v1.22.5 // indirect
 	github.com/boombuler/barcode v1.0.2 // indirect
 	github.com/casbin/govaluate v1.8.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -186,7 +187,6 @@ require (
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.4 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.4 // indirect
-	go.lumeweb.com/gswagger v0.20.8 // indirect
 	go.shabbyrobe.org/gocovmerge v0.0.0-20230507111327-fa4f82cfbf4d // indirect
 	go.sia.tech/mux v1.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/service/storage.go
+++ b/service/storage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/google/uuid"
 	"go.lumeweb.com/portal/config"
@@ -749,6 +750,30 @@ func (s StorageServiceDefault) S3GetTemporaryUpload(ctx context.Context, protoco
 // protocol: The storage protocol being used
 // uploadId: The ID of the temporary upload to delete
 // Returns error if deletion fails
+func (s StorageServiceDefault) S3Exists(ctx context.Context, bucket string, key string) (bool, error) {
+	client, err := s.S3Client(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		var notFound *types.NotFound
+		var apiErr smithy.APIError
+		if errors.As(err, &notFound) || 
+			(errors.As(err, &apiErr) && 
+				(apiErr.ErrorCode() == "NotFound" || apiErr.ErrorCode() == "NoSuchKey")) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (s StorageServiceDefault) S3DeleteTemporaryUpload(ctx context.Context, protocol core.StorageProtocol, uploadId string) error {
 	key := s.GetTemporaryUploadPath(protocol, uploadId)
 


### PR DESCRIPTION
- Added S3Exists method to StorageService interface
- Implemented S3Exists in StorageServiceDefault to check if an object exists in S3 bucket
- Uses HeadObject API and handles NotFound error case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to check the existence of objects in S3, improving reliability and clearer outcomes during storage operations.
- Tests
  - Expanded test coverage with new, type-safe mocks for S3 upload, download, delete, and existence checks to ensure robust behavior.
- Chores
  - Updated dependencies to include a previously indirect package as a direct dependency, aligning with current usage and build requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->