### PR TITLE
feat(core, testing): add error namespace import/export functionality

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -5,6 +5,8 @@ import (
 	router "go.lumeweb.com/portal-router"
 	"net/http"
 	"sync"
+
+	"github.com/samber/lo"
 )
 
 const (
@@ -28,11 +30,6 @@ type ErrorRegistry struct {
 	namespaces map[string]ErrorNamespace // Namespace -> ErrorNamespace
 }
 
-// ErrorNamespace holds the error definitions and HTTP status codes for a namespace.
-type ErrorNamespace struct {
-	errorDefinitions map[ErrorType]ErrorDefinition
-	errorCodes       map[ErrorType]int
-}
 
 // ErrorDefinition holds the data associated with an error type.  It no longer contains the HttpStatus.
 type ErrorDefinition struct {
@@ -58,6 +55,11 @@ func (e *Error) Error() string {
 	return e.Message
 }
 
+// Unwrap enables errors.Is/As to traverse the underlying cause.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
 // HttpStatus implements the router.ResponseError interface.
 func (e *Error) HttpStatus() int {
 	errorRegistryMu.RLock()
@@ -78,11 +80,88 @@ func (e *Error) IsErrorType(errType ErrorType) bool {
 	return e.Key == errType
 }
 
+// ErrorNamespace contains all exported error namespace data
+type ErrorNamespace struct {
+	Definitions map[ErrorType]ErrorDefinition
+	Codes       map[ErrorType]int
+}
+
+// ErrorNamespaces is a map of namespace names to their ErrorNamespace data
+type ErrorNamespaces map[string]ErrorNamespace
+
 // NewErrorRegistry creates a new ErrorRegistry.
 func NewErrorRegistry() *ErrorRegistry {
 	return &ErrorRegistry{
-		namespaces: make(map[string]ErrorNamespace),
+		namespaces: make(map[string]ErrorNamespace), 
 	}
+}
+
+// ExportAllNamespaces exports all registered error namespaces with their error definitions and codes
+func (r *ErrorRegistry) ExportAllNamespaces() ErrorNamespaces {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return lo.MapValues(r.namespaces, func(ns ErrorNamespace, _ string) ErrorNamespace {
+		// Deep copy Definitions map
+		defsCopy := lo.MapValues(ns.Definitions, func(def ErrorDefinition, _ ErrorType) ErrorDefinition {
+			return ErrorDefinition{
+				Key:         def.Key,
+				Message:     def.Message,
+				DefaultArgs: append([]any(nil), def.DefaultArgs...), // Deep copy slice
+			}
+		})
+
+		// Deep copy Codes map
+		codesCopy := lo.MapValues(ns.Codes, func(code int, _ ErrorType) int {
+			return code
+		})
+
+		return ErrorNamespace{
+			Definitions: defsCopy,
+			Codes:       codesCopy,
+		}
+	})
+}
+
+// ImportNamespaces imports error namespaces with their error definitions and codes.
+// Any existing definitions/codes for the same keys will be silently overwritten.
+// Returns nil on success or an error if the import fails.
+func (r *ErrorRegistry) ImportNamespaces(importData ErrorNamespaces) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for nsName, data := range importData {
+		// Get existing namespace or create new one
+		ns, exists := r.namespaces[nsName]
+		if !exists {
+			ns = ErrorNamespace{
+				Definitions: make(map[ErrorType]ErrorDefinition),
+				Codes:       make(map[ErrorType]int),
+			}
+		} else {
+			// Ensure existing maps are initialized
+			if ns.Definitions == nil {
+				ns.Definitions = make(map[ErrorType]ErrorDefinition)
+			}
+			if ns.Codes == nil {
+				ns.Codes = make(map[ErrorType]int)
+			}
+		}
+
+		// Copy definitions
+		for key, def := range data.Definitions {
+			ns.Definitions[key] = def
+		}
+		
+		// Copy codes
+		for key, code := range data.Codes {
+			ns.Codes[key] = code
+		}
+
+		// Store the updated namespace
+		r.namespaces[nsName] = ns
+	}
+	return nil
 }
 
 // RegisterNamespace creates a new namespace in the registry.
@@ -95,8 +174,8 @@ func (r *ErrorRegistry) RegisterNamespace(namespace string) error {
 	}
 
 	r.namespaces[namespace] = ErrorNamespace{
-		errorDefinitions: make(map[ErrorType]ErrorDefinition),
-		errorCodes:       make(map[ErrorType]int),
+		Definitions: make(map[ErrorType]ErrorDefinition),
+		Codes:       make(map[ErrorType]int),
 	}
 	return nil
 }
@@ -112,10 +191,15 @@ func (r *ErrorRegistry) RegisterDefaultErrorMessages(namespace string, errorMap 
 	}
 
 	for key, def := range errorMap {
-		if _, exists := ns.errorDefinitions[key]; exists {
+		if def.Key == "" {
+			def.Key = key
+		} else if def.Key != key {
+			return fmt.Errorf("definition key mismatch: map key=%q def.Key=%q in namespace %q", key, def.Key, namespace)
+		}
+		if _, exists := ns.Definitions[key]; exists {
 			return fmt.Errorf("error type '%s' already exists in namespace '%s'", key, namespace)
 		}
-		ns.errorDefinitions[key] = def
+		ns.Definitions[key] = def
 	}
 
 	return nil
@@ -132,10 +216,13 @@ func (r *ErrorRegistry) RegisterErrorCodes(namespace string, errorCodeMap map[Er
 	}
 
 	for key, code := range errorCodeMap {
-		if _, exists := ns.errorCodes[key]; exists {
+		if code < 100 || code > 599 {
+			return fmt.Errorf("invalid HTTP status code %d for type '%s' in namespace '%s'", code, key, namespace)
+		}
+		if _, exists := ns.Codes[key]; exists {
 			return fmt.Errorf("error code for type '%s' already exists in namespace '%s'", key, namespace)
 		}
-		ns.errorCodes[key] = code
+		ns.Codes[key] = code
 	}
 
 	return nil
@@ -151,7 +238,7 @@ func (r *ErrorRegistry) GetErrorDefinition(namespace string, key ErrorType) (Err
 		return ErrorDefinition{}, false
 	}
 
-	def, exists := ns.errorDefinitions[key]
+	def, exists := ns.Definitions[key]
 	return def, exists
 }
 
@@ -165,7 +252,7 @@ func (r *ErrorRegistry) GetErrorCode(namespace string, key ErrorType) (int, bool
 		return 0, false
 	}
 
-	code, exists := ns.errorCodes[key]
+	code, exists := ns.Codes[key]
 	if !exists {
 		return http.StatusInternalServerError, false
 	}
@@ -275,6 +362,36 @@ func ResetErrorRegistry() {
 	errorRegistryMu.Lock()
 	defer errorRegistryMu.Unlock()
 	errorRegistry = NewErrorRegistry()
+}
+
+// ReplaceAllErrorNamespaces replaces all error namespaces with the provided ones
+func ReplaceAllErrorNamespaces(namespaces ErrorNamespaces) error {
+	errorRegistryMu.Lock()
+	defer errorRegistryMu.Unlock()
+	
+	// Create new registry and import namespaces
+	newRegistry := NewErrorRegistry()
+	if err := newRegistry.ImportNamespaces(namespaces); err != nil {
+		return err
+	}
+	
+	// Atomically replace the registry
+	errorRegistry = newRegistry
+	return nil
+}
+
+// ExportAllErrorNamespaces exports all error namespaces from the global error registry
+func ExportAllErrorNamespaces() ErrorNamespaces {
+	errorRegistryMu.RLock()
+	defer errorRegistryMu.RUnlock()
+	return errorRegistry.ExportAllNamespaces()
+}
+
+// ImportErrorNamespaces imports error namespaces into the global error registry
+func ImportErrorNamespaces(importData ErrorNamespaces) error {
+	errorRegistryMu.Lock()
+	defer errorRegistryMu.Unlock()
+	return errorRegistry.ImportNamespaces(importData)
 }
 
 // NewError creates a new Error instance using the global error registry.

--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -574,7 +574,7 @@ func ProcessExitFuncs(ctx TestContext) error {
 // This function's role is now primarily to process options and run startup funcs.
 func InitContext(tb TB, ctx TestContext) error {
 	// Get all globally registered test options
-	allOpts, err := GetCombinedTestContextOptions(tb)
+	allOpts, err := GetCombinedTestContextOptions()
 	if err != nil {
 		return err
 	}
@@ -668,7 +668,7 @@ func WithCoreEvents() TestContextBuilderOption {
 
 // DefaultTestContextOptions returns the default options used for new test contexts.
 // These include mock implementations of common core services.
-func DefaultTestContextOptions(tb TB) ([]TestContextBuilderOption, error) {
+func DefaultTestContextOptions() ([]TestContextBuilderOption, error) {
 	_router, err := router.NewRouter(router.APIInfo().Title("Test API").Version("1.0.0"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create test router: %w", err)
@@ -678,6 +678,7 @@ func DefaultTestContextOptions(tb TB) ([]TestContextBuilderOption, error) {
 		WithEnvConfigOrDefault("core.domain", "", "test.local"),
 		WithRandomSeedPhrase(),
 		WithCoreEvents(),
+		WithErrorNamespaces(core.ExportAllErrorNamespaces()),
 	}
 
 	// Add DB setup first if enabled
@@ -731,25 +732,25 @@ func DefaultTestContextOptions(tb TB) ([]TestContextBuilderOption, error) {
 // proper initialization order and dependency resolution.
 //
 // The phases are:
-// 1. Context Initialization - Processes all context builder options (default, global and test case specific)
-//    Establishes the base context with core services and configuration
-// 2. Component Registration - Registers all components (services, APIs, protocols and extensions)
-//    Note: Service options are collected but not processed yet to allow proper ordering
-// 3. Plugin Service Registration - Registers and configures services from plugins
-//    Collects any context options they return
-// 4. Component Configuration - Configures services and protocols with their respective configs
-//    Note: APIs are configured separately in Phase 5 to ensure services are ready first
-// 5. API Configuration - Configures APIs and processes their initialization options
-//    This must complete before service options are processed (Phase 6)
-// 6. Service Option Processing - Combines all service options (main + plugin services)
-//    Processes them now that APIs are fully initialized
-// 7. Startup Functions - Runs any startup functions added during initialization
-// 8. Service Initialization - Initializes services after configuration but before API route setup
-// 9. API Route Configuration - Configures API routes after all components are initialized
-//    Applies any registered extensions using the same router
-// 10. Protocol Initialization - Initializes protocols and registers their workflows
-// 11. Protocol Workflow Configuration - Registers workflows from all protocols
-// 12. Runtime Setup - Starts cron/HTTP services if enabled and fires boot complete event
+//  1. Context Initialization - Processes all context builder options (default, global and test case specific)
+//     Establishes the base context with core services and configuration
+//  2. Component Registration - Registers all components (services, APIs, protocols and extensions)
+//     Note: Service options are collected but not processed yet to allow proper ordering
+//  3. Plugin Service Registration - Registers and configures services from plugins
+//     Collects any context options they return
+//  4. Component Configuration - Configures services and protocols with their respective configs
+//     Note: APIs are configured separately in Phase 5 to ensure services are ready first
+//  5. API Configuration - Configures APIs and processes their initialization options
+//     This must complete before service options are processed (Phase 6)
+//  6. Service Option Processing - Combines all service options (main + plugin services)
+//     Processes them now that APIs are fully initialized
+//  7. Startup Functions - Runs any startup functions added during initialization
+//  8. Service Initialization - Initializes services after configuration but before API route setup
+//  9. API Route Configuration - Configures API routes after all components are initialized
+//     Applies any registered extensions using the same router
+//  10. Protocol Initialization - Initializes protocols and registers their workflows
+//  11. Protocol Workflow Configuration - Registers workflows from all protocols
+//  12. Runtime Setup - Starts cron/HTTP services if enabled and fires boot complete event
 //     Note: HTTP service is started in a goroutine and registered for cleanup
 //
 // The function returns nil on success, or an error if any phase fails. Errors include detailed

--- a/core/testing/core.go
+++ b/core/testing/core.go
@@ -178,14 +178,14 @@ func AddTestCaseContextOptions(opts ...TestContextBuilderOption) {
 // 1. Default options
 // 2. Global options (from RunTests)
 // 3. Test case options (from RunTestCase)
-func GetCombinedTestContextOptions(tb TB) ([]TestContextBuilderOption, error) {
+func GetCombinedTestContextOptions() ([]TestContextBuilderOption, error) {
 	globalTestCtxOptsMu.RLock()
 	defer globalTestCtxOptsMu.RUnlock()
 	testCaseCtxOptsMu.RLock()
 	defer testCaseCtxOptsMu.RUnlock()
 
 	// Get defaults first
-	defaultOpts, err := DefaultTestContextOptions(tb)
+	defaultOpts, err := DefaultTestContextOptions()
 	if err != nil {
 		return nil, err
 	}

--- a/core/testing/helpers.go
+++ b/core/testing/helpers.go
@@ -49,7 +49,7 @@ func SetupTestEnvironment(tb TB) (TestContext, error) {
 	}
 
 	// Process all options (defaults + global + test case)
-	options, err := GetCombinedTestContextOptions(tb)
+	options, err := GetCombinedTestContextOptions()
 	if err != nil {
 		return ctx, fmt.Errorf("failed to get combined test context options: %w", err)
 	}

--- a/core/testing/plugin.go
+++ b/core/testing/plugin.go
@@ -603,6 +603,37 @@ func ConfigureProtocolWorkflows(ctx core.Context) error {
 	return nil
 }
 
+// WithErrorNamespaces imports error namespaces into the global error registry transactionally.
+// The imported namespaces are removed when the test context is cleaned up.
+func WithErrorNamespaces(namespaces core.ErrorNamespaces) TestContextBuilderOption {
+	return func(ctx TestContext) (TestContext, error) {
+		if namespaces == nil {
+			return ctx, nil
+		}
+
+		// Track which namespaces we're adding
+		addedNamespaces := lo.Keys(namespaces)
+
+		// Import new namespaces
+		if err := core.ImportErrorNamespaces(namespaces); err != nil {
+			return ctx, fmt.Errorf("failed to import error namespaces: %w", err)
+		}
+
+		// Register cleanup to remove the namespaces we added
+		ctx.RegisterCleanup(func() error {
+			errorRegistryMu.Lock()
+			defer errorRegistryMu.Unlock()
+			
+			lo.ForEach(addedNamespaces, func(ns string, _ int) {
+				delete(errorRegistry.namespaces, ns)
+			})
+			return nil
+		})
+
+		return ctx, nil
+	}
+}
+
 // WithPlugins registers multiple plugins for testing
 func WithPlugins(plugins ...core.PluginInfo) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {


### PR DESCRIPTION
- Added ErrorNamespace and ErrorNamespaces types for structured error data
- Implemented ExportAllNamespaces and ImportNamespaces methods in ErrorRegistry
- Added global ExportAllErrorNamespaces and ImportErrorNamespaces functions
- Included WithErrorNamespaces test context option for error namespace handling
- Removed redundant TB parameter from test context option functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Global export/import and atomic replace for error namespaces; public snapshot/restore type for namespaces and a public error-creation API that handles unknown keys and default args.
  - Test-context option to preload/import error namespaces during setup.

- **Bug Fixes**
  - Plugin/test harness registration is panic-safe and supports full rollback/cleanup on failure.

- **Refactor**
  - Simplified test-context APIs and defaults now include exported error namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->