### PR TITLE
refactor(service, core): extract operation finding logic into separate OperationFinder

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -3,10 +3,11 @@ package core
 import (
 	"context"
 	"fmt"
-	"github.com/knadh/koanf/v2"
-	"go.lumeweb.com/portal/db/models"
 	"reflect"
 	"strings"
+
+	"github.com/knadh/koanf/v2"
+	"go.lumeweb.com/portal/db/models"
 )
 
 // Default implementation
@@ -39,7 +40,7 @@ func (o *operation) DisplayName() string {
 			return info.Name
 		}
 	}
-	
+
 	// Fallback to the operation type (e.g., "ipfs.pin")
 	return o.opType
 }
@@ -55,9 +56,9 @@ const (
 
 // OperationTypeInfo contains human-readable display information for an operation type
 type OperationTypeInfo struct {
-	Name        string `json:"name"`         // Human-readable display name
-	Description string `json:"description"`  // Detailed description of the operation
-	Category    string `json:"category"`     // Category of the operation (network, storage, data)
+	Name        string `json:"name"`        // Human-readable display name
+	Description string `json:"description"` // Detailed description of the operation
+	Category    string `json:"category"`    // Category of the operation (network, storage, data)
 }
 
 // OperationTypeDisplayNames maps operation types to their human-readable display information
@@ -212,6 +213,16 @@ func NewUnstoreOperation(protocol string, handler OperationHandler) Operation {
 		OpTypeUnstore,
 		handler,
 	)
+}
+
+// OperationFinder provides methods for finding operations by type
+type OperationFinder interface {
+	// FindOperationHandler finds an operation handler by full operation type (e.g. "ipfs.pin")
+	FindOperationHandler(operationType string) (Operation, OperationHandler, error)
+	// FindProtocolOperation finds an operation handler for a protocol operation
+	FindProtocolOperation(operationType string) (Operation, OperationHandler, error)
+	// FindPluginOperation finds an operation handler for a plugin operation
+	FindPluginOperation(operationType string) (Operation, OperationHandler, error)
 }
 
 // OperationHelper provides helper methods for working with operations

--- a/service/operation_finder.go
+++ b/service/operation_finder.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+)
+
+const ContentScanOperation = "content.scan"
+
+// OperationFinder handles finding operations and their handlers
+type OperationFinder interface {
+	// FindOperationHandler locates the operation and handler for a given operation type
+	FindOperationHandler(operationType string) (core.Operation, core.OperationHandler, error)
+
+	// FindProtocolOperation searches registered protocols for the operation
+	FindProtocolOperation(operationType string) (core.Operation, core.OperationHandler, error)
+
+	// FindPluginOperation searches registered plugins for the operation
+	FindPluginOperation(operationType string) (core.Operation, core.OperationHandler, error)
+}
+
+// OperationFinderDefault is the default implementation of OperationFinder
+type operationCacheEntry struct {
+	op      core.Operation
+	handler core.OperationHandler
+}
+
+type OperationFinderDefault struct {
+	ctx       core.Context
+	logger    *core.Logger
+	opCache   map[string]operationCacheEntry
+	opCacheMu sync.RWMutex
+}
+
+// NewOperationFinder creates a new OperationFinder instance
+func NewOperationFinder(ctx core.Context) OperationFinder {
+	return &OperationFinderDefault{
+		ctx:     ctx,
+		logger:  ctx.Logger(),
+		opCache: make(map[string]operationCacheEntry),
+	}
+}
+
+// FindOperationHandler locates the operation and handler for a given operation type
+func (of *OperationFinderDefault) FindOperationHandler(operationType string) (core.Operation, core.OperationHandler, error) {
+	// Check cache first
+	of.opCacheMu.RLock()
+	cached, exists := of.opCache[operationType]
+	of.opCacheMu.RUnlock()
+	if exists {
+		return cached.op, cached.handler, nil
+	}
+
+	// First try to find operation in registered protocols
+	op, handler, err := of.FindProtocolOperation(operationType)
+	if err == nil {
+		of.opCacheMu.Lock()
+		of.opCache[operationType] = operationCacheEntry{op: op, handler: handler}
+		of.opCacheMu.Unlock()
+		return op, handler, nil
+	}
+
+	// If not found in protocols, try plugins
+	op, handler, err = of.FindPluginOperation(operationType)
+	if err == nil {
+		of.opCacheMu.Lock()
+		of.opCache[operationType] = operationCacheEntry{op: op, handler: handler}
+		of.opCacheMu.Unlock()
+		return op, handler, nil
+	}
+
+	// Special case for content scan operation
+	if operationType == ContentScanOperation {
+		scanner := core.NewNoContentScanner()
+		handler := &contentScanAdapter{scanner: scanner}
+		scanOp := core.NewOperation(ContentScanOperation, core.OpTypeScan, handler)
+		of.opCacheMu.Lock()
+		of.opCache[operationType] = operationCacheEntry{op: scanOp, handler: handler}
+		of.opCacheMu.Unlock()
+		return scanOp, handler, nil
+	}
+
+	return nil, nil, fmt.Errorf("operation not found: %s", operationType)
+}
+
+// FindProtocolOperation searches registered protocols for the operation
+func (of *OperationFinderDefault) FindProtocolOperation(operationType string) (core.Operation, core.OperationHandler, error) {
+	parts := strings.Split(operationType, ".")
+	if len(parts) < 2 {
+		return nil, nil, fmt.Errorf("invalid operation type format: %s", operationType)
+	}
+
+	protocolName := parts[0]
+	protocol := core.GetProtocol(protocolName)
+	if protocol == nil {
+		return nil, nil, fmt.Errorf("protocol not found: %s", protocolName)
+	}
+
+	for _, op := range protocol.Operations() {
+		if op.Type() == operationType {
+			return op, op.Handler(), nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("operation not found in protocol: %s", operationType)
+}
+
+// FindPluginOperation searches registered plugins for the operation
+func (of *OperationFinderDefault) FindPluginOperation(operationType string) (core.Operation, core.OperationHandler, error) {
+	plugins := core.GetPlugins()
+	for _, plugin := range plugins {
+		if plugin.Operations != nil {
+			ops, err := plugin.Operations(of.ctx)
+			if err != nil {
+				of.logger.Warn("Failed to get operations from plugin",
+					zap.String("plugin", plugin.ID),
+					zap.Error(err))
+				continue
+			}
+
+			for _, op := range ops {
+				if op.Type() == operationType {
+					return op, op.Handler(), nil
+				}
+			}
+		}
+	}
+
+	return nil, nil, fmt.Errorf("operation not found in plugins: %s", operationType)
+}

--- a/service/request.go
+++ b/service/request.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 
@@ -30,19 +29,13 @@ func init() {
 	})
 }
 
