### PR TITLE
feat(http): add dynamic global path registration

### DIFF
--- a/core/http.go
+++ b/core/http.go
@@ -11,6 +11,7 @@ type HTTPService interface {
 	Init() error
 	Serve() error
 	APISubdomain(id string, proto bool) string
+	RegisterGlobalPath(path string) error
 
 	Service
 }

--- a/core/testing/mocks/HTTPService.go
+++ b/core/testing/mocks/HTTPService.go
@@ -181,6 +181,57 @@ func (_c *MockHTTPService_Init_Call) RunAndReturn(run func() error) *MockHTTPSer
 	return _c
 }
 
+// RegisterGlobalPath provides a mock function for the type MockHTTPService
+func (_mock *MockHTTPService) RegisterGlobalPath(path string) error {
+	ret := _mock.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RegisterGlobalPath")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
+		r0 = returnFunc(path)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockHTTPService_RegisterGlobalPath_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RegisterGlobalPath'
+type MockHTTPService_RegisterGlobalPath_Call struct {
+	*mock.Call
+}
+
+// RegisterGlobalPath is a helper method to define mock.On call
+//   - path string
+func (_e *MockHTTPService_Expecter) RegisterGlobalPath(path interface{}) *MockHTTPService_RegisterGlobalPath_Call {
+	return &MockHTTPService_RegisterGlobalPath_Call{Call: _e.mock.On("RegisterGlobalPath", path)}
+}
+
+func (_c *MockHTTPService_RegisterGlobalPath_Call) Run(run func(path string)) *MockHTTPService_RegisterGlobalPath_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockHTTPService_RegisterGlobalPath_Call) Return(err error) *MockHTTPService_RegisterGlobalPath_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockHTTPService_RegisterGlobalPath_Call) RunAndReturn(run func(path string) error) *MockHTTPService_RegisterGlobalPath_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Router provides a mock function for the type MockHTTPService
 func (_mock *MockHTTPService) Router() router.Router {
 	ret := _mock.Called()

--- a/service/http.go
+++ b/service/http.go
@@ -40,7 +40,6 @@ const (
 
 var (
 	pluginIDRegex    = regexp.MustCompile(`^[a-zA-Z0-9-_]+$`)
-	httpGlobalPaths  = []string{"/api/meta", "/swagger"}
 	genericTypeRegex = regexp.MustCompile(`^(.+?)\[(.+)]$`)
 )
 
@@ -69,13 +68,15 @@ func init() {
 }
 
 type HTTPServiceDefault struct {
-	ctx         core.Context
-	logger      *core.Logger
-	router      router.Router
-	srv         *http.Server
-	access      core.AccessService
-	bundleCache sync.Map
-	fsCache     sync.Map // Cache for bundle filesystems
+	ctx           core.Context
+	logger        *core.Logger
+	router        router.Router
+	srv           *http.Server
+	access        core.AccessService
+	bundleCache   sync.Map
+	fsCache       sync.Map // Cache for bundle filesystems
+	globalPaths   []string
+	globalPathsMu sync.RWMutex
 }
 
 func NewHTTPService() (core.Service, []core.ContextBuilderOption, error) {
@@ -125,6 +126,13 @@ func (h *HTTPServiceDefault) Router() router.Router {
 }
 
 func (h *HTTPServiceDefault) Init() error {
+	// Register default global paths
+	if err := h.RegisterGlobalPath("/api/meta"); err != nil {
+		return fmt.Errorf("failed to register global path: %w", err)
+	}
+	if err := h.RegisterGlobalPath("/swagger"); err != nil {
+		return fmt.Errorf("failed to register global path: %w", err)
+	}
 
 	h.router.Use(echoMiddleware.RecoverWithConfig(echoMiddleware.RecoverConfig{
 		StackSize: 1 << 10,
@@ -471,18 +479,41 @@ func (h *HTTPServiceDefault) Serve() error {
 	return nil
 }
 
+func (h *HTTPServiceDefault) RegisterGlobalPath(path string) error {
+	h.globalPathsMu.Lock()
+	defer h.globalPathsMu.Unlock()
+
+	// Validate path
+	if path == "" {
+		return fmt.Errorf("path cannot be empty")
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("path must start with /")
+	}
+
+	// Check if already exists
+	if lo.Contains(h.globalPaths, path) {
+		return nil // Already registered
+	}
+
+	h.globalPaths = append(h.globalPaths, path)
+	return nil
+}
+
 func (h *HTTPServiceDefault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// This method is set as the CustomServeHTTPHandler on the root gswagger.Router.
 	// It is called after gswagger's standard documentation path checks.
 
 	// Prioritize global routes, which are always served by the root router
 	isGlobalPath := false
-	for _, globalPath := range httpGlobalPaths {
+	h.globalPathsMu.RLock()
+	for _, globalPath := range h.globalPaths {
 		if strings.HasPrefix(r.URL.Path, globalPath) {
 			isGlobalPath = true
 			break
 		}
 	}
+	h.globalPathsMu.RUnlock()
 	if isGlobalPath {
 		// Attempt to cast the Root gswagger Router's underlying framework router to an http.Handler
 		if handler, ok := h.router.Router().Router(true).(http.Handler); ok {


### PR DESCRIPTION
- Added `RegisterGlobalPath` method to HTTPService interface
- Replaced static `httpGlobalPaths` with thread-safe dynamic storage in `HTTPServiceDefault`
- Added mutex protection for global paths access
- Moved default paths ("/api/meta", "/swagger") to initialization
- Added path validation in registration method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dynamic registration of global HTTP paths available across all hosts.
  - Default global endpoints (e.g., /api/meta and /swagger) registered automatically.

- Refactor
  - Thread-safe, concurrent-safe handling of global paths for more reliable routing.

- Tests
  - Updated HTTP service mocks to support and verify global-path registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->