### PR TITLE
fix(tus): update request hash and CID type correctly

### DIFF
--- a/service/tus.go
+++ b/service/tus.go
@@ -247,10 +247,15 @@ func (t *TUSServiceDefault) SetHash(ctx context.Context, protocol core.StoragePr
 		return core.ErrUploadNotFound
 	}
 
-	upload.Request.Hash = hash.Multihash()
-	upload.Request.CIDType = hash.CIDType()
+	req, err := t.requests.GetRequest(ctx, upload.RequestID)
+	if err != nil {
+		return err
+	}
 
-	err := t.requests.UpdateRequest(ctx, &upload.Request)
+	req.Hash = hash.Multihash()
+	req.CIDType = hash.CIDType()
+
+	err = t.requests.UpdateRequest(ctx, req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Retrieve the request using the request ID before updating
- Set the hash and CID type on the retrieved request instance
- Update the request in the database with the modified instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving upload metadata, ensuring the hash and content ID type are consistently updated.
  * Reduced chances of stale or partially updated upload information by validating the current request state before applying changes.
  * Enhanced error handling during metadata updates, lowering the likelihood of intermittent failures users might encounter during uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->