### PR TITLE
feat(http, testing): add Port() method to HTTPService interface and implementations

### DIFF
--- a/core/http.go
+++ b/core/http.go
@@ -13,6 +13,7 @@ type HTTPService interface {
 	Stop() error
 	APISubdomain(id string, proto bool) string
 	RegisterGlobalPath(path string) error
+	Port() uint16
 
 	Service
 }

--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -393,6 +393,14 @@ func (c *testContext) ServeHTTP() error {
 		} else if err != nil {
 			c.Logger().Debug("HTTP service stopped", zap.Error(err))
 		}
+		
+		// Update config with actual port after server starts
+		port := httpService.Port()
+		if port > 0 {
+			if err := c.Config().Set(c, "core.port", port); err != nil {
+				c.Logger().Error("Failed to update config with live port", zap.Error(err))
+			}
+		}
 	}()
 
 	return nil

--- a/core/testing/mocks/HTTPService.go
+++ b/core/testing/mocks/HTTPService.go
@@ -181,6 +181,50 @@ func (_c *MockHTTPService_Init_Call) RunAndReturn(run func() error) *MockHTTPSer
 	return _c
 }
 
+// Port provides a mock function for the type MockHTTPService
+func (_mock *MockHTTPService) Port() uint16 {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Port")
+	}
+
+	var r0 uint16
+	if returnFunc, ok := ret.Get(0).(func() uint16); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(uint16)
+	}
+	return r0
+}
+
+// MockHTTPService_Port_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Port'
+type MockHTTPService_Port_Call struct {
+	*mock.Call
+}
+
+// Port is a helper method to define mock.On call
+func (_e *MockHTTPService_Expecter) Port() *MockHTTPService_Port_Call {
+	return &MockHTTPService_Port_Call{Call: _e.mock.On("Port")}
+}
+
+func (_c *MockHTTPService_Port_Call) Run(run func()) *MockHTTPService_Port_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockHTTPService_Port_Call) Return(v uint16) *MockHTTPService_Port_Call {
+	_c.Call.Return(v)
+	return _c
+}
+
+func (_c *MockHTTPService_Port_Call) RunAndReturn(run func() uint16) *MockHTTPService_Port_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RegisterGlobalPath provides a mock function for the type MockHTTPService
 func (_mock *MockHTTPService) RegisterGlobalPath(path string) error {
 	ret := _mock.Called(path)

--- a/service/http.go
+++ b/service/http.go
@@ -497,6 +497,12 @@ func (h *HTTPServiceDefault) Stop() error {
 	return err
 }
 
+func (h *HTTPServiceDefault) Port() uint16 {
+	portStr := strings.TrimPrefix(h.srv.Addr, ":")
+	port, _ := strconv.ParseUint(portStr, 10, 16)
+	return uint16(port)
+}
+
 func (h *HTTPServiceDefault) RegisterGlobalPath(path string) error {
 	h.globalPathsMu.Lock()
 	defer h.globalPathsMu.Unlock()


### PR DESCRIPTION
- Added Port() method to HTTPService interface
- Implemented Port() in HTTPServiceDefault
- Added mock implementation for testing
- Updated test context to store live port in config