### PR TITLE
refactor(auth): add rememberMe parameter to login methods and fix 2FA token handling

### DIFF
--- a/config/account.go
+++ b/config/account.go
@@ -12,17 +12,21 @@ var (
 
 type AccountConfig struct {
 	DeletionGracePeriod uint `config:"deletion_grace_period"`
+	RememberMeTTL       uint `config:"remember_me_ttl"`
 }
 
 func (a AccountConfig) Schema() z.ZogSchema {
 	return z.Struct(z.Shape{
 		"DeletionGracePeriod": z.Int().
 			GT(0, z.Message("deletion grace period must be greater than 0")),
+		"RememberMeTTL": z.Int().
+			GTE(0, z.Message("remember me TTL must be greater than or equal to 0")),
 	})
 }
 
 func (a AccountConfig) Defaults() map[string]any {
 	return map[string]any{
 		"DeletionGracePeriod": 48, // 24 * 2 hours
+		"RememberMeTTL":       30, // 30 days
 	}
 }

--- a/core/auth.go
+++ b/core/auth.go
@@ -30,15 +30,15 @@ type AuthService interface {
 
 	// LoginOTP authenticates a user with the provided user ID and OTP code.
 	// It returns the generated JWT token if successful.
-	LoginOTP(userId uint, code string) (string, error)
+	LoginOTP(userId uint, code string, rememberMe bool) (string, error)
 
 	// LoginPubkey authenticates a user with the provided public key.
 	// It returns the generated JWT token if successful.
-	LoginPubkey(pubkey string, ip string) (string, error)
+	LoginPubkey(pubkey string, ip string, rememberMe bool) (string, error)
 
 	// LoginID authenticates a user with the provided user ID.
 	// It returns the generated JWT token if successful.
-	LoginID(id uint, ip string) (string, error)
+	LoginID(id uint, ip string, rememberMe bool) (string, error)
 
 	// ValidLoginByUserObj checks if the provided password is valid for the given user.
 	ValidLoginByUserObj(user *models.User, password string) bool

--- a/core/testing/mocks/AuthService.go
+++ b/core/testing/mocks/AuthService.go
@@ -81,8 +81,8 @@ func (_c *MockAuthService_ID_Call) RunAndReturn(run func() string) *MockAuthServ
 }
 
 // LoginID provides a mock function for the type MockAuthService
-func (_mock *MockAuthService) LoginID(id uint, ip string) (string, error) {
-	ret := _mock.Called(id, ip)
+func (_mock *MockAuthService) LoginID(id uint, ip string, rememberMe bool) (string, error) {
+	ret := _mock.Called(id, ip, rememberMe)
 
 	if len(ret) == 0 {
 		panic("no return value specified for LoginID")
@@ -90,16 +90,16 @@ func (_mock *MockAuthService) LoginID(id uint, ip string) (string, error) {
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(uint, string) (string, error)); ok {
-		return returnFunc(id, ip)
+	if returnFunc, ok := ret.Get(0).(func(uint, string, bool) (string, error)); ok {
+		return returnFunc(id, ip, rememberMe)
 	}
-	if returnFunc, ok := ret.Get(0).(func(uint, string) string); ok {
-		r0 = returnFunc(id, ip)
+	if returnFunc, ok := ret.Get(0).(func(uint, string, bool) string); ok {
+		r0 = returnFunc(id, ip, rememberMe)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(uint, string) error); ok {
-		r1 = returnFunc(id, ip)
+	if returnFunc, ok := ret.Get(1).(func(uint, string, bool) error); ok {
+		r1 = returnFunc(id, ip, rememberMe)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -114,11 +114,12 @@ type MockAuthService_LoginID_Call struct {
 // LoginID is a helper method to define mock.On call
 //   - id uint
 //   - ip string
-func (_e *MockAuthService_Expecter) LoginID(id interface{}, ip interface{}) *MockAuthService_LoginID_Call {
-	return &MockAuthService_LoginID_Call{Call: _e.mock.On("LoginID", id, ip)}
+//   - rememberMe bool
+func (_e *MockAuthService_Expecter) LoginID(id interface{}, ip interface{}, rememberMe interface{}) *MockAuthService_LoginID_Call {
+	return &MockAuthService_LoginID_Call{Call: _e.mock.On("LoginID", id, ip, rememberMe)}
 }
 
-func (_c *MockAuthService_LoginID_Call) Run(run func(id uint, ip string)) *MockAuthService_LoginID_Call {
+func (_c *MockAuthService_LoginID_Call) Run(run func(id uint, ip string, rememberMe bool)) *MockAuthService_LoginID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 uint
 		if args[0] != nil {
@@ -128,9 +129,14 @@ func (_c *MockAuthService_LoginID_Call) Run(run func(id uint, ip string)) *MockA
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -141,14 +147,14 @@ func (_c *MockAuthService_LoginID_Call) Return(s string, err error) *MockAuthSer
 	return _c
 }
 
-func (_c *MockAuthService_LoginID_Call) RunAndReturn(run func(id uint, ip string) (string, error)) *MockAuthService_LoginID_Call {
+func (_c *MockAuthService_LoginID_Call) RunAndReturn(run func(id uint, ip string, rememberMe bool) (string, error)) *MockAuthService_LoginID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // LoginOTP provides a mock function for the type MockAuthService
-func (_mock *MockAuthService) LoginOTP(userId uint, code string) (string, error) {
-	ret := _mock.Called(userId, code)
+func (_mock *MockAuthService) LoginOTP(userId uint, code string, rememberMe bool) (string, error) {
+	ret := _mock.Called(userId, code, rememberMe)
 
 	if len(ret) == 0 {
 		panic("no return value specified for LoginOTP")
@@ -156,16 +162,16 @@ func (_mock *MockAuthService) LoginOTP(userId uint, code string) (string, error)
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(uint, string) (string, error)); ok {
-		return returnFunc(userId, code)
+	if returnFunc, ok := ret.Get(0).(func(uint, string, bool) (string, error)); ok {
+		return returnFunc(userId, code, rememberMe)
 	}
-	if returnFunc, ok := ret.Get(0).(func(uint, string) string); ok {
-		r0 = returnFunc(userId, code)
+	if returnFunc, ok := ret.Get(0).(func(uint, string, bool) string); ok {
+		r0 = returnFunc(userId, code, rememberMe)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(uint, string) error); ok {
-		r1 = returnFunc(userId, code)
+	if returnFunc, ok := ret.Get(1).(func(uint, string, bool) error); ok {
+		r1 = returnFunc(userId, code, rememberMe)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -180,11 +186,12 @@ type MockAuthService_LoginOTP_Call struct {
 // LoginOTP is a helper method to define mock.On call
 //   - userId uint
 //   - code string
-func (_e *MockAuthService_Expecter) LoginOTP(userId interface{}, code interface{}) *MockAuthService_LoginOTP_Call {
-	return &MockAuthService_LoginOTP_Call{Call: _e.mock.On("LoginOTP", userId, code)}
+//   - rememberMe bool
+func (_e *MockAuthService_Expecter) LoginOTP(userId interface{}, code interface{}, rememberMe interface{}) *MockAuthService_LoginOTP_Call {
+	return &MockAuthService_LoginOTP_Call{Call: _e.mock.On("LoginOTP", userId, code, rememberMe)}
 }
 
-func (_c *MockAuthService_LoginOTP_Call) Run(run func(userId uint, code string)) *MockAuthService_LoginOTP_Call {
+func (_c *MockAuthService_LoginOTP_Call) Run(run func(userId uint, code string, rememberMe bool)) *MockAuthService_LoginOTP_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 uint
 		if args[0] != nil {
@@ -194,9 +201,14 @@ func (_c *MockAuthService_LoginOTP_Call) Run(run func(userId uint, code string))
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -207,7 +219,7 @@ func (_c *MockAuthService_LoginOTP_Call) Return(s string, err error) *MockAuthSe
 	return _c
 }
 
-func (_c *MockAuthService_LoginOTP_Call) RunAndReturn(run func(userId uint, code string) (string, error)) *MockAuthService_LoginOTP_Call {
+func (_c *MockAuthService_LoginOTP_Call) RunAndReturn(run func(userId uint, code string, rememberMe bool) (string, error)) *MockAuthService_LoginOTP_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -299,8 +311,8 @@ func (_c *MockAuthService_LoginPassword_Call) RunAndReturn(run func(email string
 }
 
 // LoginPubkey provides a mock function for the type MockAuthService
-func (_mock *MockAuthService) LoginPubkey(pubkey string, ip string) (string, error) {
-	ret := _mock.Called(pubkey, ip)
+func (_mock *MockAuthService) LoginPubkey(pubkey string, ip string, rememberMe bool) (string, error) {
+	ret := _mock.Called(pubkey, ip, rememberMe)
 
 	if len(ret) == 0 {
 		panic("no return value specified for LoginPubkey")
@@ -308,16 +320,16 @@ func (_mock *MockAuthService) LoginPubkey(pubkey string, ip string) (string, err
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) (string, error)); ok {
-		return returnFunc(pubkey, ip)
+	if returnFunc, ok := ret.Get(0).(func(string, string, bool) (string, error)); ok {
+		return returnFunc(pubkey, ip, rememberMe)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string, string) string); ok {
-		r0 = returnFunc(pubkey, ip)
+	if returnFunc, ok := ret.Get(0).(func(string, string, bool) string); ok {
+		r0 = returnFunc(pubkey, ip, rememberMe)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = returnFunc(pubkey, ip)
+	if returnFunc, ok := ret.Get(1).(func(string, string, bool) error); ok {
+		r1 = returnFunc(pubkey, ip, rememberMe)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -332,11 +344,12 @@ type MockAuthService_LoginPubkey_Call struct {
 // LoginPubkey is a helper method to define mock.On call
 //   - pubkey string
 //   - ip string
-func (_e *MockAuthService_Expecter) LoginPubkey(pubkey interface{}, ip interface{}) *MockAuthService_LoginPubkey_Call {
-	return &MockAuthService_LoginPubkey_Call{Call: _e.mock.On("LoginPubkey", pubkey, ip)}
+//   - rememberMe bool
+func (_e *MockAuthService_Expecter) LoginPubkey(pubkey interface{}, ip interface{}, rememberMe interface{}) *MockAuthService_LoginPubkey_Call {
+	return &MockAuthService_LoginPubkey_Call{Call: _e.mock.On("LoginPubkey", pubkey, ip, rememberMe)}
 }
 
-func (_c *MockAuthService_LoginPubkey_Call) Run(run func(pubkey string, ip string)) *MockAuthService_LoginPubkey_Call {
+func (_c *MockAuthService_LoginPubkey_Call) Run(run func(pubkey string, ip string, rememberMe bool)) *MockAuthService_LoginPubkey_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 string
 		if args[0] != nil {
@@ -346,9 +359,14 @@ func (_c *MockAuthService_LoginPubkey_Call) Run(run func(pubkey string, ip strin
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -359,7 +377,7 @@ func (_c *MockAuthService_LoginPubkey_Call) Return(s string, err error) *MockAut
 	return _c
 }
 
-func (_c *MockAuthService_LoginPubkey_Call) RunAndReturn(run func(pubkey string, ip string) (string, error)) *MockAuthService_LoginPubkey_Call {
+func (_c *MockAuthService_LoginPubkey_Call) RunAndReturn(run func(pubkey string, ip string, rememberMe bool) (string, error)) *MockAuthService_LoginPubkey_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/service/auth.go
+++ b/service/auth.go
@@ -6,6 +6,7 @@ import (
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db"
+	dbHelper "go.lumeweb.com/portal/service/internal/db"
 	"go.lumeweb.com/portal/db/models"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
@@ -71,7 +72,7 @@ func (a AuthServiceDefault) LoginPassword(email string, password string, ip stri
 	return token, user, nil
 }
 
-func (a AuthServiceDefault) LoginOTP(userId uint, code string) (string, error) {
+func (a AuthServiceDefault) LoginOTP(userId uint, code string, rememberMe bool) (string, error) {
 	valid, err := a.otp.OTPVerify(userId, code)
 
 	if err != nil {
@@ -85,15 +86,15 @@ func (a AuthServiceDefault) LoginOTP(userId uint, code string) (string, error) {
 	var user models.User
 	user.ID = userId
 
-	token, tokenErr := jwt.CreateToken(a.ctx.Config().Config().Core.Identity.PrivateKey(), a.config.Config().Core.Domain, strconv.Itoa(int(user.ID)), jwt.PurposeLogin, 0)
-	if tokenErr != nil {
+	token, err := a.doLogin(&user, "", false, rememberMe)
+	if err != nil {
 		return "", err
 	}
 
 	return token, nil
 }
 
-func (a AuthServiceDefault) LoginPubkey(pubkey string, ip string) (string, error) {
+func (a AuthServiceDefault) LoginPubkey(pubkey string, ip string, rememberMe bool) (string, error) {
 	var model models.PublicKey
 	var rowsAffected int64
 
@@ -107,12 +108,12 @@ func (a AuthServiceDefault) LoginPubkey(pubkey string, ip string) (string, error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return "", core.NewAccountError(core.ErrKeyInvalidLogin, err)
 		}
-		return "", core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+		return "", dbHelper.HandleDBError(err)
 	}
 
 	user := model.User
 
-	token, err := a.doLogin(&user, ip, true, false)
+	token, err := a.doLogin(&user, ip, true, rememberMe)
 
 	if err != nil {
 		return "", err
@@ -121,7 +122,7 @@ func (a AuthServiceDefault) LoginPubkey(pubkey string, ip string) (string, error
 	return token, nil
 }
 
-func (a AuthServiceDefault) LoginID(id uint, ip string) (string, error) {
+func (a AuthServiceDefault) LoginID(id uint, ip string, rememberMe bool) (string, error) {
 	var user models.User
 	var rowsAffected int64
 
@@ -137,10 +138,10 @@ func (a AuthServiceDefault) LoginID(id uint, ip string) (string, error) {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return "", core.NewAccountError(core.ErrKeyInvalidLogin, err)
 		}
-		return "", core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+		return "", dbHelper.HandleDBError(err)
 	}
 
-	token, err := a.doLogin(&user, ip, true, false)
+	token, err := a.doLogin(&user, ip, true, rememberMe)
 
 	if err != nil {
 		return "", err
@@ -148,6 +149,7 @@ func (a AuthServiceDefault) LoginID(id uint, ip string) (string, error) {
 
 	return token, nil
 }
+
 
 func (a AuthServiceDefault) ValidLoginByUserObj(user *models.User, password string) bool {
 	return a.validPassword(user, password)
@@ -167,7 +169,7 @@ func (a AuthServiceDefault) ValidLoginByEmail(email string, password string) (bo
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil, core.NewAccountError(core.ErrKeyInvalidLogin, err)
 		}
-		return false, nil, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+		return false, nil, dbHelper.HandleDBError(err)
 	}
 
 	valid := a.ValidLoginByUserObj(&user, password)
@@ -195,7 +197,7 @@ func (a AuthServiceDefault) ValidLoginByUserID(id uint, password string) (bool, 
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil, core.NewAccountError(core.ErrKeyInvalidLogin, err)
 		}
-		return false, nil, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+		return false, nil, dbHelper.HandleDBError(err)
 	}
 
 	valid := a.ValidLoginByUserObj(&user, password)
@@ -225,7 +227,7 @@ func (a AuthServiceDefault) doLogin(user *models.User, ip string, bypassSecurity
 	dur := time.Hour * 24
 
 	if rememberMe {
-		dur = time.Hour * 24 * 30
+		dur = time.Hour * 24 * time.Duration(a.config.Config().Core.Account.RememberMeTTL)
 	}
 
 	token, jwtErr := jwt.CreateToken(a.ctx.Config().Config().Core.Identity.PrivateKey(), a.config.Config().Core.Domain, strconv.Itoa(int(user.ID)), purpose, dur)

--- a/service/internal/db/db.go
+++ b/service/internal/db/db.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"go.lumeweb.com/portal/core"
+	"gorm.io/gorm"
+)
+
+// HandleDBError standardizes database error handling across services
+func HandleDBError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	// Optionally: detect duplicate key and map to a friendlier error key
+	// if errors.Is(err, gorm.ErrDuplicatedKey) { return core.NewAccountError(core.ErrKeyDuplicate, err) }
+	
+	return core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+}

--- a/service/user.go
+++ b/service/user.go
@@ -3,22 +3,28 @@ package service
 import (
 	"errors"
 	"fmt"
+	"net/url"
+	"time"
+
 	"github.com/go-sql-driver/mysql"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db"
+	dbHelper "go.lumeweb.com/portal/service/internal/db"
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/event"
 	"go.lumeweb.com/portal/service/internal/user"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	"net/url"
-	"time"
 )
 
 var _ core.UserService = (*UserServiceDefault)(nil)
 var _ core.Cronable = (*UserServiceDefault)(nil)
+
+func (u UserServiceDefault) getAuthService() core.AuthService {
+	return core.GetService[core.AuthService](u.ctx, core.AUTH_SERVICE)
+}
 
 func init() {
 	core.RegisterService(core.ServiceInfo{
@@ -107,15 +113,16 @@ func (u UserServiceDefault) EmailExists(email string) (bool, *models.User, error
 	if !exists || err != nil {
 		return false, nil, err
 	}
-	return true, model.(*models.User), nil // Type assertion since `Exists` returns interface{}
+	return true, model.(*models.User), nil
 }
+
 func (u UserServiceDefault) PubkeyExists(pubkey string) (bool, *models.PublicKey, error) {
 	publicKey := &models.PublicKey{}
 	exists, model, err := u.Exists(publicKey, map[string]interface{}{"key": pubkey})
 	if !exists || err != nil {
 		return false, nil, err
 	}
-	return true, model.(*models.PublicKey), nil // Type assertion is necessary
+	return true, model.(*models.PublicKey), nil
 }
 
 func (u UserServiceDefault) AccountExists(id uint) (bool, *models.User, error) {
@@ -124,8 +131,9 @@ func (u UserServiceDefault) AccountExists(id uint) (bool, *models.User, error) {
 	if !exists || err != nil {
 		return false, nil, err
 	}
-	return true, model.(*models.User), nil // Ensure to assert the type correctly
+	return true, model.(*models.User), nil
 }
+
 
 func (u UserServiceDefault) HashPassword(password string) (string, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
@@ -223,7 +231,7 @@ func (u UserServiceDefault) UpdateAccountEmail(userId uint, email string, passwo
 		return core.NewAccountError(core.ErrKeyEmailAlreadyExists, nil)
 	}
 
-	valid, user, err := u.ValidLoginByUserID(userId, password)
+	valid, user, err := u.getAuthService().ValidLoginByUserID(userId, password)
 	if err != nil {
 		return err
 	}
@@ -242,7 +250,8 @@ func (u UserServiceDefault) UpdateAccountEmail(userId uint, email string, passwo
 }
 
 func (u UserServiceDefault) UpdateAccountPassword(userId uint, password string, newPassword string) error {
-	valid, _, err := u.ValidLoginByUserID(userId, password)
+
+	valid, _, err := u.getAuthService().ValidLoginByUserID(userId, password)
 	if err != nil {
 		return err
 	}
@@ -261,43 +270,6 @@ func (u UserServiceDefault) UpdateAccountPassword(userId uint, password string, 
 	})
 }
 
-func (u UserServiceDefault) ValidLoginByUserID(id uint, password string) (bool, *models.User, error) {
-	var user models.User
-
-	user.ID = id
-
-	var rowsAffected int64
-
-	err := db.RetryOnLock(u.db, func(db *gorm.DB) *gorm.DB {
-		tx := db.Model(&user).Where(&user).First(&user)
-		rowsAffected = tx.RowsAffected
-
-		return tx
-	})
-
-	if rowsAffected == 0 || err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return false, nil, core.NewAccountError(core.ErrKeyInvalidLogin, err)
-		}
-
-		return false, nil, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
-	}
-
-	valid := u.ValidLoginByUserObj(&user, password)
-
-	if !valid {
-		return false, nil, nil
-	}
-
-	return true, &user, nil
-}
-
-func (u UserServiceDefault) validPassword(user *models.User, password string) bool {
-	err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password))
-
-	return err == nil
-}
-
 func (u UserServiceDefault) UpdateAccountInfo(userId uint, info map[string]any) error {
 	var user models.User
 	user.ID = userId
@@ -311,9 +283,6 @@ func (u UserServiceDefault) UpdateAccountInfo(userId uint, info map[string]any) 
 	return nil
 }
 
-func (u UserServiceDefault) ValidLoginByUserObj(user *models.User, password string) bool {
-	return u.validPassword(user, password)
-}
 func (u UserServiceDefault) AddPubkeyToAccount(user models.User, pubkey string) error {
 	var model models.PublicKey
 
@@ -355,7 +324,7 @@ func (u UserServiceDefault) Exists(model any, conditions map[string]any) (bool, 
 		return true, model, nil
 	}
 
-	return false, model, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+	return false, model, dbHelper.HandleDBError(err)
 }
 
 func (u UserServiceDefault) SendEmailVerification(userId uint) error {
@@ -395,7 +364,7 @@ func (u UserServiceDefault) SendEmailVerification(userId uint) error {
 		"FirstName":        _user.FirstName,
 		"Email":            _user.Email,
 		"VerificationLink": verifyUrl,
-		"ExpireTime":       time.Until(verification.ExpiresAt).Round(time.Second * 2),
+		"ExpireTime":       time.Until(verification.ExpiresAt).Round(time.Second),
 		"PortalName":       u.config.Config().Core.PortalName,
 	}
 
@@ -413,7 +382,7 @@ func (u UserServiceDefault) IsAccountVerified(userId uint) (bool, error) {
 			return false, err
 		}
 
-		return false, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+		return false, dbHelper.HandleDBError(err)
 	}
 
 	return _user.Verified, nil
@@ -488,22 +457,22 @@ func (u *UserServiceDefault) DeleteAccount(userId uint) error {
 		var _user models.User
 		if err := tx.First(&_user, userId).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				_ = tx.AddError(errors.New("user not found"))
+				_ = tx.AddError(core.NewAccountError(core.ErrKeyUserNotFound, nil))
 			} else {
-				_ = tx.AddError(err)
+				_ = tx.AddError(dbHelper.HandleDBError(err))
 			}
 			return tx
 		}
 
 		// Delete associated AccountDeletion record if it exists
 		if err := tx.Where("user_id = ?", userId).Delete(&models.AccountDeletion{}).Error; err != nil {
-			_ = tx.AddError(err)
+			_ = tx.AddError(dbHelper.HandleDBError(err))
 			return tx
 		}
 
 		// Delete the user
 		if err := tx.Delete(&_user).Error; err != nil {
-			_ = tx.AddError(err)
+			_ = tx.AddError(dbHelper.HandleDBError(err))
 			return tx
 		}
 


### PR DESCRIPTION
* Added `rememberMe` boolean parameter to `LoginOTP`, `LoginPubkey`, and `LoginID` methods in `AuthService` interface and implementation
* Updated mock implementations to include the new `rememberMe` parameter
* Refactored login logic to use a shared `doLogin` method that handles the `rememberMe` functionality
* Created new internal db package with `HandleDBError` function for standardized database error handling
* Improved 2FA OTP verification flow by integrating it with the unified login process
* Removed redundant password validation methods from UserService and delegated to AuthService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a “Remember me” option across all login methods and configurable TTL for longer sessions.
- Bug Fixes
  - Standardized database error handling for clearer, more consistent errors during login and account actions.
  - Improved reliability of login validation during email and password updates.
- Refactor
  - Centralized authentication and DB error handling to reduce duplicated logic.
- Tests
  - Updated test mocks to support the new remember-me parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->