-type operationCacheEntry struct {
-	op      core.Operation
-	handler core.OperationHandler
-}
-
 type RequestServiceDefault struct {
-	ctx       core.Context
-	logger    *core.Logger
-	db        *gorm.DB
-	models    map[string]data_models.RequestDataModel
-	mutex     sync.RWMutex
-	opCache   map[string]operationCacheEntry
-	opCacheMu sync.RWMutex
+	ctx    core.Context
+	logger *core.Logger
+	db     *gorm.DB
+	models map[string]data_models.RequestDataModel
+	mutex  sync.RWMutex
+	ops    core.OperationFinder
 }
 
 func (r *RequestServiceDefault) RegisterRequestModel(operation string, model data_models.RequestDataModel) {
@@ -110,8 +103,7 @@ func (r *RequestServiceDefault) ListDistinctRequestFilters(ctx context.Context, 
 
 func NewRequestService() (core.Service, []core.ContextBuilderOption, error) {
 	req := &RequestServiceDefault{
-		models:  make(map[string]data_models.RequestDataModel),
-		opCache: make(map[string]operationCacheEntry),
+		models: make(map[string]data_models.RequestDataModel),
 	}
 
 	opts := core.ContextOptions(
@@ -119,6 +111,7 @@ func NewRequestService() (core.Service, []core.ContextBuilderOption, error) {
 			req.ctx = ctx
 			req.logger = ctx.ServiceLogger(req)
 			req.db = ctx.DB()
+			req.ops = NewOperationFinder(ctx)
 			return nil
 		}),
 	)
@@ -211,7 +204,7 @@ func (r *RequestServiceDefault) ExecuteRequest(ctx context.Context, id uint) err
 	}
 
 	// Find the operation handler
-	_, handler, err := r.findOperationHandler(req.Operation)
+	_, handler, err := r.ops.FindOperationHandler(req.Operation)
 	if err != nil {
 		return err
 	}
@@ -285,7 +278,7 @@ func (r *RequestServiceDefault) DeleteRequest(ctx context.Context, id uint) erro
 		return err
 	}
 
