### PR TITLE
refactor(testing): reorganize component registration in BootEnvironment

### DIFF
--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -729,33 +729,52 @@ func DefaultTestContextOptions(tb TB) ([]TestContextBuilderOption, error) {
 // BootEnvironment initializes the test environment by processing all context options,
 // running startup functions, configuring services, and setting up APIs.
 func BootEnvironment(tb TB, ctx TestContext) error {
-	// Phase 1: Registration
+	// Phase 1: Context Setup
 	// Initialize context with all options (default, global, and test case specific)
 	if err := InitContext(tb, ctx); err != nil {
 		return fmt.Errorf("context initialization failed: %w", err)
 	}
 
-	core.RegisterServicesFromPlugins()
-
-	if err := ConfigurePluginServices(ctx); err != nil {
-		return fmt.Errorf("service configuration failed: %w", err)
+	// Phase 2: Component Registration
+	// Register components (APIs, protocols, extensions) and their context options
+	componentOpts, err := RegisterComponents(ctx)
+	if err != nil {
+		return fmt.Errorf("component registration failed: %w", err)
 	}
 
-	// Phase 2: Configuration
+	// Process component options
+	ctx, err = ProcessCtxOptions(ctx, componentOpts...)
+	if err != nil {
+		return fmt.Errorf("processing component options failed: %w", err)
+	}
+
+	// Register any services from plugins
+	core.RegisterServicesFromPlugins()
+	newCtx, err := ConfigurePluginServices(ctx)
+	if err != nil {
+		return fmt.Errorf("service registration failed: %w", err)
+	}
+	ctx = newCtx
+
+	// Phase 3: Component Configuration
+	// Configure protocols (no initialization)
 	if err := ConfigureProtocols(ctx); err != nil {
 		return fmt.Errorf("protocol configuration failed: %w", err)
 	}
 
+	// Configure APIs and collect their initialization options
 	apiOpts, err := ConfigureAPIs(ctx)
 	if err != nil {
 		return fmt.Errorf("API configuration failed: %w", err)
 	}
 
+	// Configure services
 	if err = ConfigureServices(ctx); err != nil {
 		return fmt.Errorf("service configuration failed: %w", err)
 	}
 
-	// Phase 3: Initialization
+	// Phase 4: Component Initialization
+	// Process API initialization options
 	var newCtx TestContext
 	if newCtx, err = ProcessCtxOptions(ctx, apiOpts...); err != nil {
 		return fmt.Errorf("API initialization failed: %w", err)
@@ -769,6 +788,11 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 
 	if err = ConfigureAPIRoutes(ctx); err != nil {
 		return fmt.Errorf("API route configuration failed: %w", err)
+	}
+
+	// Initialize protocols
+	if err := InitializeProtocols(ctx); err != nil {
+		return err
 	}
 
 	// Register workflows from all protocols
@@ -816,24 +840,24 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 // It iterates through all registered services, filters for those associated with plugins,
 // creates service instances using their factories, applies any context options they return,
 // and registers them in the test context.
-func ConfigurePluginServices(ctx TestContext) error {
+func ConfigurePluginServices(ctx TestContext) (TestContext, error) {
 	for _, svcInfo := range core.Unsafe_GetServiceMap() {
 		plugin := core.GetPluginForService(svcInfo.ID)
 		if plugin != "" {
 			ctxOpts, err := RegisterService(ctx, svcInfo.ID, svcInfo.Factory, plugin)
 			if err != nil {
-				return err
+				return ctx, err
 			}
 
 			newCtx, err := ProcessCtxOptions(ctx, ctxOpts...)
 			if err != nil {
-				return err
+				return ctx, err
 			}
 			ctx = newCtx
 		}
 	}
 
-	return nil
+	return ctx, nil
 }
 
 // StartCron starts the cron service if enabled

--- a/core/testing/plugin.go
+++ b/core/testing/plugin.go
@@ -120,6 +120,32 @@ func WithAPIExtension(extFactory core.APIExtensionFactory) TestContextBuilderOpt
 	}
 }
 
+// RegisterAPIs registers all APIs from plugins similar to portal's registerAPIs
+func RegisterAPIs(ctx TestContext) ([]TestContextBuilderOption, error) {
+	var opts []TestContextBuilderOption
+
+	for _, plugin := range core.GetPlugins() {
+		if core.PluginHasAPI(plugin) {
+			api, apiOpts, err := plugin.API()
+			if err != nil {
+				ctx.Logger().Error("Error building API", 
+					zap.String("plugin", plugin.ID), 
+					zap.Error(err))
+				return nil, err
+			}
+
+			if api == nil {
+				continue
+			}
+
+			opts = append(opts, WrapCoreOptions(apiOpts)...)
+			core.RegisterAPI(plugin.ID, api)
+		}
+	}
+
+	return opts, nil
+}
+
 // RegisterAPI registers an API and wraps any returned context options for test context
 func RegisterAPI(ctx TestContext, id string, factory core.APIFactory) (ctxOpts []TestContextBuilderOption, err error) {
 	api, opts, err := factory()
@@ -136,6 +162,46 @@ func RegisterAPI(ctx TestContext, id string, factory core.APIFactory) (ctxOpts [
 
 	core.RegisterAPI(id, api)
 	return WrapCoreOptions(opts), nil
+}
+
+// RegisterAPIExtensions registers all API extensions from plugins similar to portal's registerAPIExtensions
+func RegisterAPIExtensions(ctx TestContext) ([]TestContextBuilderOption, error) {
+	var opts []TestContextBuilderOption
+
+	for _, plugin := range core.GetPlugins() {
+		if core.PluginHasAPIExtensions(plugin) {
+			extensions, err := plugin.APIExtensions(ctx)
+			if err != nil {
+				ctx.Logger().Error("Error building API extensions",
+					zap.String("plugin", plugin.ID),
+					zap.Error(err))
+				return nil, err
+			}
+
+			for _, extFactory := range extensions {
+				factory := extFactory
+				apiExtStartup := TestContextBuilderOption(func(tctx TestContext) (TestContext, error) {
+					ext, ctxOpts, err := factory()
+					if err != nil {
+						tctx.Logger().Error("Error building API extension",
+							zap.String("plugin", plugin.ID),
+							zap.Error(err))
+						return tctx, err
+					}
+
+					tctx.Logger().Info("Registering API extension",
+						zap.String("plugin", plugin.ID),
+						zap.String("target", ext.TargetAPI()))
+					core.RegisterAPIExtension(ext)
+
+					return ProcessCtxOptions(tctx, WrapCoreOptions(ctxOpts)...)
+				})
+				opts = append(opts, apiExtStartup)
+			}
+		}
+	}
+
+	return opts, nil
 }
 
 // RegisterAPIExtension registers API extensions and wraps any returned context options
@@ -177,6 +243,32 @@ func RegisterAPIExtension(ctx TestContext, factory core.APIExtensionsFactory) (c
 	return ctxOpts, nil
 }
 
+// RegisterProtocols registers all protocols from plugins similar to portal's registerProtocols
+func RegisterProtocols(ctx TestContext) ([]TestContextBuilderOption, error) {
+	var opts []TestContextBuilderOption
+
+	for _, plugin := range core.GetPlugins() {
+		if core.PluginHasProtocol(plugin) {
+			proto, protoOpts, err := plugin.Protocol()
+			if err != nil {
+				ctx.Logger().Error("Error building protocol",
+					zap.String("plugin", plugin.ID),
+					zap.Error(err))
+				return nil, err
+			}
+
+			if proto == nil {
+				continue
+			}
+
+			opts = append(opts, WrapCoreOptions(protoOpts)...)
+			core.RegisterProtocol(plugin.ID, proto)
+		}
+	}
+
+	return opts, nil
+}
+
 // RegisterProtocol registers a Protocol and wraps any returned context options for test context
 func RegisterProtocol(ctx TestContext, id string, factory core.ProtocolFactory) (ctxOpts []TestContextBuilderOption, err error) {
 	proto, opts, err := factory()
@@ -195,8 +287,8 @@ func RegisterProtocol(ctx TestContext, id string, factory core.ProtocolFactory) 
 	return WrapCoreOptions(opts), nil
 }
 
-// ConfigureProtocols configures all registered protocols. Unlike ConfigureAPIs,
-// protocols don't return context options during initialization.
+// ConfigureProtocols configures all registered protocols with their respective configs.
+// This only handles configuration - initialization is handled separately by InitializeProtocols.
 func ConfigureProtocols(ctx TestContext) error {
 	for name, proto := range core.GetProtocols() {
 		// Configure protocol through config manager
@@ -208,16 +300,6 @@ func ConfigureProtocols(ctx TestContext) error {
 			return err
 		}
 
-		// Initialize protocol if it implements ProtocolInit
-		if initProto, ok := proto.(core.ProtocolInit); ok {
-			err = initProto.Init(ctx)
-			if err != nil {
-				ctx.Logger().Error("Error initializing protocol",
-					zap.String("protocol", proto.Name()),
-					zap.Error(err))
-				return err
-			}
-		}
 	}
 
 	return nil
@@ -419,6 +501,48 @@ func ConfigureAPIRoutes(ctx TestContext) error {
 		}
 	}
 
+	return nil
+}
+
+// RegisterComponents registers APIs, protocols and extensions similar to portal boot process
+func RegisterComponents(ctx TestContext) ([]TestContextBuilderOption, error) {
+	var opts []TestContextBuilderOption
+
+	// Register components
+	apiOpts, err := RegisterAPIs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, apiOpts...)
+
+	protoOpts, err := RegisterProtocols(ctx)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, protoOpts...)
+
+	extOpts, err := RegisterAPIExtensions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, extOpts...)
+
+	return opts, nil
+}
+
+// InitializeProtocols initializes all registered protocols that implement ProtocolInit.
+// This is called after ConfigureProtocols has configured all protocols.
+func InitializeProtocols(ctx TestContext) error {
+	for _, proto := range core.GetProtocols() {
+		if initProto, ok := proto.(core.ProtocolInit); ok {
+			if err := initProto.Init(ctx); err != nil {
+				ctx.Logger().Error("Error initializing protocol",
+					zap.String("protocol", proto.Name()),
+					zap.Error(err))
+				return fmt.Errorf("protocol initialization failed: %w", err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/core/testing/plugin.go
+++ b/core/testing/plugin.go
@@ -189,6 +189,13 @@ func RegisterAPIExtensions(ctx TestContext) ([]TestContextBuilderOption, error) 
 						return tctx, err
 					}
 
+					if ext == nil {
+						err := fmt.Errorf("API extension factory returned nil extension for plugin %s", plugin.ID)
+						tctx.Logger().Error(err.Error(),
+							zap.String("plugin", plugin.ID))
+						return tctx, err
+					}
+
 					tctx.Logger().Info("Registering API extension",
 						zap.String("plugin", plugin.ID),
 						zap.String("target", ext.TargetAPI()))


### PR DESCRIPTION
- Added explicit component registration phase before plugin services
- Extracted RegisterComponents helper to consolidate API/protocol/extensions registration
- Added InitializeProtocols helper for protocol initialization
- Added new helper functions for registering APIs, protocols and extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatic registration and configuration of APIs, API extensions, protocols, and other components during test boot.
  - Optionally start cron and HTTP services during test boots; HTTP startup updates live port and registers cleanup.
  - Test helpers to register/unregister plugins and services for isolated setups.

- **Improvements**
  - Clearer lifecycle: separate configuration, initialization, route setup, and startup phases.
  - Improved error reporting and logging across component, API, protocol, and service setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->