### PR TITLE
fix(testing): add delay before port config update and ensure HTTP service wait

### DIFF
--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -393,15 +393,17 @@ func (c *testContext) ServeHTTP() error {
 		} else if err != nil {
 			c.Logger().Debug("HTTP service stopped", zap.Error(err))
 		}
-		
-		// Update config with actual port after server starts
-		port := httpService.Port()
-		if port > 0 {
-			if err := c.Config().Set(c, "core.port", port); err != nil {
-				c.Logger().Error("Failed to update config with live port", zap.Error(err))
-			}
-		}
 	}()
+
+	time.Sleep(time.Second)
+
+	// Update config with actual port after server starts
+	port := httpService.Port()
+	if port > 0 {
+		if err := c.Config().Set(c, "core.port", port); err != nil {
+			c.Logger().Error("Failed to update config with live port", zap.Error(err))
+		}
+	}
 
 	return nil
 }

--- a/service/http.go
+++ b/service/http.go
@@ -207,7 +207,7 @@ func (h *HTTPServiceDefault) Init() error {
 		router.GetRouter(hostRouter).OPTIONS("/api/*", func(c echo.Context) error {
 			return c.NoContent(http.StatusOK)
 		}, echo.WrapMiddleware(cors.NewWithDefaults(corsCfg)))
-		
+
 		if apiInfo != nil {
 			// Generate and expose the OpenAPI spec for this API's router
 			if err = hostRouter.GenerateAndExposeOpenapi(); err != nil {
@@ -477,6 +477,7 @@ func (h *HTTPServiceDefault) Serve() error {
 		}
 	}()
 
+	h.wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
- Added 1-second delay before updating config with live port in test context
- Ensured HTTP service waits for completion with wg.Wait()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Live HTTP port is now applied to configuration shortly after startup, improving accuracy for components that rely on it.
  - Server lifecycle handling now waits for the server to exit, reducing race conditions during shutdown and restart.
- Refactor
  - Adjusted startup timing and control flow for more predictable server behavior; no public API changes.
- Style
  - Minor whitespace cleanup with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->