-	_, handler, err := r.findOperationHandler(req.Operation)
+	_, handler, err := r.ops.FindOperationHandler(req.Operation)
 	if err != nil {
 		r.logger.Warn("Could not find operation handler for cleanup",
 			zap.Error(err), zap.String("operation", req.Operation))
@@ -465,7 +458,7 @@ func (r *RequestServiceDefault) computeRequestStatus(ctx context.Context, id uin
 	}
 
 	// Find operation handler
-	_, handler, err := r.findOperationHandler(req.Operation)
+	_, handler, err := r.ops.FindOperationHandler(req.Operation)
 	if err != nil {
 		return nil, err
 	}
@@ -516,7 +509,7 @@ func (r *RequestServiceDefault) computeRequestStatus(ctx context.Context, id uin
 
 func (r *RequestServiceDefault) ValidateRequest(ctx context.Context, req *models.Request) error {
 	// Find the operation handler
-	_, handler, err := r.findOperationHandler(req.Operation)
+	_, handler, err := r.ops.FindOperationHandler(req.Operation)
 	if err != nil {
 		return fmt.Errorf("failed to find handler for operation %s: %w", req.Operation, err)
 	}
@@ -628,96 +621,6 @@ func (r *RequestServiceDefault) UpdateRequestData(ctx context.Context, req *mode
 
 	// Store in database
 	return r.db.Where("request_id = ?", req.ID).Save(model).Error
-}
-
-// findOperationHandler locates the operation and handler for a given operation type
-func (r *RequestServiceDefault) findOperationHandler(operationType string) (core.Operation, core.OperationHandler, error) {
-	// Check cache first
-	r.opCacheMu.RLock()
-	cached, exists := r.opCache[operationType]
-	r.opCacheMu.RUnlock()
-	if exists {
-		return cached.op, cached.handler, nil
-	}
-
-	// First try to find operation in registered protocols
-	op, handler, err := r.findProtocolOperation(operationType)
-	if err == nil {
-		r.cacheOperation(operationType, op, handler)
-		return op, handler, nil
-	}
-
-	// If not found in protocols, try plugins
-	op, handler, err = r.findPluginOperation(operationType)
-	if err == nil {
-		r.cacheOperation(operationType, op, handler)
-		return op, handler, nil
-	}
-
-	// Special case for content scan operation
-	if operationType == "content.scan" {
-		scanner := core.NewNoContentScanner()
-		scanOp := core.NewOperation("content.scan", core.OpTypeScan, scanner.(core.OperationHandler))
-		r.cacheOperation(operationType, scanOp, scanner.(core.OperationHandler))
-		return scanOp, scanner.(core.OperationHandler), nil
-	}
-
-	return nil, nil, fmt.Errorf("operation not found: %s", operationType)
-}
-
-func (r *RequestServiceDefault) cacheOperation(operationType string, op core.Operation, handler core.OperationHandler) {
-	r.opCacheMu.Lock()
-	defer r.opCacheMu.Unlock()
-	r.opCache[operationType] = operationCacheEntry{
-		op:      op,
-		handler: handler,
-	}
-}
-
-// findProtocolOperation searches registered protocols for the operation
-func (r *RequestServiceDefault) findProtocolOperation(operationType string) (core.Operation, core.OperationHandler, error) {
-	parts := strings.Split(operationType, ".")
-	if len(parts) < 2 {
-		return nil, nil, fmt.Errorf("invalid operation type format: %s", operationType)
-	}
-
-	protocolName := parts[0]
-	protocol := core.GetProtocol(protocolName)
-	if protocol == nil {
-		return nil, nil, fmt.Errorf("protocol not found: %s", protocolName)
-	}
-
-	for _, op := range protocol.Operations() {
-		if op.Type() == operationType {
-			return op, op.Handler(), nil
-		}
-	}
-
-	return nil, nil, fmt.Errorf("operation not found in protocol: %s", operationType)
-}
-
-// findPluginOperation searches registered plugins for the operation
-func (r *RequestServiceDefault) findPluginOperation(operationType string) (core.Operation, core.OperationHandler, error) {
-	plugins := core.GetPlugins()
-	for _, plugin := range plugins {
-		if plugin.Operations != nil {
-			ops, err := plugin.Operations(r.ctx)
-			if err != nil {
-				r.logger.Warn("Failed to get operations from plugin",
-					zap.String("plugin", plugin.ID),
-					zap.Error(err))
-				continue
-			}
-
-			for _, op := range ops {
-				if op.Type() == operationType {
-					return op, op.Handler(), nil
-				}
-			}
-		}
-	}
-
-	return nil, nil, fmt.Errorf("operation not found in plugins: %s", operationType)
 }
 
 func (r *RequestServiceDefault) QueryRequestData(ctx context.Context, query any, filter core.RequestFilter) (*models.Request, error) {


### PR DESCRIPTION
- Moved operation finding logic from RequestService to new OperationFinder interface
- Created OperationFinderDefault implementation with caching
- Updated RequestService to use OperationFinder
- Added OperationFinder interface to core package
- Cleaned up imports and formatting in operation.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for a new “content scan” operation.
- Refactor
  - Unified and centralized operation discovery across protocols and plugins for more consistent behavior.
- Performance
  - Introduced lightweight caching for faster repeat operation lookups.
- Reliability
  - Improved fallback logic when resolving operations, reducing edge-case failures.
- UX
  - Clearer error messages when an operation type is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->