### PR TITLE
feat(event): add comprehensive boot and init event system

### DIFF
--- a/event/boot.go
+++ b/event/boot.go
@@ -4,7 +4,20 @@ import (
 	"go.lumeweb.com/portal/core"
 )
 
-const EVENT_BOOT_COMPLETE = "boot.complete"
+const (
+	EVENT_BOOT_START     = "boot.start"
+	EVENT_BOOT_COMPLETED = "boot.completed"
+)
+
+type BootStartEvent struct {
+	Context core.Context
+}
+
+func NewBootStartEvent(ctx core.Context) *BootStartEvent {
+	return &BootStartEvent{
+		Context: ctx,
+	}
+}
 
 type BootCompleteEvent struct {
 	Context core.Context
@@ -14,4 +27,20 @@ func NewBootCompleteEvent(ctx core.Context) *BootCompleteEvent {
 	return &BootCompleteEvent{
 		Context: ctx,
 	}
+}
+
+// OnBootStart registers a handler to run when the system boot starts.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_START event.
+func OnBootStart(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootStartEvent](ctx, EVENT_BOOT_START, func(e *core.CoreEvent[BootStartEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+// OnBootComplete registers a handler to run when the system boot completes.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_COMPLETED event.
+func OnBootComplete(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootCompleteEvent](ctx, EVENT_BOOT_COMPLETED, func(e *core.CoreEvent[BootCompleteEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
 }

--- a/event/boot_cron.go
+++ b/event/boot_cron.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_BOOT_CRON           = "boot.cron"
+	EVENT_BOOT_CRON_COMPLETED = "boot.cron.completed"
+)
+
+type BootCronEvent struct {
+	Context core.Context
+}
+
+func NewBootCronEvent(ctx core.Context) *BootCronEvent {
+	return &BootCronEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootCron registers a handler to run when the system boot cron start.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_CRON event.
+func OnBootCron(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootCronEvent](ctx, EVENT_BOOT_CRON, func(e *core.CoreEvent[BootCronEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+type BootCronCompletedEvent struct {
+	Context core.Context
+}
+
+func NewBootCronCompletedEvent(ctx core.Context) *BootCronCompletedEvent {
+	return &BootCronCompletedEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootCronCompleted registers a handler to run when the system boot cron completes.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_CRON_COMPLETED event.
+func OnBootCronCompleted(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootCronCompletedEvent](ctx, EVENT_BOOT_CRON_COMPLETED, func(e *core.CoreEvent[BootCronCompletedEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/boot_http.go
+++ b/event/boot_http.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_BOOT_HTTP           = "boot.http"
+	EVENT_BOOT_HTTP_COMPLETED = "boot.http.completed"
+)
+
+type BootHTTPEvent struct {
+	Context core.Context
+}
+
+func NewBootHTTPEvent(ctx core.Context) *BootHTTPEvent {
+	return &BootHTTPEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootHTTP registers a handler to run when the system boot http start.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_HTTP event.
+func OnBootHTTP(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootHTTPEvent](ctx, EVENT_BOOT_HTTP, func(e *core.CoreEvent[BootHTTPEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+type BootHTTPCompletedEvent struct {
+	Context core.Context
+}
+
+func NewBootHTTPCompletedEvent(ctx core.Context) *BootHTTPCompletedEvent {
+	return &BootHTTPCompletedEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootHTTPCompleted registers a handler to run when the system boot http completes.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_HTTP_COMPLETED event.
+func OnBootHTTPCompleted(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootHTTPCompletedEvent](ctx, EVENT_BOOT_HTTP_COMPLETED, func(e *core.CoreEvent[BootHTTPCompletedEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/boot_mailer.go
+++ b/event/boot_mailer.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_BOOT_MAILER           = "boot.mailer"
+	EVENT_BOOT_MAILER_COMPLETED = "boot.mailer.completed"
+)
+
+type BootMailerEvent struct {
+	Context core.Context
+}
+
+func NewBootMailerEvent(ctx core.Context) *BootMailerEvent {
+	return &BootMailerEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootMailer registers a handler to run when the system boot mailer start.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_MAILER event.
+func OnBootMailer(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootMailerEvent](ctx, EVENT_BOOT_MAILER, func(e *core.CoreEvent[BootMailerEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+type BootMailerCompletedEvent struct {
+	Context core.Context
+}
+
+func NewBootMailerCompletedEvent(ctx core.Context) *BootMailerCompletedEvent {
+	return &BootMailerCompletedEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootMailerCompleted registers a handler to run when the system boot mailer completes.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_MAILER_COMPLETED event.
+func OnBootMailerCompleted(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootMailerCompletedEvent](ctx, EVENT_BOOT_MAILER_COMPLETED, func(e *core.CoreEvent[BootMailerCompletedEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/boot_plugin_workflows.go
+++ b/event/boot_plugin_workflows.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_BOOT_PLUGIN_WORKFLOWS           = "boot.plugin.workflows"
+	EVENT_BOOT_PLUGIN_WORKFLOWS_COMPLETED = "boot.plugin.workflows.completed"
+)
+
+type BootPluginWorkflowsEvent struct {
+	Context core.Context
+}
+
+func NewBootPluginWorkflowsEvent(ctx core.Context) *BootPluginWorkflowsEvent {
+	return &BootPluginWorkflowsEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootPluginWorkflows registers a handler to run when the system boot plugin workflows start.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_PLUGIN_WORKFLOWS event.
+func OnBootPluginWorkflows(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootPluginWorkflowsEvent](ctx, EVENT_BOOT_PLUGIN_WORKFLOWS, func(e *core.CoreEvent[BootPluginWorkflowsEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+type BootPluginWorkflowsCompletedEvent struct {
+	Context core.Context
+}
+
+func NewBootPluginWorkflowsCompletedEvent(ctx core.Context) *BootPluginWorkflowsCompletedEvent {
+	return &BootPluginWorkflowsCompletedEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootPluginWorkflowsCompleted registers a handler to run when the system boot plugin workflows completes.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_PLUGIN_WORKFLOWS_COMPLETED event.
+func OnBootPluginWorkflowsCompleted(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootPluginWorkflowsCompletedEvent](ctx, EVENT_BOOT_PLUGIN_WORKFLOWS_COMPLETED, func(e *core.CoreEvent[BootPluginWorkflowsCompletedEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/boot_protocol_workflows.go
+++ b/event/boot_protocol_workflows.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_BOOT_PROTOCOL_WORKFLOWS           = "boot.protocol.workflows"
+	EVENT_BOOT_PROTOCOL_WORKFLOWS_COMPLETED = "boot.protocol.workflows.completed"
+)
+
+type BootProtocolWorkflowsEvent struct {
+	Context core.Context
+}
+
+func NewBootProtocolWorkflowsEvent(ctx core.Context) *BootProtocolWorkflowsEvent {
+	return &BootProtocolWorkflowsEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootProtocolWorkflows registers a handler to run when the system boot protocol workflows start.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_PROTOCOL_WORKFLOWS event.
+func OnBootProtocolWorkflows(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootProtocolWorkflowsEvent](ctx, EVENT_BOOT_PROTOCOL_WORKFLOWS, func(e *core.CoreEvent[BootProtocolWorkflowsEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+type BootProtocolWorkflowsCompletedEvent struct {
+	Context core.Context
+}
+
+func NewBootProtocolWorkflowsCompletedEvent(ctx core.Context) *BootProtocolWorkflowsCompletedEvent {
+	return &BootProtocolWorkflowsCompletedEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootProtocolWorkflowsCompleted registers a handler to run when the system boot protocol workflows completes.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_PROTOCOL_WORKFLOWS_COMPLETED event.
+func OnBootProtocolWorkflowsCompleted(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootProtocolWorkflowsCompletedEvent](ctx, EVENT_BOOT_PROTOCOL_WORKFLOWS_COMPLETED, func(e *core.CoreEvent[BootProtocolWorkflowsCompletedEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/boot_protocols.go
+++ b/event/boot_protocols.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_BOOT_PROTOCOLS           = "boot.protocols"
+	EVENT_BOOT_PROTOCOLS_COMPLETED = "boot.protocols.completed"
+)
+
+type BootProtocolsEvent struct {
+	Context core.Context
+}
+
+func NewBootProtocolsEvent(ctx core.Context) *BootProtocolsEvent {
+	return &BootProtocolsEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootProtocols registers a handler to run when the system boot protocols start.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_PROTOCOLS event.
+func OnBootProtocols(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootProtocolsEvent](ctx, EVENT_BOOT_PROTOCOLS, func(e *core.CoreEvent[BootProtocolsEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+type BootProtocolsCompletedEvent struct {
+	Context core.Context
+}
+
+func NewBootProtocolsCompletedEvent(ctx core.Context) *BootProtocolsCompletedEvent {
+	return &BootProtocolsCompletedEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootProtocolsCompleted registers a handler to run when the system boot protocols completes.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_PROTOCOLS_COMPLETED event.
+func OnBootProtocolsCompleted(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootProtocolsCompletedEvent](ctx, EVENT_BOOT_PROTOCOLS_COMPLETED, func(e *core.CoreEvent[BootProtocolsCompletedEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/boot_startup_funcs.go
+++ b/event/boot_startup_funcs.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_BOOT_STARTUP_FUNCS           = "boot.startup.funcs"
+	EVENT_BOOT_STARTUP_FUNCS_COMPLETED = "boot.startup.funcs.completed"
+)
+
+type BootStartupFuncsEvent struct {
+	Context core.Context
+}
+
+func NewBootStartupFuncsEvent(ctx core.Context) *BootStartupFuncsEvent {
+	return &BootStartupFuncsEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootStartupFuncs registers a handler to run when the system boot startup funcs start.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_STARTUP_FUNCS event.
+func OnBootStartupFuncs(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootStartupFuncsEvent](ctx, EVENT_BOOT_STARTUP_FUNCS, func(e *core.CoreEvent[BootStartupFuncsEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+type BootStartupFuncsCompletedEvent struct {
+	Context core.Context
+}
+
+func NewBootStartupFuncsCompletedEvent(ctx core.Context) *BootStartupFuncsCompletedEvent {
+	return &BootStartupFuncsCompletedEvent{
+		Context: ctx,
+	}
+}
+
+// OnBootStartupFuncsCompleted registers a handler to run when the system boot startup funcs completes.
+// This is a convenience wrapper around Listen for the EVENT_BOOT_STARTUP_FUNCS_COMPLETED event.
+func OnBootStartupFuncsCompleted(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[BootStartupFuncsCompletedEvent](ctx, EVENT_BOOT_STARTUP_FUNCS_COMPLETED, func(e *core.CoreEvent[BootStartupFuncsCompletedEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/download.go
+++ b/event/download.go
@@ -1,5 +1,7 @@
 package event
 
+import "go.lumeweb.com/portal/core"
+
 const EVENT_DOWNLOAD_COMPLETED = "download.completed"
 
 type DownloadCompletedEvent struct {
@@ -14,4 +16,12 @@ func NewDownloadCompletedEvent(uploadID uint, bytes uint64, ip string) *Download
 		Bytes:    bytes,
 		IP:       ip,
 	}
+}
+
+// OnDownloadCompleted registers a handler to run when a download is completed.
+// This is a convenience wrapper around Listen for the EVENT_DOWNLOAD_COMPLETED event.
+func OnDownloadCompleted(ctx core.Context, handler func(uint, uint64, string) error, priority ...int) {
+	core.Listen[DownloadCompletedEvent](ctx, EVENT_DOWNLOAD_COMPLETED, func(e *core.CoreEvent[DownloadCompletedEvent]) error {
+		return handler(e.Data.UploadID, e.Data.Bytes, e.Data.IP)
+	}, priority...)
 }

--- a/event/init.go
+++ b/event/init.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_INIT_START    = "init.start"
+	EVENT_INIT_COMPLETE = "init.complete"
+)
+
+type InitStartEvent struct {
+	Context core.Context
+}
+
+func NewInitStartEvent(ctx core.Context) *InitStartEvent {
+	return &InitStartEvent{
+		Context: ctx,
+	}
+}
+
+type InitCompleteEvent struct {
+	Context core.Context
+}
+
+func NewInitCompleteEvent(ctx core.Context) *InitCompleteEvent {
+	return &InitCompleteEvent{
+		Context: ctx,
+	}
+}
+
+// OnInitStart registers a handler to run when the system init starts.
+// This is a convenience wrapper around Listen for the EVENT_INIT_START event.
+func OnInitStart(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[InitStartEvent](ctx, EVENT_INIT_START, func(e *core.CoreEvent[InitStartEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+// OnInitComplete registers a handler to run when the system init completes.
+// This is a convenience wrapper around Listen for the EVENT_INIT_COMPLETE event.
+func OnInitComplete(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[InitCompleteEvent](ctx, EVENT_INIT_COMPLETE, func(e *core.CoreEvent[InitCompleteEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/init_components.go
+++ b/event/init_components.go
@@ -1,0 +1,44 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const (
+	EVENT_INIT_COMPONENTS_REGISTERED  = "init.components.registered"
+	EVENT_INIT_COMPONENTS_CONFIGURED = "init.components.configured"
+)
+
+type InitComponentsRegisteredEvent struct {
+	Context core.Context
+}
+
+func NewInitComponentsRegisteredEvent(ctx core.Context) *InitComponentsRegisteredEvent {
+	return &InitComponentsRegisteredEvent{
+		Context: ctx,
+	}
+}
+
+type InitComponentsConfiguredEvent struct {
+	Context core.Context
+}
+
+func NewInitComponentsConfiguredEvent(ctx core.Context) *InitComponentsConfiguredEvent {
+	return &InitComponentsConfiguredEvent{
+		Context: ctx,
+	}
+}
+
+// OnInitComponentsRegistered registers a handler to run when system components are registered.
+// This is a convenience wrapper around Listen for the EVENT_INIT_COMPONENTS_REGISTERED event.
+func OnInitComponentsRegistered(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[InitComponentsRegisteredEvent](ctx, EVENT_INIT_COMPONENTS_REGISTERED, func(e *core.CoreEvent[InitComponentsRegisteredEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}
+
+// OnInitComponentsConfigured registers a handler to run when system components are configured.
+// This is a convenience wrapper around Listen for the EVENT_INIT_COMPONENTS_CONFIGURED event.
+func OnInitComponentsConfigured(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[InitComponentsConfiguredEvent](ctx, EVENT_INIT_COMPONENTS_CONFIGURED, func(e *core.CoreEvent[InitComponentsConfiguredEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/init_database.go
+++ b/event/init_database.go
@@ -1,0 +1,23 @@
+package event
+
+import "go.lumeweb.com/portal/core"
+
+const EVENT_INIT_DATABASE_READY = "init.database.ready"
+
+type InitDatabaseReadyEvent struct {
+	Context core.Context
+}
+
+func NewInitDatabaseReadyEvent(ctx core.Context) *InitDatabaseReadyEvent {
+	return &InitDatabaseReadyEvent{
+		Context: ctx,
+	}
+}
+
+// OnInitDatabaseReady registers a handler to run when the database is ready.
+// This is a convenience wrapper around Listen for the EVENT_INIT_DATABASE_READY event.
+func OnInitDatabaseReady(ctx core.Context, handler func(core.Context) error, priority ...int) {
+	core.Listen[InitDatabaseReadyEvent](ctx, EVENT_INIT_DATABASE_READY, func(e *core.CoreEvent[InitDatabaseReadyEvent]) error {
+		return handler(e.Data.Context)
+	}, priority...)
+}

--- a/event/storage_pin.go
+++ b/event/storage_pin.go
@@ -1,6 +1,9 @@
 package event
 
-import "go.lumeweb.com/portal/db/models"
+import (
+	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal/db/models"
+)
 
 const EVENT_STORAGE_OBJECT_PINNED = "storage.object.pinned"
 
@@ -14,4 +17,12 @@ func NewStorageObjectPinnedEvent(pin *models.Pin, ip string) *StorageObjectPinne
 		Pin: pin,
 		IP:  ip,
 	}
+}
+
+// OnStorageObjectPinned registers a handler to run when a storage object is pinned.
+// This is a convenience wrapper around Listen for the EVENT_STORAGE_OBJECT_PINNED event.
+func OnStorageObjectPinned(ctx core.Context, handler func(*models.Pin, string) error, priority ...int) {
+	core.Listen[StorageObjectPinnedEvent](ctx, EVENT_STORAGE_OBJECT_PINNED, func(e *core.CoreEvent[StorageObjectPinnedEvent]) error {
+		return handler(e.Data.Pin, e.Data.IP)
+	}, priority...)
 }

--- a/event/storage_unpin.go
+++ b/event/storage_unpin.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 )
 
@@ -16,4 +17,12 @@ func NewStorageObjectUnpinnedEvent(pin *models.Pin, ip string) *StorageObjectUnp
 		Pin: pin,
 		IP:  ip,
 	}
+}
+
+// OnStorageObjectUnpinned registers a handler to run when a storage object is unpinned.
+// This is a convenience wrapper around Listen for the EVENT_STORAGE_OBJECT_UNPINNED event.
+func OnStorageObjectUnpinned(ctx core.Context, handler func(*models.Pin, string) error, priority ...int) {
+	core.Listen[StorageObjectUnpinnedEvent](ctx, EVENT_STORAGE_OBJECT_UNPINNED, func(e *core.CoreEvent[StorageObjectUnpinnedEvent]) error {
+		return handler(e.Data.Pin, e.Data.IP)
+	}, priority...)
 }

--- a/event/user_activated.go
+++ b/event/user_activated.go
@@ -1,6 +1,9 @@
 package event
 
-import "go.lumeweb.com/portal/db/models"
+import (
+	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal/db/models"
+)
 
 const EVENT_USER_ACTIVATED = "user.activated"
 
@@ -15,4 +18,12 @@ func NewUserActivatedEvent(user *models.User) *UserActivatedEvent {
 	return &UserActivatedEvent{
 		User: user,
 	}
+}
+
+// OnUserActivated registers a handler to run when a user is activated.
+// This is a convenience wrapper around Listen for the EVENT_USER_ACTIVATED event.
+func OnUserActivated(ctx core.Context, handler func(*models.User) error, priority ...int) {
+	core.Listen[UserActivatedEvent](ctx, EVENT_USER_ACTIVATED, func(e *core.CoreEvent[UserActivatedEvent]) error {
+		return handler(e.Data.User)
+	}, priority...)
 }

--- a/event/user_created.go
+++ b/event/user_created.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
 )
 
@@ -17,4 +18,12 @@ func NewUserCreatedEvent(user *models.User) *UserCreatedEvent {
 	return &UserCreatedEvent{
 		User: user,
 	}
+}
+
+// OnUserCreated registers a handler to run when a user is created.
+// This is a convenience wrapper around Listen for the EVENT_USER_CREATED event.
+func OnUserCreated(ctx core.Context, handler func(*models.User) error, priority ...int) {
+	core.Listen[UserCreatedEvent](ctx, EVENT_USER_CREATED, func(e *core.CoreEvent[UserCreatedEvent]) error {
+		return handler(e.Data.User)
+	}, priority...)
 }

--- a/event/user_service_subdomain.go
+++ b/event/user_service_subdomain.go
@@ -1,5 +1,7 @@
 package event
 
+import "go.lumeweb.com/portal/core"
+
 const EVENT_USER_SERVICE_SUBDOMAIN_SET = "user.subdomain.set"
 
 type UserServiceSubdomainSetEvent struct {
@@ -10,4 +12,12 @@ func NewUserServiceSubdomainSetEvent(subdomain string) *UserServiceSubdomainSetE
 	return &UserServiceSubdomainSetEvent{
 		Subdomain: subdomain,
 	}
+}
+
+// OnUserServiceSubdomainSet registers a handler to run when a user service subdomain is set.
+// This is a convenience wrapper around Listen for the EVENT_USER_SERVICE_SUBDOMAIN_SET event.
+func OnUserServiceSubdomainSet(ctx core.Context, handler func(string) error, priority ...int) {
+	core.Listen[UserServiceSubdomainSetEvent](ctx, EVENT_USER_SERVICE_SUBDOMAIN_SET, func(e *core.CoreEvent[UserServiceSubdomainSetEvent]) error {
+		return handler(e.Data.Subdomain)
+	}, priority...)
 }

--- a/portal.go
+++ b/portal.go
@@ -38,6 +38,12 @@ func (p *PortalImpl) Init() error {
 	ctx := p.Context()
 	ctx.Logger().Info("Initializing portal")
 
+	// Fire init start event
+	if err := core.Fire(ctx, event.EVENT_INIT_START, event.NewInitStartEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing init start event", zap.Error(err))
+		return err
+	}
+
 	// Stage 1: Component Registration
 	// Register all services, protocols, APIs and extensions to make them available
 	// for configuration and initialization later. Gather context options that
@@ -72,11 +78,17 @@ func (p *PortalImpl) Init() error {
 	}
 	ctxOpts = append(ctxOpts, opts...)
 
+	// Fire components registered event
+	if err := core.Fire(ctx, event.EVENT_INIT_COMPONENTS_REGISTERED, event.NewInitComponentsRegisteredEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing init components registered event", zap.Error(err))
+		return err
+	}
+
 	// Create new context with gathered options - this establishes the base context
 	// with all registered components but before any configuration is applied
 	ctx, err = core.NewContext(ctx.Config(), ctx.Logger(), ctxOpts...)
 	if err != nil {
-		ctx.Logger().Error("Error creating context", zap.Error(err))
+		ctx.Logger().Error("Error applying context options", zap.Error(err))
 		return err
 	}
 	p.SetContext(ctx)
@@ -93,6 +105,12 @@ func (p *PortalImpl) Init() error {
 
 	if err = p.configureAPIs(ctx); err != nil {
 		return fmt.Errorf("failed to configure APIs: %w", err)
+	}
+
+	// Fire components configured event
+	if err := core.Fire(ctx, event.EVENT_INIT_COMPONENTS_CONFIGURED, event.NewInitComponentsConfiguredEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing init components configured event", zap.Error(err))
+		return err
 	}
 
 	// Initialize config system and apply log level settings
@@ -116,8 +134,22 @@ func (p *PortalImpl) Init() error {
 	}
 	dbOpts = append(dbOpts, opts...)
 
-	// Use database options as the base for this stage
-	ctxOpts = dbOpts
+	// Apply database options first and update portal context
+	ctx, err = core.ProcessCtxOptions(ctx, dbOpts...)
+	if err != nil {
+		ctx.Logger().Error("Error applying database options", zap.Error(err))
+		return err
+	}
+	p.SetContext(ctx)
+
+	// Fire database ready event (now with working DB)
+	if err := core.Fire(ctx, event.EVENT_INIT_DATABASE_READY, event.NewInitDatabaseReadyEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing init database ready event", zap.Error(err))
+		return err
+	}
+
+	// Start fresh with empty options for next stage
+	ctxOpts = []core.ContextBuilderOption{}
 	// Stage 4: Component Initialization
 	// Perform final initialization of protocols, APIs and other components.
 	// Service-specific context options are applied last to ensure all other
@@ -139,13 +171,21 @@ func (p *PortalImpl) Init() error {
 
 	ctxOpts = append(ctxOpts, svcOpts...)
 
-	// Finalize context with all gathered options
-	ctx, err = core.ProcessCtxOptions(ctx, ctxOpts...)
-	if err != nil {
-		ctx.Logger().Error("Error creating context", zap.Error(err))
+	// Finalize context with remaining options (excluding already-applied dbOpts)
+	if len(ctxOpts) > 0 {
+		ctx, err = core.ProcessCtxOptions(ctx, ctxOpts...)
+		if err != nil {
+			ctx.Logger().Error("Error creating context", zap.Error(err))
+			return err
+		}
+		p.SetContext(ctx)
+	}
+
+	// Fire init complete event
+	if err := core.Fire(ctx, event.EVENT_INIT_COMPLETE, event.NewInitCompleteEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing init complete event", zap.Error(err))
 		return err
 	}
-	p.SetContext(ctx)
 
 	return nil
 }
@@ -154,7 +194,27 @@ func (p *PortalImpl) Start() error {
 	ctx := p.Context()
 	ctx.Logger().Info("Starting portal")
 
+	if err := core.Fire(ctx, event.EVENT_BOOT_START, event.NewBootStartEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot start event", zap.Error(err))
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_STARTUP_FUNCS, event.NewBootStartupFuncsEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot startup funcs event", zap.Error(err))
+		return err
+	}
+
 	if err := p.startStartupFuncs(ctx); err != nil {
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_STARTUP_FUNCS_COMPLETED, event.NewBootStartupFuncsCompletedEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot startup funcs completed event", zap.Error(err))
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_PLUGIN_WORKFLOWS, event.NewBootPluginWorkflowsEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot plugin workflows event", zap.Error(err))
 		return err
 	}
 
@@ -162,7 +222,41 @@ func (p *PortalImpl) Start() error {
 		return err
 	}
 
+	if err := core.Fire(ctx, event.EVENT_BOOT_PLUGIN_WORKFLOWS_COMPLETED, event.NewBootPluginWorkflowsCompletedEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot plugin workflows completed event", zap.Error(err))
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_PROTOCOL_WORKFLOWS, event.NewBootProtocolWorkflowsEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot protocol workflows event", zap.Error(err))
+		return err
+	}
+
+	if err := p.registerProtocolWorkflows(ctx); err != nil {
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_PROTOCOL_WORKFLOWS_COMPLETED, event.NewBootProtocolWorkflowsCompletedEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot protocol workflows completed event", zap.Error(err))
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_PROTOCOLS, event.NewBootProtocolsEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot protocols event", zap.Error(err))
+		return err
+	}
+
 	if err := p.startProtocols(ctx); err != nil {
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_PROTOCOLS_COMPLETED, event.NewBootProtocolsCompletedEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot protocols completed event", zap.Error(err))
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_CRON, event.NewBootCronEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot cron event", zap.Error(err))
 		return err
 	}
 
@@ -170,7 +264,27 @@ func (p *PortalImpl) Start() error {
 		return err
 	}
 
+	if err := core.Fire(ctx, event.EVENT_BOOT_CRON_COMPLETED, event.NewBootCronCompletedEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot cron completed event", zap.Error(err))
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_HTTP, event.NewBootHTTPEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot http event", zap.Error(err))
+		return err
+	}
+
 	if err := p.startHTTP(ctx); err != nil {
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_HTTP_COMPLETED, event.NewBootHTTPCompletedEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot http completed event", zap.Error(err))
+		return err
+	}
+
+	if err := core.Fire(ctx, event.EVENT_BOOT_MAILER, event.NewBootMailerEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot mailer event", zap.Error(err))
 		return err
 	}
 
@@ -178,8 +292,13 @@ func (p *PortalImpl) Start() error {
 		return err
 	}
 
-	if err := p.fireBootCompleteEvent(ctx); err != nil {
-		ctx.Logger().Error("Error firing boot complete event", zap.Error(err))
+	if err := core.Fire(ctx, event.EVENT_BOOT_MAILER_COMPLETED, event.NewBootMailerCompletedEvent(ctx)); err != nil {
+		ctx.Logger().Error("Error firing boot mailer completed event", zap.Error(err))
+		return err
+	}
+
+	if err := p.fireBootCompletedEvent(ctx); err != nil {
+		ctx.Logger().Error("Error firing boot completed event", zap.Error(err))
 		return err
 	}
 
@@ -200,6 +319,27 @@ func (p *PortalImpl) registerPluginWorkflows(ctx core.Context) error {
 				if err = workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps, workflow.AutoTriggerFirstStep); err != nil {
 					return fmt.Errorf("failed to register workflow %s for plugin %s: %w", workflow.Name, plugin.ID, err)
 				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *PortalImpl) registerProtocolWorkflows(ctx core.Context) error {
+	workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+
+	for _, proto := range core.GetProtocols() {
+		wfs := proto.Workflows()
+		if len(wfs) == 0 {
+			continue
+		}
+		for _, workflow := range wfs {
+			ctx.Logger().Debug("Registering protocol workflow",
+				zap.String("protocol", proto.Name()),
+				zap.String("workflow", workflow.Name))
+			if err := workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps, workflow.AutoTriggerFirstStep); err != nil {
+				return fmt.Errorf("failed to register workflow %s for protocol %s: %w", workflow.Name, proto.Name(), err)
 			}
 		}
 	}
@@ -436,27 +576,13 @@ func (p *PortalImpl) initProtocols(ctx core.Context) (ctxOpts []core.ContextBuil
 				return nil, err
 			}
 		}
-
-		workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
-
-		// Register workflows for each protocol
-		for _, workflow := range proto.Workflows() {
-			if err := workflowSvc.RegisterWorkflow(workflow.Name, workflow.Steps, workflow.AutoTriggerFirstStep); err != nil {
-				return nil, fmt.Errorf("failed to register workflow %s for protocol %s: %w", workflow.Name, proto.Name(), err)
-			}
-		}
 	}
 
 	return ctxOpts, nil
 }
 
 func (p *PortalImpl) initAPIs(ctx core.Context) (ctxOpts []core.ContextBuilderOption, err error) {
-	for name, api := range core.GetAPIs() {
-		err := ctx.Config().ConfigureAPI(name, api.Config())
-		if err != nil {
-			ctx.Logger().Error("Error configuring api", zap.String("api", api.Name()), zap.Error(err))
-			return nil, err
-		}
+	for _, api := range core.GetAPIs() {
 		if initApi, ok := api.(core.APIInit); ok {
 			opts, err := initApi.Init()
 			if err != nil {
@@ -590,8 +716,8 @@ func (p *PortalImpl) runExitFuncs(ctx core.Context) error {
 	return nil
 }
 
-func (p *PortalImpl) fireBootCompleteEvent(ctx core.Context) error {
-	return core.Fire(ctx, event.EVENT_BOOT_COMPLETE, event.NewBootCompleteEvent(ctx))
+func (p *PortalImpl) fireBootCompletedEvent(ctx core.Context) error {
+	return core.Fire(ctx, event.EVENT_BOOT_COMPLETED, event.NewBootCompletedEvent(ctx))
 }
 
 func NewPortal(ctx core.Context) *PortalImpl {


### PR DESCRIPTION
- Added new event files for different boot phases (cron, http, mailer, plugin workflows, protocol workflows, protocols, startup funcs)
- Added init event system with stages (start, components registered/configured, database ready, complete)
- Modified existing events to include convenience wrapper functions
- Updated portal.go to fire events at each stage of initialization and boot process
- Split protocol workflow registration into separate method
- Renamed EVENT_BOOT_COMPLETE to EVENT_BOOT_COMPLETED for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive lifecycle event hooks and simple registration helpers across init and boot phases (init, init components, database ready, boot, startup funcs, plugin/protocol workflows, protocols, HTTP, cron, mailer) plus user, download and storage pin/unpin convenience listeners.

- **Refactor**
  - Standardized startup/init into explicit event-driven steps, extracted protocol-workflow registration into a dedicated step, and aligned boot event naming/sequence for clearer lifecycle flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->