### PR TITLE
refactor(db): ensure gorm generates all dates with a UTC location to standardize

### DIFF
--- a/db/mysql_provider.go
+++ b/db/mysql_provider.go
@@ -3,6 +3,8 @@ package db
 
 import (
 	"fmt"
+	"time"
+
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
@@ -34,7 +36,8 @@ func (p *MySQLProvider) Connect(logger *core.Logger) (*gorm.DB, error) {
 	logger.Debug("Connecting to MySQL", zap.String("dsn", dsn))
 
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
-		Logger: NewLogger(logger.Logger, logger.Level()),
+		Logger:  NewLogger(logger.Logger, logger.Level()),
+		NowFunc: func() time.Time { return time.Now().UTC() },
 	})
 
 	if err != nil {

--- a/db/sqlite_memory_provider.go
+++ b/db/sqlite_memory_provider.go
@@ -1,8 +1,10 @@
 package db
 
 import (
-	"go.uber.org/zap"
 	"sync"
+	"time"
+
+	"go.uber.org/zap"
 
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
@@ -42,7 +44,8 @@ func (p *SQLiteMemoryProvider) Connect(logger *core.Logger) (*gorm.DB, error) {
 	}
 
 	_db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
-		Logger: NewLogger(logger.Logger, logger.Level()),
+		Logger:  NewLogger(logger.Logger, logger.Level()),
+		NowFunc: func() time.Time { return time.Now().UTC() },
 	})
 	if err != nil {
 		return nil, err

--- a/db/sqlite_provider.go
+++ b/db/sqlite_provider.go
@@ -2,6 +2,8 @@
 package db
 
 import (
+	"time"
+
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"gorm.io/driver/sqlite"
@@ -30,7 +32,8 @@ func (p *SQLiteProvider) Connect(logger *core.Logger) (*gorm.DB, error) {
 	}
 
 	db, err := gorm.Open(sqlite.Open(dbFile), &gorm.Config{
-		Logger: NewLogger(logger.Logger, logger.Level()),
+		Logger:  NewLogger(logger.Logger, logger.Level()),
+		NowFunc: func() time.Time { return time.Now().UTC() },
 	})
 
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamps are now stored and returned in UTC across MySQL and SQLite connections, providing consistent created/updated times across environments and eliminating timezone-related discrepancies in lists, reports, and filters. Improves accuracy for time-based sorting, exports, and notifications across different timezones globally.
* **Chores**
  * Internal configuration updated to enforce UTC; no API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->