### PR TITLE
feat(operations): add human-readable display names for operations and statuses

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -16,6 +16,9 @@ type operation struct {
 	handler    OperationHandler
 }
 
+// Ensure operation implements OperationDisplay
+var _ OperationDisplay = (*operation)(nil)
+
 func (o *operation) Type() string {
 	return o.opType
 }
@@ -28,7 +31,49 @@ func (o *operation) Handler() OperationHandler {
 	return o.handler
 }
 
+// DisplayName returns the human-readable display name for this operation
+func (o *operation) DisplayName() string {
+	// If this operation has a global type, use the display info from the map
+	if o.globalType != "" {
+		if info, exists := GetOperationTypeDisplayInfo(o.globalType); exists {
+			return info.Name
+		}
+	}
+	
+	// Fallback to the operation type (e.g., "ipfs.pin")
+	return o.opType
+}
+
 type OperationType string
+
+// Operation category constants
+const (
+	OperationCategoryNetwork = "network"
+	OperationCategoryStorage = "storage"
+	OperationCategoryData    = "data"
+)
+
+// OperationTypeInfo contains human-readable display information for an operation type
+type OperationTypeInfo struct {
+	Name        string `json:"name"`         // Human-readable display name
+	Description string `json:"description"`  // Detailed description of the operation
+	Category    string `json:"category"`     // Category of the operation (network, storage, data)
+}
+
+// OperationTypeDisplayNames maps operation types to their human-readable display information
+var OperationTypeDisplayNames = map[OperationType]OperationTypeInfo{
+	// Network operations
+	OpTypeRetrieve: {Name: "Retrieve", Description: "Fetch content from network", Category: OperationCategoryNetwork},
+	OpTypePublish:  {Name: "Publish", Description: "Publish content to network", Category: OperationCategoryNetwork},
+
+	// Storage operations
+	OpTypeStore:   {Name: "Store", Description: "Store content locally", Category: OperationCategoryStorage},
+	OpTypeUnstore: {Name: "Unstore", Description: "Remove local storage", Category: OperationCategoryStorage},
+
+	// Data operations
+	OpTypeUpload: {Name: "Upload", Description: "Upload new content", Category: OperationCategoryData},
+	OpTypeScan:   {Name: "Scan", Description: "Scan and validate content", Category: OperationCategoryData},
+}
 
 var (
 	// Network operations
@@ -48,6 +93,11 @@ type Operation interface {
 	Type() string              // Specific operation name (e.g., "ipfs.pin" or "ipfs.pin.car")
 	GlobalType() OperationType // Optional global type mapping (e.g., OpTypePin) or empty for custom ops
 	Handler() OperationHandler // The handler implementation
+}
+
+// OperationDisplay provides human-readable display information for operations
+type OperationDisplay interface {
+	DisplayName() string // Human-readable display name for the operation
 }
 
 type OperationHandler interface {
@@ -293,6 +343,29 @@ func (h *OperationHelperDefault) UpdateWorkflowData(requestID uint, data map[str
 // UpdateWorkflowDataStruct updates workflow metadata with the provided struct
 func (h *OperationHelperDefault) UpdateWorkflowDataStruct(requestID uint, data any) error {
 	return h.workflow.UpdateWorkflowDataStruct(h.ctx, requestID, data, h.unmarshalTag)
+}
+
+// GetOperationTypeDisplayInfo returns the human-readable display information for a given operation type
+func GetOperationTypeDisplayInfo(opType OperationType) (OperationTypeInfo, bool) {
+	info, exists := OperationTypeDisplayNames[opType]
+	return info, exists
+}
+
+// GetOperationDisplayName returns the human-readable display name for a given operation
+func GetOperationDisplayName(op Operation) string {
+	if op == nil {
+		return ""
+	}
+
+	if displayOp, ok := op.(OperationDisplay); ok {
+		return displayOp.DisplayName()
+	}
+
+	if info, ok := GetOperationTypeDisplayInfo(op.GlobalType()); ok && info.Name != "" {
+		return info.Name
+	}
+
+	return op.Type()
 }
 
 // StartWorkflow starts a new workflow with the given name and options

--- a/core/request.go
+++ b/core/request.go
@@ -93,18 +93,31 @@ type RequestStatus struct {
 	Error           error                    `json:"-"`                // Not serialized
 }
 
+// RequestStatusInfo contains human-readable display information for a request status
+type RequestStatusInfo struct {
+	Name        string `json:"name"`         // Human-readable display name
+	Description string `json:"description"`  // Detailed description of the status
+}
+
+// RequestStatusDisplayNames maps request status types to their human-readable display information
+var RequestStatusDisplayNames = map[models.RequestStatusType]RequestStatusInfo{
+	models.RequestStatusPending:   {Name: "Pending", Description: "Waiting to be processed"},
+	models.RequestStatusProcessing: {Name: "Processing", Description: "Currently being processed"},
+	models.RequestStatusCompleted:  {Name: "Completed", Description: "Successfully completed"},
+	models.RequestStatusFailed:     {Name: "Failed", Description: "Failed to complete"},
+	models.RequestStatusDuplicate:  {Name: "Duplicate", Description: "Duplicate request"},
+}
+
+// GetRequestStatusDisplayInfo returns the human-readable display information for a given request status
+func GetRequestStatusDisplayInfo(status models.RequestStatusType) (RequestStatusInfo, bool) {
+	info, exists := RequestStatusDisplayNames[status]
+	return info, exists
+}
+
 // GetDefaultStatusMessage returns the default status message for a given request status
 func GetDefaultStatusMessage(status models.RequestStatusType) string {
-	switch status {
-	case models.RequestStatusPending:
-		return "Request is pending processing"
-	case models.RequestStatusProcessing:
-		return "Request is being processed"
-	case models.RequestStatusCompleted:
-		return "Request completed successfully"
-	case models.RequestStatusFailed:
-		return "Request failed"
-	default:
-		return ""
+	if info, exists := RequestStatusDisplayNames[status]; exists {
+		return info.Description
 	}
+	return ""
 }

--- a/core/workflow.go
+++ b/core/workflow.go
@@ -174,6 +174,12 @@ type WorkflowOptionsDefault struct {
 	koanfCache  *koanf.Koanf
 }
 
+// GetWorkflowStatusDisplayInfo returns the human-readable display information for a given workflow status
+func GetWorkflowStatusDisplayInfo(status models.RequestStatusType) (WorkflowStatusInfo, bool) {
+	info, exists := WorkflowStatusDisplayNames[status]
+	return info, exists
+}
+
 // NewWorkflowOptions creates a new WorkflowOptions instance with initialized koanf cache
 func NewWorkflowOptions() WorkflowOptions {
 	return &WorkflowOptionsDefault{
@@ -376,6 +382,21 @@ type WorkflowDefinition struct {
 	Name                 string
 	Steps                []OperationStep
 	AutoTriggerFirstStep bool // Whether to automatically trigger first step execution
+}
+
+// WorkflowStatusInfo contains human-readable display information for workflow status
+type WorkflowStatusInfo struct {
+	Name        string `json:"name"`         // Human-readable display name
+	Description string `json:"description"`  // Detailed description of the status
+}
+
+// WorkflowStatusDisplayNames maps workflow status types to their human-readable display information
+var WorkflowStatusDisplayNames = map[models.RequestStatusType]WorkflowStatusInfo{
+	models.RequestStatusPending:   {Name: "Pending", Description: "Waiting to start"},
+	models.RequestStatusProcessing: {Name: "Processing", Description: "Currently executing"},
+	models.RequestStatusCompleted:  {Name: "Completed", Description: "Finished successfully"},
+	models.RequestStatusFailed:     {Name: "Failed", Description: "Encountered an error"},
+	models.RequestStatusDuplicate:  {Name: "Duplicate", Description: "Duplicate detected"},
 }
 
 // WorkflowStatus provides current status of a workflow instance


### PR DESCRIPTION
- Added OperationDisplay interface and implementation for operation types
- Added display info structs and maps for:
  - Operation types (with categories)
  - Request statuses
  - Workflow statuses
- Added helper functions to get display info
- Updated default status messages to use display info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added human-readable names and descriptions for operations, request statuses, and workflow statuses.
  * Introduced operation categories (network, storage, data) for clearer grouping and filtering.
  * Added expanded operation type labels and a fallback mechanism to derive display names when unavailable.
  * Standardized default status messages using a centralized display-info mapping.
  * Unified display metadata across workflows and UI surfaces for more consistent, readable labels and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->