### PR TITLE
refactor(user): extract duplicate key error handling into helper method

### DIFF
--- a/service/user.go
+++ b/service/user.go
@@ -175,11 +175,7 @@ func (u UserServiceDefault) CreateAccount(email string, password string, verifyE
 	})
 
 	if err != nil {
-		if errors.Is(err, gorm.ErrDuplicatedKey) {
-			return nil, core.NewAccountError(core.ErrKeyEmailAlreadyExists, nil)
-		}
-
-		if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == 1062 {
+		if u.isDuplicateKeyError(err) {
 			return nil, core.NewAccountError(core.ErrKeyEmailAlreadyExists, nil)
 		}
 
@@ -293,7 +289,7 @@ func (u UserServiceDefault) AddPubkeyToAccount(user models.User, pubkey string) 
 		return db.Create(&model)
 
 	}); err != nil {
-		if errors.Is(err, gorm.ErrDuplicatedKey) {
+		if u.isDuplicateKeyError(err) {
 			return core.NewAccountError(core.ErrKeyPublicKeyExists, err)
 		}
 
@@ -537,4 +533,23 @@ func (u *UserServiceDefault) GetAccountsPendingDeletion() ([]*models.User, error
 	}
 
 	return users, nil
+}
+
+func (u UserServiceDefault) isDuplicateKeyError(err error) bool {
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+
+	// MySQL duplicate key error
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr != nil && mysqlErr.Number == 1062 {
+		return true
+	}
+
+	// SQLite unique constraint violation
+	if errors.Is(err, gorm.ErrConstraintViolated) {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
* Consolidated duplicate key error checking into `isDuplicateKeyError` helper
* Handles GORM, MySQL, and SQLite duplicate key scenarios
* Improves code maintainability and reduces duplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Consistent detection of duplicate email addresses during sign-up, yielding clearer error messages across supported databases.
  - Consistent detection of duplicate public keys when adding keys to accounts, preventing conflicting key entries.
  - Reduced edge-case failures in account creation and key addition, improving reliability and predictability without user action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->