### PR TITLE
fix(service, testing): correct handler type assertion and add DisplayName mocks

### DIFF
--- a/core/testing/mocks/Protocol.go
+++ b/core/testing/mocks/Protocol.go
@@ -83,6 +83,50 @@ func (_c *MockProtocol_Config_Call) RunAndReturn(run func() config.ProtocolConfi
 	return _c
 }
 
+// DisplayName provides a mock function for the type MockProtocol
+func (_mock *MockProtocol) DisplayName() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DisplayName")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockProtocol_DisplayName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DisplayName'
+type MockProtocol_DisplayName_Call struct {
+	*mock.Call
+}
+
+// DisplayName is a helper method to define mock.On call
+func (_e *MockProtocol_Expecter) DisplayName() *MockProtocol_DisplayName_Call {
+	return &MockProtocol_DisplayName_Call{Call: _e.mock.On("DisplayName")}
+}
+
+func (_c *MockProtocol_DisplayName_Call) Run(run func()) *MockProtocol_DisplayName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockProtocol_DisplayName_Call) Return(s string) *MockProtocol_DisplayName_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockProtocol_DisplayName_Call) RunAndReturn(run func() string) *MockProtocol_DisplayName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Name provides a mock function for the type MockProtocol
 func (_mock *MockProtocol) Name() string {
 	ret := _mock.Called()

--- a/core/testing/mocks/ProtocolParser.go
+++ b/core/testing/mocks/ProtocolParser.go
@@ -83,6 +83,50 @@ func (_c *MockProtocolParser_Config_Call) RunAndReturn(run func() config.Protoco
 	return _c
 }
 
+// DisplayName provides a mock function for the type MockProtocolParser
+func (_mock *MockProtocolParser) DisplayName() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DisplayName")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockProtocolParser_DisplayName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DisplayName'
+type MockProtocolParser_DisplayName_Call struct {
+	*mock.Call
+}
+
+// DisplayName is a helper method to define mock.On call
+func (_e *MockProtocolParser_Expecter) DisplayName() *MockProtocolParser_DisplayName_Call {
+	return &MockProtocolParser_DisplayName_Call{Call: _e.mock.On("DisplayName")}
+}
+
+func (_c *MockProtocolParser_DisplayName_Call) Run(run func()) *MockProtocolParser_DisplayName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockProtocolParser_DisplayName_Call) Return(s string) *MockProtocolParser_DisplayName_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockProtocolParser_DisplayName_Call) RunAndReturn(run func() string) *MockProtocolParser_DisplayName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Name provides a mock function for the type MockProtocolParser
 func (_mock *MockProtocolParser) Name() string {
 	ret := _mock.Called()

--- a/core/testing/mocks/TestingProtocolPinHandler.go
+++ b/core/testing/mocks/TestingProtocolPinHandler.go
@@ -207,6 +207,50 @@ func (_c *MockTestingProtocolPinHandler_DeleteProtocolPin_Call) RunAndReturn(run
 	return _c
 }
 
+// DisplayName provides a mock function for the type MockTestingProtocolPinHandler
+func (_mock *MockTestingProtocolPinHandler) DisplayName() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DisplayName")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockTestingProtocolPinHandler_DisplayName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DisplayName'
+type MockTestingProtocolPinHandler_DisplayName_Call struct {
+	*mock.Call
+}
+
+// DisplayName is a helper method to define mock.On call
+func (_e *MockTestingProtocolPinHandler_Expecter) DisplayName() *MockTestingProtocolPinHandler_DisplayName_Call {
+	return &MockTestingProtocolPinHandler_DisplayName_Call{Call: _e.mock.On("DisplayName")}
+}
+
+func (_c *MockTestingProtocolPinHandler_DisplayName_Call) Run(run func()) *MockTestingProtocolPinHandler_DisplayName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockTestingProtocolPinHandler_DisplayName_Call) Return(s string) *MockTestingProtocolPinHandler_DisplayName_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockTestingProtocolPinHandler_DisplayName_Call) RunAndReturn(run func() string) *MockTestingProtocolPinHandler_DisplayName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetProtocolPin provides a mock function for the type MockTestingProtocolPinHandler
 func (_mock *MockTestingProtocolPinHandler) GetProtocolPin(ctx context.Context, tx *gorm.DB, id uint) (any, error) {
 	ret := _mock.Called(ctx, tx, id)

--- a/core/testing/mocks/TestingProtocolRequestDataHandler.go
+++ b/core/testing/mocks/TestingProtocolRequestDataHandler.go
@@ -263,6 +263,50 @@ func (_c *MockTestingProtocolRequestDataHandler_DeleteProtocolData_Call) RunAndR
 	return _c
 }
 
+// DisplayName provides a mock function for the type MockTestingProtocolRequestDataHandler
+func (_mock *MockTestingProtocolRequestDataHandler) DisplayName() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for DisplayName")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockTestingProtocolRequestDataHandler_DisplayName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DisplayName'
+type MockTestingProtocolRequestDataHandler_DisplayName_Call struct {
+	*mock.Call
+}
+
+// DisplayName is a helper method to define mock.On call
+func (_e *MockTestingProtocolRequestDataHandler_Expecter) DisplayName() *MockTestingProtocolRequestDataHandler_DisplayName_Call {
+	return &MockTestingProtocolRequestDataHandler_DisplayName_Call{Call: _e.mock.On("DisplayName")}
+}
+
+func (_c *MockTestingProtocolRequestDataHandler_DisplayName_Call) Run(run func()) *MockTestingProtocolRequestDataHandler_DisplayName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockTestingProtocolRequestDataHandler_DisplayName_Call) Return(s string) *MockTestingProtocolRequestDataHandler_DisplayName_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockTestingProtocolRequestDataHandler_DisplayName_Call) RunAndReturn(run func() string) *MockTestingProtocolRequestDataHandler_DisplayName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetProtocolData provides a mock function for the type MockTestingProtocolRequestDataHandler
 func (_mock *MockTestingProtocolRequestDataHandler) GetProtocolData(ctx context.Context, tx *gorm.DB, id uint) (any, error) {
 	ret := _mock.Called(ctx, tx, id)

--- a/service/operation_finder.go
+++ b/service/operation_finder.go
@@ -76,12 +76,11 @@ func (of *OperationFinderDefault) FindOperationHandler(operationType string) (co
 	// Special case for content scan operation
 	if operationType == ContentScanOperation {
 		scanner := core.NewNoContentScanner()
-		handler := &contentScanAdapter{scanner: scanner}
-		scanOp := core.NewOperation(ContentScanOperation, core.OpTypeScan, handler)
+		scanOp := core.NewOperation("content.scan", core.OpTypeScan, scanner.(core.OperationHandler))
 		of.opCacheMu.Lock()
 		of.opCache[operationType] = operationCacheEntry{op: scanOp, handler: handler}
 		of.opCacheMu.Unlock()
-		return scanOp, handler, nil
+		return scanOp, scanner.(core.OperationHandler), nil
 	}
 
 	return nil, nil, fmt.Errorf("operation not found: %s", operationType)


### PR DESCRIPTION
- Fix type assertion in OperationFinder's content scan handler
- Updated testing mocks