### PR TITLE
fix(db): add schedule_type column to MySQL cron_jobs table definition

### DIFF
--- a/db/migrations/mysql/20250308183521_init.sql
+++ b/db/migrations/mysql/20250308183521_init.sql
@@ -69,6 +69,7 @@ CREATE TABLE `cron_jobs`
     `job_type`       varchar(255)    NOT NULL,
     `args`           longtext,
     `sched_def`      longtext,
+    `schedule_type`  varchar(20),
     `last_run`       datetime(3)     DEFAULT NULL,
     `failures`       bigint unsigned DEFAULT NULL,
     `state`          varchar(20)     DEFAULT 'queued',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded scheduling options for automated jobs by adding support for a schedule type, enabling clearer configuration of how schedules are interpreted.

- Chores
  - Updated database schema to include a schedule type field for cron jobs to support the enhanced scheduling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->