### PR TITLE
fix(testing): add port config when using mock HTTP service

### DIFF
--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -711,7 +711,10 @@ func DefaultTestContextOptions() ([]TestContextBuilderOption, error) {
 			WithHTTPService(),
 		)
 	} else {
-		opts = append(opts, WithMockHTTPService())
+		opts = append(opts,
+			WithMockHTTPService(),
+			WithConfig("core.port", 80),
+		)
 	}
 
 	opts = append(opts,


### PR DESCRIPTION
- Added WithConfig("core.port", 80) option when using WithMockHTTPService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test context defaults by assigning a standard port when HTTP is mocked, resulting in more predictable and stable test runs.
  * Clarifies default behavior in non-real HTTP scenarios, reducing configuration overhead and flakiness.
  * Aligns local and CI test behavior for greater consistency.
  * No user-facing impact; runtime behavior in real environments remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->