### PR TITLE
refactor(testing): simplify SQLite temp file cleanup and add HTTP service support

### DIFF
--- a/core/testing/db.go
+++ b/core/testing/db.go
@@ -36,25 +36,17 @@ func WithSQLite() TestContextBuilderOption {
 			return nil, fmt.Errorf("failed to set database file: %w", err)
 		}
 
-		// Register cleanup to remove temp file
-		ctx.RegisterCleanup(func() {
-			err = os.Remove(tempFile.Name())
-			if err != nil {
-				ctx.Logger().Error("Failed to remove temp SQLite file",
-					zap.String("path", tempFile.Name()),
-					zap.Error(err))
-			}
-		})
-
 		// Add a startup function that will create and connect the DB
 		startupOpt := core.ContextWithStartupFunc(func(ctx core.Context) error {
 			provider := db.NewTestSQLiteProvider(ctx)
-
+			connected := false
+			
 			// Connect to the database
 			_db, err := provider.Connect(ctx.Logger())
 			if err != nil {
 				return fmt.Errorf("failed to connect to SQLite: %w", err)
 			}
+			connected = true
 
 			// Set the DB on the context
 			if tc, ok := ctx.(TestContext); ok {
@@ -63,33 +55,16 @@ func WithSQLite() TestContextBuilderOption {
 				return fmt.Errorf("context is not TestContext")
 			}
 
-			// Register cleanup
+			// Close DB then remove temp file; always attempt removal, return close error.
 			ctx.OnExit(func(c core.Context) error {
-				return provider.Close()
+				closeErr := provider.Close()
+				if err := os.Remove(tempFile.Name()); err != nil && !os.IsNotExist(err) {
+					c.Logger().Error("Failed to remove temp SQLite file",
+						zap.String("path", tempFile.Name()),
+						zap.Error(err))
+				}
+				return closeErr
 			})
-
-			// Register temp file removal to run after provider.Close
-			if tc, ok := ctx.(TestContext); ok {
-				tc.OnExit(func(c core.Context) error {
-					err := os.Remove(tempFile.Name())
-					if err != nil {
-						ctx.Logger().Error("Failed to remove temp SQLite file",
-							zap.String("path", tempFile.Name()),
-							zap.Error(err))
-					}
-					return nil
-				})
-			} else {
-				// Fallback to RegisterCleanup if ctx is not TestContext
-				ctx.RegisterCleanup(func() {
-					err := os.Remove(tempFile.Name())
-					if err != nil {
-						ctx.Logger().Error("Failed to remove temp SQLite file",
-							zap.String("path", tempFile.Name()),
-							zap.Error(err))
-					}
-				})
-			}
 
 			return nil
 		})

--- a/core/testing/service.go
+++ b/core/testing/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/core/testing/mocks"
+	"go.lumeweb.com/portal/service"
 	"go.uber.org/zap"
 )
 
@@ -255,6 +256,13 @@ func WithMockTUSService() TestContextBuilderOption {
 func WithMockUserService() TestContextBuilderOption {
 	return WithMockService(core.USER_SERVICE, func(tb TB, _ TestContext) any {
 		return mocks.NewMockUserService(tb)
+	})
+}
+
+// WithHTTPService adds the real HTTPService to the test context.
+func WithHTTPService() TestContextBuilderOption {
+	return WithServiceFactory(core.HTTP_SERVICE, func() (core.Service, []core.ContextBuilderOption, error) {
+		return service.NewHTTPService()
 	})
 }
 


### PR DESCRIPTION
- Consolidated SQLite temp file cleanup to always use OnExit instead of branching logic
- Added WithHTTPService option to test context builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added a helper to run tests with the real HTTP service, making integration-style testing simpler and more realistic.
  - Standardized test database cleanup to always close and remove temporary DB files on exit, with clearer error logging for removal failures.

- Chores
  - Unified and simplified test cleanup registration to improve reliability and reduce conditional logic in test setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->