### PR TITLE
feat(testing): add HTTP service support to test framework

### DIFF
--- a/core/http.go
+++ b/core/http.go
@@ -10,6 +10,7 @@ type HTTPService interface {
 	Router() router.Router
 	Init() error
 	Serve() error
+	Stop() error
 	APISubdomain(id string, proto bool) string
 	RegisterGlobalPath(path string) error
 

--- a/core/testing/config.go
+++ b/core/testing/config.go
@@ -188,11 +188,12 @@ func getEnvValue(envVars []string, defaultValues []interface{}) (string, error) 
 	return "", fmt.Errorf("none of the environment variables %v are set", envVars)
 }
 
-// WithEnvConfig reads a configuration value from environment variable
-// and sets it in the test context. Returns error if none of the env vars are set.
-// If no envVars provided, the key will be converted to an env var name.
-// Empty values are allowed; callers that require non-empty values should validate after retrieval
-// or use WithEnvConfigOrDefault with a non-empty default.
+// WithEnvConfig reads a configuration value from environment variables
+// and sets it in the test context. If none of the env vars are set, it logs a
+// warning and leaves the config unset (no error). If no envVars provided, the key
+// will be converted to an env var name. Empty values are allowed; callers that
+// require non-empty values should validate after retrieval or use
+// WithEnvConfigOrDefault with a non-empty default.
 func WithEnvConfig(key string, envVars ...string) TestContextBuilderOption {
 	if len(envVars) == 0 {
 		envVars = []string{envVarName(key)}
@@ -219,7 +220,7 @@ func WithEnvConfigOrDefault(key string, envVarsAndDefaults ...interface{}) TestC
 	for i, arg := range envVarsAndDefaults {
 		if i%2 == 0 {
 			// Even index: environment variable name
-			if envVar, ok := arg.(string); ok {
+			if envVar, ok := arg.(string); ok && envVar != "" {
 				envVars = append(envVars, envVar)
 			}
 		} else {
@@ -228,7 +229,7 @@ func WithEnvConfigOrDefault(key string, envVarsAndDefaults ...interface{}) TestC
 		}
 	}
 
-	// If no env vars provided, compute from key
+	// If no valid env vars provided (either none or all empty), compute from key
 	if len(envVars) == 0 {
 		envVars = []string{envVarName(key)}
 	}

--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -4,6 +4,7 @@ package testing
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -62,6 +63,7 @@ type testContext struct {
 	cleanupFuncs     []func()
 	apiID            string // Stores the API ID for this context
 	fireBootComplete bool   // Controls whether to fire boot complete event
+	httpDone         chan struct{} // Signals when HTTP server is done
 }
 
 // Ensure testContext implements TestContext
@@ -156,6 +158,16 @@ func (c *testContext) Teardown() {
 	// Cancel context
 	if c.cancel != nil {
 		c.cancel()
+	}
+
+	// Wait for HTTP server to stop if it was started, with timeout
+	if c.httpDone != nil {
+		select {
+		case <-c.httpDone:
+			// Normal shutdown
+		case <-time.After(5 * time.Second):
+			c.Logger().Warn("Timeout waiting for HTTP service to stop")
+		}
 	}
 
 	// Process exit functions first (e.g., provider.Close) before cleanup functions
@@ -350,6 +362,40 @@ func (c *testContext) SetAPIID(id string) {
 // FireBootComplete returns whether boot complete event should fire
 func (c *testContext) FireBootComplete() bool {
 	return c.fireBootComplete
+}
+
+// ServeHTTP starts the HTTP service in a goroutine and returns immediately.
+// Returns nil if service starts successfully, or an error if the service
+// cannot be found or started. Prevents multiple starts by returning nil
+// if already running.
+func (c *testContext) ServeHTTP() error {
+	httpSvc := c.Service(core.HTTP_SERVICE)
+	if httpSvc == nil {
+		return fmt.Errorf("HTTP service not found in context")
+	}
+
+	httpService, ok := httpSvc.(core.HTTPService)
+	if !ok {
+		return fmt.Errorf("service found but is not core.HTTPService")
+	}
+
+	// Prevent multiple starts
+	if c.httpDone != nil {
+		return fmt.Errorf("HTTP service already running")
+	}
+
+	c.httpDone = make(chan struct{})
+	go func() {
+		defer close(c.httpDone)
+		err := httpService.Serve()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			c.Logger().Error("HTTP service failed", zap.Error(err))
+		} else if err != nil {
+			c.Logger().Debug("HTTP service stopped", zap.Error(err))
+		}
+	}()
+
+	return nil
 }
 
 // SetStartupFuncs sets the startup functions for the context
@@ -639,7 +685,19 @@ func DefaultTestContextOptions(tb TB) ([]TestContextBuilderOption, error) {
 		WithMockAuthService(),
 		WithMockContentScannerService(),
 		WithMockCronService(),
-		WithMockHTTPService(),
+	)
+
+	// Use real HTTP service if enabled, otherwise mock
+	if ShouldSetupHTTP() {
+		opts = append(opts,
+			WithEnvConfigOrDefault("core.port", 0),
+			WithHTTPService(),
+		)
+	} else {
+		opts = append(opts, WithMockHTTPService())
+	}
+
+	opts = append(opts,
 		WithMockHashMappingService(),
 		WithMockMailerService(),
 		WithMockOTPService(),
@@ -713,6 +771,25 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 		if err = StartCron(ctx); err != nil {
 			return fmt.Errorf("Failed to start cron service: %v", err)
 		}
+	}
+
+	// Start HTTP service if enabled
+	if ShouldSetupHTTP() {
+		tctx := ctx.(*testContext)
+		if err = tctx.ServeHTTP(); err != nil {
+			return fmt.Errorf("Failed to start HTTP service: %v", err)
+		}
+		// Register HTTP service stop with tb.Cleanup to ensure LIFO ordering
+		// relative to other cleanup functions
+		tctx.tb.Cleanup(func() {
+			if httpSvc := tctx.Service(core.HTTP_SERVICE); httpSvc != nil {
+				if httpService, ok := httpSvc.(core.HTTPService); ok {
+					if err := httpService.Stop(); err != nil {
+						tctx.Logger().Debug("HTTP service stop error", zap.Error(err))
+					}
+				}
+			}
+		})
 	}
 
 	// Fire boot complete event if enabled

--- a/core/testing/core.go
+++ b/core/testing/core.go
@@ -42,6 +42,8 @@ var (
 	setupMockDBMu     sync.RWMutex
 	setupCron         = false
 	setupCronMu       sync.RWMutex
+	setupHTTP         = false
+	setupHTTPMu       sync.RWMutex
 	testContexts      sync.Map   // map[*testing.T]TestContext
 	testMutex         sync.Mutex // Protects test execution
 )
@@ -51,6 +53,7 @@ type TestMainOpts struct {
 	WithDB         bool
 	DBMigrations   bool
 	WithCron       bool
+	WithHTTP       bool // Enable HTTP service
 	CustomSetup    func()
 	CustomTeardown func()
 }
@@ -66,6 +69,10 @@ func RunTests(m *testing.M, opts TestMainOpts) int {
 
 	if opts.WithCron {
 		EnableCron()
+	}
+
+	if opts.WithHTTP {
+		EnableHTTP()
 	}
 
 	if opts.CustomSetup != nil {
@@ -85,6 +92,10 @@ func RunTests(m *testing.M, opts TestMainOpts) int {
 
 	if opts.WithCron {
 		DisableCron()
+	}
+
+	if opts.WithHTTP {
+		DisableHTTP()
 	}
 
 	// Clear global options at the end of RunTests
@@ -240,9 +251,6 @@ func SetupTestWithDB(t TB) (TestContext, error) {
 
 	// Enable DB migrations
 	EnableDBMigrations()
-	
-	// Ensure migrations are disabled when test finishes
-	t.Cleanup(DisableDBMigrations)
 
 	// Setup test context
 	ctx, err := SetupTest(t)
@@ -264,8 +272,8 @@ func GetTestContext(t TB) (TestContext, error) {
 	return nil, fmt.Errorf("No test context found - did you call SetupTest()?")
 }
 
-// RunTestCase provides a cleaner way to run tests with automatic context setup
-func RunTestCase(t TB, testFunc func(tb TB, ctx TestContext), opts ...TestContextBuilderOption) {
+// runTestCaseInternal is a helper function that contains the common logic for all RunTestCase variants
+func runTestCaseInternal(t TB, testFunc func(tb TB, ctx TestContext), enableDB bool, enableHTTP bool, opts ...TestContextBuilderOption) {
 	t.Helper()
 
 	testMutex.Lock()
@@ -275,19 +283,53 @@ func RunTestCase(t TB, testFunc func(tb TB, ctx TestContext), opts ...TestContex
 	ResetAllState()
 	defer ResetAllState()
 
-	// Phase 1: Registration
-	// Add test case specific options
+	// Enable features as needed
+	if enableDB {
+		EnableDBMigrations()
+	}
+	if enableHTTP {
+		EnableHTTP()
+	}
+
+	// Set up cleanup functions
+	cleanupFuncs := []func(){}
+	if enableDB {
+		cleanupFuncs = append(cleanupFuncs, DisableDBMigrations)
+	}
+	if enableHTTP {
+		cleanupFuncs = append(cleanupFuncs, DisableHTTP)
+	}
+
+	// Register cleanup
+	defer func() {
+		for _, fn := range cleanupFuncs {
+			fn()
+		}
+	}()
+
+	// Add any provided options to the test case collection
 	if len(opts) > 0 {
 		AddTestCaseContextOptions(opts...)
 	}
 
-	// Create test context
-	ctx, err := SetupTest(t)
-	if err != nil {
-		t.Fatalf("Failed to setup test context: %v", err)
+	// Get or create the context
+	var ctx TestContext
+	var err error
+	if enableDB {
+		// Get or create the context (without booting the environment yet)
+		ctx, err = SetupTestWithDB(t)
+		if err != nil {
+			t.Fatalf("Failed to setup test context with DB: %v", err)
+		}
+	} else {
+		// Create test context
+		ctx, err = SetupTest(t)
+		if err != nil {
+			t.Fatalf("Failed to setup test context: %v", err)
+		}
 	}
 
-	// Phases 2 & 3: Configuration & Initialization
+	// Boot the environment
 	if err := BootEnvironment(t, ctx); err != nil {
 		t.Fatalf("Failed to boot test environment: %v", err)
 	}
@@ -296,39 +338,30 @@ func RunTestCase(t TB, testFunc func(tb TB, ctx TestContext), opts ...TestContex
 	testFunc(t, ctx)
 }
 
+// RunTestCase provides a cleaner way to run tests with automatic context setup
+func RunTestCase(t TB, testFunc func(tb TB, ctx TestContext), opts ...TestContextBuilderOption) {
+	t.Helper()
+	runTestCaseInternal(t, testFunc, false, false, opts...)
+}
+
 // RunTestCaseWithDB provides a cleaner way to run tests with automatic context setup and database support
 func RunTestCaseWithDB(t TB, testFunc func(tb TB, ctx TestContext), opts ...TestContextBuilderOption) {
 	t.Helper()
+	runTestCaseInternal(t, testFunc, true, false, opts...)
+}
 
-	testMutex.Lock()
-	defer testMutex.Unlock()
+// RunTestCaseWithHTTP provides a cleaner way to run tests with automatic context setup
+// and HTTP service enabled (no DB)
+func RunTestCaseWithHTTP(t TB, testFunc func(tb TB, ctx TestContext), opts ...TestContextBuilderOption) {
+	t.Helper()
+	runTestCaseInternal(t, testFunc, false, true, opts...)
+}
 
-	// Reset test case state before test
-	ResetAllState()
-	defer ResetAllState()
-
-	EnableDBMigrations()
-	defer DisableDBMigrations()
-
-	// Add any provided options to the test case collection
-	if len(opts) > 0 {
-		AddTestCaseContextOptions(opts...)
-	}
-
-	// Get or create the context (without booting the environment yet)
-	ctx, err := SetupTestWithDB(t)
-	if err != nil {
-		t.Fatalf("Failed to setup test context with DB: %v", err)
-	}
-
-	// Boot the environment *after* the context is stored and before running the test function
-	if err := BootEnvironment(t, ctx); err != nil {
-		t.Fatalf("Failed to boot test environment: %v", err)
-	}
-
-	testFunc(t, ctx)
-
-	// Test case options are cleared by deferred ResetAllState
+// RunTestCaseWithDBAndHTTP provides a cleaner way to run tests with automatic context setup,
+// database support, and HTTP service enabled
+func RunTestCaseWithDBAndHTTP(t TB, testFunc func(tb TB, ctx TestContext), opts ...TestContextBuilderOption) {
+	t.Helper()
+	runTestCaseInternal(t, testFunc, true, true, opts...)
 }
 
 // ResetAllState resets all global state in the core package and testing package
@@ -340,8 +373,8 @@ func ResetAllState() {
 	// Reset testing state (only clears test case specific options)
 	ClearTestCaseContextOptions()
 
-	// Note: We intentionally don't reset runDBMigrations/setupMockDB here
-	// as these are package-level settings that should persist across tests
+	// Note: We intentionally don't reset runDBMigrations/setupMockDB/setupCron/setupHTTP here
+	// as these package-level settings should persist across tests within a suite.
 	// They are only reset when TestMain completes
 }
 
@@ -389,6 +422,27 @@ func DisableCron() {
 	setupCronMu.Lock()
 	defer setupCronMu.Unlock()
 	setupCron = false
+}
+
+// EnableHTTP enables HTTP service startup during test context initialization
+func EnableHTTP() {
+	setupHTTPMu.Lock()
+	defer setupHTTPMu.Unlock()
+	setupHTTP = true
+}
+
+// DisableHTTP disables HTTP service startup during test context initialization
+func DisableHTTP() {
+	setupHTTPMu.Lock()
+	defer setupHTTPMu.Unlock()
+	setupHTTP = false
+}
+
+// ShouldSetupHTTP returns whether HTTP service should be started
+func ShouldSetupHTTP() bool {
+	setupHTTPMu.RLock()
+	defer setupHTTPMu.RUnlock()
+	return setupHTTP
 }
 
 // ShouldSetupCron returns whether cron service should be started

--- a/service/http.go
+++ b/service/http.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -22,6 +23,7 @@ import (
 	"path"
 	"strconv"
 	"sync"
+	"time"
 
 	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/core"
@@ -77,6 +79,8 @@ type HTTPServiceDefault struct {
 	fsCache       sync.Map // Cache for bundle filesystems
 	globalPaths   []string
 	globalPathsMu sync.RWMutex
+	wg            sync.WaitGroup
+	stopOnce      sync.Once
 }
 
 func NewHTTPService() (core.Service, []core.ContextBuilderOption, error) {
@@ -108,7 +112,7 @@ func NewHTTPService() (core.Service, []core.ContextBuilderOption, error) {
 			return nil
 		}),
 		core.ContextWithExitFunc(func(ctx core.Context) error {
-			return srv.Shutdown(ctx)
+			return _http.Stop()
 		}),
 	)
 
@@ -459,24 +463,38 @@ func (h *HTTPServiceDefault) apiPluginWebBundleFileServerHandler(e echo.Context)
 }
 
 func (h *HTTPServiceDefault) Serve() error {
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
 	ln, err := net.Listen("tcp", h.srv.Addr)
 	if err != nil {
 		return err
 	}
 
+	h.wg.Add(1)
 	go func() {
-		defer wg.Done()
+		defer h.wg.Done()
 		err := h.srv.Serve(ln)
 		if err != nil && err != http.ErrServerClosed {
 			h.logger.Fatal("Failed to serve", zap.Error(err))
 		}
 	}()
 
-	wg.Wait()
 	return nil
+}
+
+func (h *HTTPServiceDefault) Stop() error {
+	var err error
+	h.stopOnce.Do(func() {
+		if h.srv == nil {
+			return // Already stopped or never started
+		}
+
+		// Use fresh context with timeout for shutdown
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		err = h.srv.Shutdown(timeoutCtx)
+		h.wg.Wait() // Wait for server goroutine to complete
+	})
+	return err
 }
 
 func (h *HTTPServiceDefault) RegisterGlobalPath(path string) error {


### PR DESCRIPTION
- Added HTTP service management functions (EnableHTTP/DisableHTTP/ShouldSetupHTTP)
- Implemented ServeHTTP method in testContext to start HTTP service
- Added RunTestCaseWithDBAndHTTP helper function
- Enhanced BootEnvironment to handle HTTP service startup/teardown
- Added Stop method to HTTPService interface and implemented proper shutdown in HTTPServiceDefault
- Improved test context cleanup to wait for HTTP server shutdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Coordinated, idempotent shutdown for the HTTP service and a public Stop operation.
  - Optional HTTP startup in the test harness and a new test entry to run with both DB and HTTP enabled.

- Bug Fixes
  - Ignore empty environment-variable names when building test configs and align default values with resolved env vars.

- Tests
  - Test harness now starts/stops HTTP services cleanly, waits for shutdown during teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->