### PR TITLE
fix(testing): correct event package reference in BootEnvironment

### DIFF
--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -875,7 +875,7 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 	}
 
 	if tctx, ok := ctx.(*testContext); ok && tctx.FireBootComplete() {
-		if err = core.Fire(ctx, event.EVENT_BOOT_COMPLETED, event.NewBootCompletedEvent(ctx)); err != nil {
+		if err = core.Fire(ctx, pevent.EVENT_BOOT_COMPLETED, pevent.NewBootCompletedEvent(ctx)); err != nil {
 			return fmt.Errorf("failed to fire boot complete event: %w", err)
 		}
 	}


### PR DESCRIPTION
- Changed core.Fire to use pevent package constants/functions instead of event package
- This appears to be a bug fix where the wrong event package was being used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized boot completion event handling to use the unified portal event system. No changes to behavior, timing, or error messages.
- Chores
  - Internal alignment of event constants and constructors for consistency across components. No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->