### PR TITLE
feat(testing): add RegisterGlobalPath method to MockHTTPService

### DIFF
--- a/core/testing/mock_http.go
+++ b/core/testing/mock_http.go
@@ -39,6 +39,10 @@ func NewMockHTTPService(t TB) *MockHTTPService {
 		Maybe().
 		Return(nil)
 
+	mockHTTPService.On("RegisterGlobalPath", mock.AnythingOfType("string")).
+		Maybe().
+		Return(nil)
+
 	mockHTTPService.On("APISubdomain", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).
 		Maybe().
 		Return(httpService.apiSubdomainFunc("", false))
@@ -84,6 +88,16 @@ func (m *MockHTTPService) Init() error {
 	}
 
 	return m.MockHTTPService.Init()
+}
+
+// RegisterGlobalPath implements core.HTTPService with automatic mock setup
+func (m *MockHTTPService) RegisterGlobalPath(path string) error {
+	// Set up expectation if not already set
+	if !WasMethodCalled(&m.MockHTTPService.Mock, "RegisterGlobalPath", path) {
+		m.On("RegisterGlobalPath", path).Return(nil)
+	}
+
+	return m.MockHTTPService.RegisterGlobalPath(path)
 }
 
 // WithRouter sets the router for the mock HTTP service


### PR DESCRIPTION
* Added RegisterGlobalPath method implementation to MockHTTPService struct
* Added default expectation for RegisterGlobalPath in NewMockHTTPService
* Method includes automatic mock setup with Maybe() and Return(nil)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced HTTP service mocks to automatically handle global path registration when not explicitly configured, reducing boilerplate and improving reliability.
  * Introduces a default expectation that preserves existing behavior while preventing unexpected test failures.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->