### PR TITLE
refactor(http): include port in host router domain registration

### DIFF
--- a/service/http.go
+++ b/service/http.go
@@ -147,10 +147,10 @@ func (h *HTTPServiceDefault) Init() error {
 	h.srv.Addr = ":" + strconv.FormatUint(uint64(h.ctx.Config().Config().Core.Port), 10)
 	for _, api := range core.GetAPIs() {
 		subdomain := api.Subdomain()
-		domain := fmt.Sprintf("%s.%s", api.Subdomain(), h.ctx.Config().Config().Core.Domain)
+		domain := fmt.Sprintf("%s.%s:%d", api.Subdomain(), h.ctx.Config().Config().Core.Domain, h.ctx.Config().Config().Core.Port)
 
 		if subdomain == "" {
-			domain = h.ctx.Config().Config().Core.Domain
+			domain = fmt.Sprintf("%s:%d", h.ctx.Config().Config().Core.Domain, h.ctx.Config().Config().Core.Port)
 		}
 
 		// Create a gswagger router wrapping the mux subrouter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hostname handling now consistently includes port numbers, ensuring API routes resolve correctly on custom or non-default ports.
  * Improves routing reliability across local, staging, and production environments, including setups behind proxies.
  * No changes to public APIs or user-facing configuration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->