### PR TITLE
feat(tus): add PreFinishResponse callback and CID generation

### DIFF
--- a/core/tus.go
+++ b/core/tus.go
@@ -61,6 +61,10 @@ type TUSUploadCreatedVerifyFunc func(hook handler.HookEvent, uploaderId uint) (S
 // TUSUploadCreatedAfterFunc defines a callback that runs after upload creation
 type TUSUploadCreatedAfterFunc func(requestId uint) error
 
+// TUSPreFinishResponseCallback defines a callback that runs before finishing an upload
+// Can modify the HTTP response before it's sent to the client
+type TUSPreFinishResponseCallback func(hook handler.HookEvent) (handler.HTTPResponse, error)
+
 // TUSHandlerConfig defines configuration for the TUS handler
 type TUSHandlerConfig struct {
 	// BasePath is the base URL path for TUS endpoints
@@ -81,6 +85,10 @@ type TUSHandlerConfig struct {
 
 	// CompletedUploadHandler handles events when uploads complete successfully
 	CompletedUploadHandler TUSUploadCallbackHandler
+
+	// PreFinishResponse is an optional callback that runs before finishing an upload
+	// Can modify the HTTP response before it's sent to the client
+	PreFinishResponse TUSPreFinishResponseCallback
 
 	// Protocol is the storage protocol this handler is associated with
 	Protocol Protocol

--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -3,6 +3,10 @@ package tus
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/labstack/echo/v4"
@@ -17,9 +21,6 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/exp/slog"
 	"gorm.io/gorm"
-	"io"
-	"net/http"
-	"strings"
 )
 
 type CtxRangeKeyType string
@@ -303,15 +304,16 @@ func (t *TusHandlerDefault) init(handlerConfig core.TUSHandlerConfig) error {
 	}
 
 	handlr, err := handler.NewHandler(handler.Config{
-		BasePath:                handlerConfig.BasePath,
-		StoreComposer:           composer,
-		DisableDownload:         true,
-		NotifyCompleteUploads:   true,
-		NotifyTerminatedUploads: true,
-		NotifyCreatedUploads:    true,
-		RespectForwardedHeaders: true,
-		PreUploadCreateCallback: handlerConfig.PreUpload,
-		Logger:                  loggerToSlog(t.logger),
+		BasePath:                  handlerConfig.BasePath,
+		StoreComposer:             composer,
+		DisableDownload:           true,
+		NotifyCompleteUploads:     true,
+		NotifyTerminatedUploads:   true,
+		NotifyCreatedUploads:      true,
+		RespectForwardedHeaders:   true,
+		PreUploadCreateCallback:   handlerConfig.PreUpload,
+		PreFinishResponseCallback: handlerConfig.PreFinishResponse,
+		Logger:                    loggerToSlog(t.logger),
 	})
 
 	if err != nil {

--- a/service/tus.go
+++ b/service/tus.go
@@ -2,8 +2,14 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	mh "github.com/multiformats/go-multihash"
 	"github.com/samber/lo"
 	tusHandler "github.com/tus/tusd/v2/pkg/handler"
 	"go.lumeweb.com/portal/core"
@@ -11,7 +17,6 @@ import (
 	"go.lumeweb.com/portal/service/internal/tus"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
-	"time"
 )
 
 var _ core.TUSService = (*TUSServiceDefault)(nil)
@@ -475,4 +480,40 @@ func TUSDefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSU
 
 func TUSDefaultUploadTerminatedHandler(ctx core.Context) core.TUSUploadCallbackHandler {
 	return tus.DefaultUploadTerminatedHandler(ctx)
+}
+
+// TUSMultihashGeneratorFunc defines a function type that generates a multihash from TUS upload data
+type TUSMultihashGeneratorFunc func(hook tusHandler.HookEvent) (mh.Multihash, error)
+
+// TUSDefaultPreFinishResponse creates a default PreFinishResponse callback that returns a CID JSON object
+// hashFunc: A function that generates the multihash from the upload data
+func TUSDefaultPreFinishResponse(hashFunc TUSMultihashGeneratorFunc) core.TUSPreFinishResponseCallback {
+	return func(hook tusHandler.HookEvent) (tusHandler.HTTPResponse, error) {
+		// Generate the multihash
+		multihash, err := hashFunc(hook)
+		if err != nil {
+			return tusHandler.HTTPResponse{}, err
+		}
+
+		// Create CID from multihash
+		fileCID := cid.NewCidV1(cid.Raw, multihash)
+
+		// Return JSON response with CID
+		jsonBody, err := json.Marshal(struct {
+			CID string `json:"cid"`
+		}{
+			CID: fileCID.String(),
+		})
+		if err != nil {
+			return tusHandler.HTTPResponse{}, err
+		}
+
+		return tusHandler.HTTPResponse{
+			StatusCode: http.StatusOK,
+			Header: map[string]string{
+				"Content-Type": "application/json",
+			},
+			Body: string(jsonBody),
+		}, nil
+	}
 }


### PR DESCRIPTION
- Added new TUSPreFinishResponseCallback type for modifying HTTP responses before upload completion
- Added PreFinishResponse field to TUSHandlerConfig
- Implemented TUSDefaultPreFinishResponse helper that generates and returns a CID
- Updated tus handler initialization to include the new callback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TUS uploads now support a pre-finish response hook to customize the HTTP response just before an upload completes.
  * Default pre-finish behavior returns a JSON payload containing a CID (content identifier) derived from the uploaded content for immediate content addressing.
  * API is extensible so callers can supply custom multihash-to-CID generators for tailored responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->