### PR TITLE
refactor(tus,cron): centralize failure handling and add hash computation callback

### DIFF
--- a/core/testing/mocks/CronCoordinator.go
+++ b/core/testing/mocks/CronCoordinator.go
@@ -515,6 +515,57 @@ func (_c *MockCronCoordinator_Jobs_Call) RunAndReturn(run func() []gocron.Job) *
 	return _c
 }
 
+// RemoveJob provides a mock function for the type MockCronCoordinator
+func (_mock *MockCronCoordinator) RemoveJob(jobID uuid.UUID) error {
+	ret := _mock.Called(jobID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveJob")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(uuid.UUID) error); ok {
+		r0 = returnFunc(jobID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockCronCoordinator_RemoveJob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveJob'
+type MockCronCoordinator_RemoveJob_Call struct {
+	*mock.Call
+}
+
+// RemoveJob is a helper method to define mock.On call
+//   - jobID uuid.UUID
+func (_e *MockCronCoordinator_Expecter) RemoveJob(jobID interface{}) *MockCronCoordinator_RemoveJob_Call {
+	return &MockCronCoordinator_RemoveJob_Call{Call: _e.mock.On("RemoveJob", jobID)}
+}
+
+func (_c *MockCronCoordinator_RemoveJob_Call) Run(run func(jobID uuid.UUID)) *MockCronCoordinator_RemoveJob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 uuid.UUID
+		if args[0] != nil {
+			arg0 = args[0].(uuid.UUID)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockCronCoordinator_RemoveJob_Call) Return(err error) *MockCronCoordinator_RemoveJob_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockCronCoordinator_RemoveJob_Call) RunAndReturn(run func(jobID uuid.UUID) error) *MockCronCoordinator_RemoveJob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetHeartbeat provides a mock function for the type MockCronCoordinator
 func (_mock *MockCronCoordinator) SetHeartbeat(jobID uuid.UUID) error {
 	ret := _mock.Called(jobID)

--- a/core/testing/mocks/WorkflowCoordinator.go
+++ b/core/testing/mocks/WorkflowCoordinator.go
@@ -311,6 +311,63 @@ func (_c *MockWorkflowCoordinator_DisableWorkflow_Call) RunAndReturn(run func(na
 	return _c
 }
 
+// DispatchWorkflowStep provides a mock function for the type MockWorkflowCoordinator
+func (_mock *MockWorkflowCoordinator) DispatchWorkflowStep(ctx context.Context, requestID uint) error {
+	ret := _mock.Called(ctx, requestID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DispatchWorkflowStep")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, requestID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowCoordinator_DispatchWorkflowStep_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DispatchWorkflowStep'
+type MockWorkflowCoordinator_DispatchWorkflowStep_Call struct {
+	*mock.Call
+}
+
+// DispatchWorkflowStep is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+func (_e *MockWorkflowCoordinator_Expecter) DispatchWorkflowStep(ctx interface{}, requestID interface{}) *MockWorkflowCoordinator_DispatchWorkflowStep_Call {
+	return &MockWorkflowCoordinator_DispatchWorkflowStep_Call{Call: _e.mock.On("DispatchWorkflowStep", ctx, requestID)}
+}
+
+func (_c *MockWorkflowCoordinator_DispatchWorkflowStep_Call) Run(run func(ctx context.Context, requestID uint)) *MockWorkflowCoordinator_DispatchWorkflowStep_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowCoordinator_DispatchWorkflowStep_Call) Return(err error) *MockWorkflowCoordinator_DispatchWorkflowStep_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowCoordinator_DispatchWorkflowStep_Call) RunAndReturn(run func(ctx context.Context, requestID uint) error) *MockWorkflowCoordinator_DispatchWorkflowStep_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // EnableWorkflow provides a mock function for the type MockWorkflowCoordinator
 func (_mock *MockWorkflowCoordinator) EnableWorkflow(name string) error {
 	ret := _mock.Called(name)

--- a/core/testing/mocks/WorkflowService.go
+++ b/core/testing/mocks/WorkflowService.go
@@ -379,6 +379,63 @@ func (_c *MockWorkflowService_DisableWorkflow_Call) RunAndReturn(run func(name s
 	return _c
 }
 
+// DispatchWorkflowStep provides a mock function for the type MockWorkflowService
+func (_mock *MockWorkflowService) DispatchWorkflowStep(ctx context.Context, requestID uint) error {
+	ret := _mock.Called(ctx, requestID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DispatchWorkflowStep")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) error); ok {
+		r0 = returnFunc(ctx, requestID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockWorkflowService_DispatchWorkflowStep_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DispatchWorkflowStep'
+type MockWorkflowService_DispatchWorkflowStep_Call struct {
+	*mock.Call
+}
+
+// DispatchWorkflowStep is a helper method to define mock.On call
+//   - ctx context.Context
+//   - requestID uint
+func (_e *MockWorkflowService_Expecter) DispatchWorkflowStep(ctx interface{}, requestID interface{}) *MockWorkflowService_DispatchWorkflowStep_Call {
+	return &MockWorkflowService_DispatchWorkflowStep_Call{Call: _e.mock.On("DispatchWorkflowStep", ctx, requestID)}
+}
+
+func (_c *MockWorkflowService_DispatchWorkflowStep_Call) Run(run func(ctx context.Context, requestID uint)) *MockWorkflowService_DispatchWorkflowStep_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockWorkflowService_DispatchWorkflowStep_Call) Return(err error) *MockWorkflowService_DispatchWorkflowStep_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockWorkflowService_DispatchWorkflowStep_Call) RunAndReturn(run func(ctx context.Context, requestID uint) error) *MockWorkflowService_DispatchWorkflowStep_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // EnableWorkflow provides a mock function for the type MockWorkflowService
 func (_mock *MockWorkflowService) EnableWorkflow(name string) error {
 	ret := _mock.Called(name)

--- a/core/tus.go
+++ b/core/tus.go
@@ -64,6 +64,9 @@ type TUSUploadCreatedVerifyFunc func(hook handler.HookEvent, uploaderId uint) (S
 // TUSUploadCreatedAfterFunc defines a callback that runs after upload creation
 type TUSUploadCreatedAfterFunc func(requestId uint) error
 
+// TUSUploadCompletedHashFunc defines a callback that computes and returns the multihash for a completed upload
+type TUSUploadCompletedHashFunc func(handlr TusHandler, hook handler.HookEvent) (StorageHash, error)
+
 // TUSPreFinishResponseCallback defines a callback that runs before finishing an upload
 // Can modify the HTTP response before it's sent to the client
 type TUSPreFinishResponseCallback func(hook handler.HookEvent) (handler.HTTPResponse, error)

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -264,57 +264,13 @@ func (s *StandaloneCoordinator) EnqueueJob(jobID uuid.UUID) error {
 			zap.Error(err))
 
 		s.failureMu.Lock()
-		defer s.failureMu.Unlock()
-
 		// Increment failure count
 		s.failureCounts[jobID]++
+		failures := s.failureCounts[jobID]
+		s.failureMu.Unlock()
 
-		var retryPolicy *core.RetryPolicy
-		if dbJob, err := s.getJobRecord(jobID); err == nil && len(dbJob.RetryPolicy) > 0 {
-			if err := json.Unmarshal([]byte(dbJob.RetryPolicy), &retryPolicy); err != nil {
-				s.logger.Error("Failed to parse retry policy",
-					zap.String("jobID", jobID.String()),
-					zap.Error(err))
-			}
-		}
-
-		maxFailures := s.maxFailures
-		if retryPolicy != nil && retryPolicy.MaxRetries > 0 {
-			maxFailures = retryPolicy.MaxRetries
-		}
-
-		if s.failureCounts[jobID] >= maxFailures {
-			s.logger.Error("Job exceeded maximum failure threshold - marking as permanently failed",
-				zap.String("jobID", jobID.String()),
-				zap.Int("failures", s.failureCounts[jobID]))
-
-			// Transition to permanent failure state
-			if err := s.stateMachine.Transition(
-				context.Background(),
-				jobID,
-				models.CronJobStateFailed,
-				core.WithCronFailures(s.failureCounts[jobID]),
-			); err != nil {
-				s.logger.Error("Failed to transition job to failed state",
-					zap.String("jobID", jobID.String()),
-					zap.Error(err))
-			}
-
-			// Remove from scheduler
-			if err := s.scheduler.RemoveJob(jobID); err != nil {
-				s.logger.Error("Failed to remove failed job from scheduler",
-					zap.String("jobID", jobID.String()),
-					zap.Error(err))
-			}
-
-			// Clean up resources
-			delete(s.failureCounts, jobID)
-			s.cancelJobContext(jobID)
-			return
-		}
-
-		// Standard failure handling
-		if err := s.HandleFailedJob(jobID, uint(s.failureCounts[jobID])); err != nil {
+		// Handle all failure transitions through HandleFailedJob
+		if err := s.HandleFailedJob(jobID, uint(failures)); err != nil {
 			s.logger.Error("Failed to handle failed job",
 				zap.String("jobID", jobID.String()),
 				zap.Error(err))
@@ -328,14 +284,15 @@ func (s *StandaloneCoordinator) EnqueueJob(jobID uuid.UUID) error {
 			zap.String("jobName", jobName),
 			zap.Any("recoverData", recoverData))
 
-		// Attempt to handle the failed job (e.g., requeue)
-		var currentJob models.CronJob
-		err = s.db.Where(&models.CronJob{UUID: types.FromUUID(jobID)}).First(&currentJob).Error
-		if err != nil {
-			s.logger.Error("Failed to get job failure count", zap.String("jobID", jobID.String()), zap.Error(err))
-			return
-		}
-		if err = s.HandleFailedJob(jobID, currentJob.Failures+1); err != nil {
+		s.failureMu.Lock()
+		// Increment failure count
+		s.failureCounts[jobID]++
+		failures := s.failureCounts[jobID]
+		s.failureMu.Unlock()
+
+		// Handle all failure transitions through HandleFailedJob
+		// For panic recovery, we'll treat it as a retryable failure (not permanent)
+		if err := s.HandleFailedJob(jobID, uint(failures)); err != nil {
 			s.logger.Error("Failed to handle failed job", zap.String("jobID", jobID.String()), zap.Error(err))
 		}
 	}
@@ -367,6 +324,9 @@ func (s *StandaloneCoordinator) HandleFailedJob(jobID uuid.UUID, failures uint) 
 	// Cancel any existing context first
 	s.cancelJobContext(jobID)
 
+	// Stop heartbeat monitoring
+	s.cronService.Monitor().StopHeartbeat(jobID)
+
 	// Update job state to failed and increment failures
 	ctx, cancel := context.WithCancel(s.ctx)
 	defer cancel()
@@ -380,7 +340,33 @@ func (s *StandaloneCoordinator) HandleFailedJob(jobID uuid.UUID, failures uint) 
 		return fmt.Errorf("failed to update job status: %w", err)
 	}
 
-	// Requeue the job
+	// Determine if this is a permanent failure based on retry policy
+	var retryPolicy *core.RetryPolicy
+	if dbJob, err := s.getJobRecord(jobID); err == nil && len(dbJob.RetryPolicy) > 0 {
+		if err := json.Unmarshal([]byte(dbJob.RetryPolicy), &retryPolicy); err != nil {
+			s.logger.Error("Failed to parse retry policy",
+				zap.String("jobID", jobID.String()),
+				zap.Error(err))
+		}
+	}
+
+	maxFailures := s.maxFailures
+	if retryPolicy != nil && retryPolicy.MaxRetries > 0 {
+		maxFailures = retryPolicy.MaxRetries
+	}
+
+	permanent := int(failures) >= maxFailures
+
+	// If this is a permanent failure, don't requeue
+	if permanent {
+		s.logger.Error("Job exceeded maximum failure threshold - marking as permanently failed",
+			zap.String("jobID", jobID.String()),
+			zap.Uint("failures", failures),
+			zap.Int("maxFailures", maxFailures))
+		return nil
+	}
+
+	// Requeue the job for retry
 	if err := s.EnqueueJob(jobID); err != nil {
 		return fmt.Errorf("failed to requeue job: %w", err)
 	}

--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -521,7 +521,7 @@ func DefaultUploadTerminatedHandler(ctx core.Context) core.TUSUploadCallbackHand
 	}
 }
 
-func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUploadCallbackHandler) core.TUSUploadCallbackHandler {
+func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUploadCallbackHandler, hashCallback core.TUSUploadCompletedHashFunc, workflowName string) core.TUSUploadCallbackHandler {
 	return func(handlr core.TusHandler, hook handler.HookEvent) {
 		sp, err := handlr.StorageProtocol()
 		if err != nil {
@@ -530,6 +530,30 @@ func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUplo
 			ctx.Logger().Error(errMessage, zap.Error(err))
 			return
 		}
+
+		// Compute hash if callback is provided
+		var computedHash core.StorageHash
+		if hashCallback != nil {
+			computedHash, err = hashCallback(handlr, hook)
+			if err != nil {
+				errMessage := "Failed to compute hash"
+				handlr.HandleEventResponseError(errMessage, http.StatusInternalServerError, hook)
+				ctx.Logger().Error(errMessage, zap.Error(err))
+				return
+			}
+
+			// Update the request with the computed hash using TUS service
+			if computedHash != nil {
+				err = handlr.SetHashById(ctx, hook.Upload.ID, computedHash)
+				if err != nil {
+					errMessage := "Failed to update request with computed hash"
+					handlr.HandleEventResponseError(errMessage, http.StatusInternalServerError, hook)
+					ctx.Logger().Error(errMessage, zap.Error(err))
+					return
+				}
+			}
+		}
+
 		err = core.GetService[core.TUSService](ctx, core.TUS_SERVICE).UploadProcessing(ctx, sp, hook.Upload.ID)
 		if err != nil {
 			errMessage := "Failed to update upload status"
@@ -540,6 +564,49 @@ func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUplo
 
 		if processHandler != nil {
 			processHandler(handlr, hook)
+		}
+
+		// Get services for workflow processing
+		requestSvc := core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
+		tusService := core.GetService[core.TUSService](ctx, core.TUS_SERVICE)
+		workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+
+		// Check if this upload exists
+		exists, tusReq := tusService.UploadExists(ctx, sp, hook.Upload.ID)
+		if !exists {
+			return // Not our upload, nothing to do
+		}
+
+		// Verify request exists
+		exists, err = requestSvc.RequestExists(ctx, tusReq.RequestID)
+		if !exists || err != nil {
+			ctx.Logger().Error("Failed to get request", zap.Error(err))
+			return
+		}
+
+		// Convert and execute workflow
+		err = workflowSvc.ConvertRequestToWorkflow(ctx, tusReq.RequestID, workflowName, 0)
+		if err != nil {
+			ctx.Logger().Error("Failed to convert request to workflow", zap.Error(err))
+			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID,
+				fmt.Sprintf("Workflow conversion failed: %v", err)); updateErr != nil {
+				ctx.Logger().Error("Failed to update request status",
+					zap.Error(updateErr),
+					zap.Uint("requestID", tusReq.RequestID))
+			}
+			return
+		}
+
+		// Dispatch the first workflow step using the public interface
+		err = workflowSvc.DispatchWorkflowStep(ctx, tusReq.RequestID)
+		if err != nil {
+			ctx.Logger().Error("Failed to dispatch workflow step", zap.Error(err))
+			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID,
+				fmt.Sprintf("Workflow dispatch failed: %v", err)); updateErr != nil {
+				ctx.Logger().Error("Failed to update request status",
+					zap.Error(updateErr),
+					zap.Uint("requestID", tusReq.RequestID))
+			}
 		}
 	}
 }

--- a/service/tus.go
+++ b/service/tus.go
@@ -400,83 +400,8 @@ func (h *TUSOperationHandler) Cleanup(ctx context.Context, req *models.Request) 
 	return nil
 }
 
-func TUSDefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUploadCallbackHandler, workflowName string) core.TUSUploadCallbackHandler {
-	return func(handlr core.TusHandler, info tusHandler.HookEvent) {
-		// Call the original handler first
-		processHandler(handlr, info)
-
-		// Get services
-		requestSvc := core.GetService[core.RequestService](ctx, core.REQUEST_SERVICE)
-		tusService := core.GetService[core.TUSService](ctx, core.TUS_SERVICE)
-		workflowSvc := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
-
-		storageProtoMissing := false
-
-		// Get storage protocol first
-		sproto, err := handlr.StorageProtocol()
-		if err != nil {
-			storageProtoMissing = true
-		}
-
-		// Check if this upload exists
-		exists, tusReq := tusService.UploadExists(ctx, sproto, info.Upload.ID)
-		if !exists {
-			return // Not our upload, nothing to do
-		}
-
-		// Verify request exists
-		exists, err = requestSvc.RequestExists(ctx, tusReq.RequestID)
-		if !exists || err != nil {
-			ctx.Logger().Error("Failed to get request", zap.Error(err))
-			return
-		}
-
-		if workflowSvc == nil {
-			ctx.Logger().Error("Workflow service not available")
-			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID, "Workflow service unavailable"); updateErr != nil {
-				ctx.Logger().Error("Failed to update request status",
-					zap.Error(updateErr),
-					zap.Uint("requestID", tusReq.RequestID))
-			}
-			return
-		}
-
-		if storageProtoMissing {
-			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID, "Storage protocol missing"); updateErr != nil {
-				ctx.Logger().Error("Failed to update request status",
-					zap.Error(updateErr),
-					zap.Uint("requestID", tusReq.RequestID))
-			} else {
-				ctx.Logger().Error("Failed to get storage protocol", zap.Error(err), zap.Uint("requestID", tusReq.RequestID))
-			}
-
-		}
-
-		// Convert and execute workflow
-		err = workflowSvc.ConvertRequestToWorkflow(ctx, tusReq.RequestID, workflowName, 0)
-		if err != nil {
-			ctx.Logger().Error("Failed to convert request to workflow", zap.Error(err))
-			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID,
-				fmt.Sprintf("Workflow conversion failed: %v", err)); updateErr != nil {
-				ctx.Logger().Error("Failed to update request status",
-					zap.Error(updateErr),
-					zap.Uint("requestID", tusReq.RequestID))
-			}
-			return
-		}
-
-		// Dispatch the first workflow step using the public interface
-		err = workflowSvc.DispatchWorkflowStep(ctx, tusReq.RequestID)
-		if err != nil {
-			ctx.Logger().Error("Failed to dispatch workflow step", zap.Error(err))
-			if updateErr := requestSvc.FailRequest(ctx, tusReq.RequestID,
-				fmt.Sprintf("Workflow dispatch failed: %v", err)); updateErr != nil {
-				ctx.Logger().Error("Failed to update request status",
-					zap.Error(updateErr),
-					zap.Uint("requestID", tusReq.RequestID))
-			}
-		}
-	}
+func TUSDefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUploadCallbackHandler, workflowName string, hashCallback core.TUSUploadCompletedHashFunc) core.TUSUploadCallbackHandler {
+	return tus.DefaultUploadCompletedHandler(ctx, processHandler, hashCallback, workflowName)
 }
 
 func TUSDefaultUploadTerminatedHandler(ctx core.Context) core.TUSUploadCallbackHandler {


### PR DESCRIPTION
- Refactored cron job failure handling to be managed within `HandleFailedJob`, including permanent failure logic based on retry policies
- Updated mocks
- Enhanced TUS upload completion handler to support hash computation via a new `TUSUploadCompletedHashFunc` callback
- Moved TUS workflow processing logic into a shared `DefaultUploadCompletedHandler` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Upload completion can now compute and store a content hash and automatically trigger the next workflow step.
  - More configurable upload-completion handler to integrate hashing and workflow orchestration.

- Refactor
  - Centralized and more resilient job failure handling with policy-driven retries, backoff delays, and consistent cleanup and logging for improved reliability.

- Tests
  - Expanded test mocks to support job removal and workflow step dispatch, enabling more comprehensive testing of new behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->