### PR TITLE
feat(core): add custom name support to operations

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -16,6 +16,7 @@ type operation struct {
 	opType     string
 	globalType OperationType
 	handler    OperationHandler
+	name       string
 }
 
 // Ensure operation implements OperationDisplay
@@ -33,8 +34,20 @@ func (o *operation) Handler() OperationHandler {
 	return o.handler
 }
 
+func (o *operation) Name() string {
+	if o.name != "" {
+		return o.name
+	}
+	return o.DisplayName()
+}
+
 // DisplayName returns the human-readable display name for this operation
 func (o *operation) DisplayName() string {
+	// If this operation has a custom name, use it
+	if o.name != "" {
+		return o.name
+	}
+
 	// If this operation has a global type, use the display info from the map
 	if o.globalType != "" {
 		if info, exists := GetOperationTypeDisplayInfo(o.globalType); exists {
@@ -95,6 +108,7 @@ type Operation interface {
 	Type() string              // Specific operation name (e.g., "ipfs.pin" or "ipfs.pin.car")
 	GlobalType() OperationType // Optional global type mapping (e.g., OpTypePin) or empty for custom ops
 	Handler() OperationHandler // The handler implementation
+	Name() string             // Custom name for the operation
 }
 
 // OperationDisplay provides human-readable display information for operations
@@ -186,10 +200,15 @@ func formatOperationName(parts ...string) string {
 }
 
 func NewOperation(opType string, globalType OperationType, handler OperationHandler) Operation {
+	return NewNamedOperation(opType, globalType, handler, "")
+}
+
+func NewNamedOperation(opType string, globalType OperationType, handler OperationHandler, name string) Operation {
 	return &operation{
 		opType:     opType,
 		globalType: globalType,
 		handler:    handler,
+		name:       name,
 	}
 }
 

--- a/core/operation.go
+++ b/core/operation.go
@@ -38,15 +38,6 @@ func (o *operation) Name() string {
 	if o.name != "" {
 		return o.name
 	}
-	return o.DisplayName()
-}
-
-// DisplayName returns the human-readable display name for this operation
-func (o *operation) DisplayName() string {
-	// If this operation has a custom name, use it
-	if o.name != "" {
-		return o.name
-	}
 
 	// If this operation has a global type, use the display info from the map
 	if o.globalType != "" {
@@ -57,6 +48,11 @@ func (o *operation) DisplayName() string {
 
 	// Fallback to the operation type (e.g., "ipfs.pin")
 	return o.opType
+}
+
+// DisplayName returns the human-readable display name for this operation
+func (o *operation) DisplayName() string {
+	return o.Name()
 }
 
 type OperationType string


### PR DESCRIPTION
- Add `name` field to `operation` struct
- Implement `Name()` method to return custom name or fallback to display name
- Add `NewNamedOperation()` function to create operations with custom names
- Modify `NewOperation()` to use `NewNamedOperation()` with empty name
- Update `Operation` interface to include `Name()` method
- Enhance `DisplayName()` to prioritize custom name if set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support for custom operation names. When provided, the custom name is used in displays; otherwise, the default name is used.
- API Updates
  - Added a public way to retrieve an operation’s custom name.
  - Introduced a constructor to create operations with a custom name.
  - Existing constructor remains available and behaves as before, delegating to the new named variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->