### PR TITLE
refactor(testing): replace require with mock and simplify router setup in MockAPI

### DIFF
--- a/core/testing/api.go
+++ b/core/testing/api.go
@@ -3,7 +3,7 @@ package testing
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/mock"
 	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
@@ -64,8 +64,6 @@ func NewMockAPI(t testing.TB, name string) *MockAPI {
 	}
 
 	apiInfo := router.APIInfo().Title("Test").Version("0.1.0")
-	_router, err := router.NewRouter(apiInfo)
-	require.NoError(t, err)
 
 	mockAPI.openAPIInfoValue = apiInfo
 
@@ -75,7 +73,9 @@ func NewMockAPI(t testing.TB, name string) *MockAPI {
 	mockAPI.EXPECT().Subdomain().Return("").Maybe()
 	mockAPI.EXPECT().AuthTokenName().Return("").Maybe()
 	mockAPI.EXPECT().OpenAPIInfo().Return(apiInfo).Maybe()
-	mockAPI.EXPECT().Configure(_router, new(core.AccessService)).Return(nil).Maybe()
+	routerType := "*swagger.Router[github.com/labstack/echo/v4.HandlerFunc,github.com/labstack/echo/v4.MiddlewareFunc,*github.com/labstack/echo/v4.Route]"
+	mockAPI.EXPECT().Configure(mock.AnythingOfType(routerType), mock.AnythingOfType("core.AccessService")).Return(nil).Maybe()
+	mockAPI.EXPECT().Configure(mock.AnythingOfType(routerType), mock.AnythingOfType("*testing.MockAccessService")).Return(nil).Maybe()
 
 	return mockAPI
 }

--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -181,10 +181,40 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 			factory := mockSvcFactory.factory
 			depends := mockSvcFactory.depends
 
-			// Call the factory function immediately with stored context's TB
+			// Validate factory is a function with correct signature
 			factoryValue := reflect.ValueOf(factory)
+			if factoryValue.Kind() != reflect.Func {
+				return nil, nil, fmt.Errorf("mock service factory for '%s' is not a function", id)
+			}
+
+			factoryType := factoryValue.Type()
+			if factoryType.NumIn() != 1 {
+				return nil, nil, fmt.Errorf("mock service factory for '%s' does not have exactly 1 input parameter", id)
+			}
+
+			expectedType := reflect.TypeOf(b.ctx.T())
+			if !factoryType.In(0).AssignableTo(expectedType) {
+				return nil, nil, fmt.Errorf("mock service factory for '%s' first parameter is not assignable from %v", id, expectedType)
+			}
+
+			// Call the factory function immediately with stored context's TB
 			tbValue := reflect.ValueOf(b.ctx.T())
-			results := factoryValue.Call([]reflect.Value{tbValue})
+			
+			// Wrap the call in a recover to prevent panics from crashing the process
+			var results []reflect.Value
+			var callErr error
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						callErr = fmt.Errorf("mock service factory for '%s' panicked: %v", id, r)
+					}
+				}()
+				results = factoryValue.Call([]reflect.Value{tbValue})
+			}()
+			
+			if callErr != nil {
+				return nil, nil, callErr
+			}
 
 			// Get the mock instance from the results
 			if len(results) == 0 {
@@ -196,14 +226,17 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 				return nil, nil, fmt.Errorf("mock service factory for '%s' returned nil", id)
 			}
 
-			// Capture the mock instance in the closure
-			mockInst := mockInstance
+			// Validate that mockInstance implements core.Service
+			mockInst, ok := mockInstance.(core.Service)
+			if !ok {
+				return nil, nil, fmt.Errorf("mock service factory for '%s' did not return a core.Service implementation", id)
+			}
 
 			// Add to services list with a factory that returns the mock instance
 			allServices = append(allServices, core.ServiceInfo{
 				ID: id,
 				Factory: func() (core.Service, []core.ContextBuilderOption, error) {
-					return mockInst.(core.Service), nil, nil
+					return mockInst, nil, nil
 				},
 				Depends: depends,
 			})

--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -1,15 +1,33 @@
 package testing
 
 import (
+	"fmt"
+	"reflect"
+
 	"go.lumeweb.com/portal/build"
 	"go.lumeweb.com/portal/core"
 )
 
+type mockServiceEntry struct {
+	id      string
+	factory func(tb TB, ctx TestContext) any
+	depends []string
+}
+
+type mockServiceFactoryEntry struct {
+	id      string
+	factory interface{}
+	depends []string
+}
+
 // MockPluginBuilder is a builder for creating PluginInfo structs for testing.
 type MockPluginBuilder struct {
-	plugin     core.PluginInfo
-	services   []core.ServiceInfo
-	extensions []core.APIExtensionFactory
+	plugin               core.PluginInfo
+	services             []core.ServiceInfo
+	extensions           []core.APIExtensionFactory
+	mockServices         []mockServiceEntry
+	mockServiceFactories []mockServiceFactoryEntry
+	ctx                  TestContext
 }
 
 // NewMockPluginBuilder creates a new MockPluginBuilder with a default ID.
@@ -19,8 +37,10 @@ func NewMockPluginBuilder(id string) *MockPluginBuilder {
 			ID:      id,
 			Version: build.New("", "", "", "", "", "", ""),
 		},
-		services:   make([]core.ServiceInfo, 0),
-		extensions: make([]core.APIExtensionFactory, 0),
+		services:             make([]core.ServiceInfo, 0),
+		extensions:           make([]core.APIExtensionFactory, 0),
+		mockServices:         make([]mockServiceEntry, 0),
+		mockServiceFactories: make([]mockServiceFactoryEntry, 0),
 	}
 }
 
@@ -51,6 +71,18 @@ func (b *MockPluginBuilder) WithProtocol(protocol core.ProtocolFactory) *MockPlu
 // WithService adds an individual service to the plugin with its dependencies.
 func (b *MockPluginBuilder) WithService(id string, factory core.ServiceFactory, depends ...string) *MockPluginBuilder {
 	b.services = append(b.services, core.ServiceInfo{ID: id, Factory: factory, Depends: depends})
+	return b
+}
+
+// WithMockService adds a mock service to the plugin with its dependencies.
+func (b *MockPluginBuilder) WithMockService(id string, factory func(tb TB, ctx TestContext) any, depends ...string) *MockPluginBuilder {
+	b.mockServices = append(b.mockServices, mockServiceEntry{id: id, factory: factory, depends: depends})
+	return b
+}
+
+// WithMockServiceFactory adds a mock service factory to the plugin with its dependencies.
+func (b *MockPluginBuilder) WithMockServiceFactory(id string, factory interface{}, depends ...string) *MockPluginBuilder {
+	b.mockServiceFactories = append(b.mockServiceFactories, mockServiceFactoryEntry{id: id, factory: factory, depends: depends})
 	return b
 }
 
@@ -103,25 +135,86 @@ func (b *MockPluginBuilder) WithTargetApps(targetApps ...string) *MockPluginBuil
 }
 
 // Build returns the constructed PluginInfo.
-func (b *MockPluginBuilder) Build() *MockPluginBuilder {
+func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, error) {
 	if len(b.extensions) > 0 {
 		b.plugin.APIExtensions = func(context core.Context) ([]core.APIExtensionFactory, error) {
 			return b.extensions, nil
 		}
 	}
 
-	if len(b.services) > 0 {
+	if len(b.services) > 0 || len(b.mockServices) > 0 || len(b.mockServiceFactories) > 0 {
+		allServices := make([]core.ServiceInfo, 0, len(b.services)+len(b.mockServices)+len(b.mockServiceFactories))
+		allServices = append(allServices, b.services...)
+
+		// Process mock services - add to services list with no-op factories
+		for _, mockSvc := range b.mockServices {
+			id := mockSvc.id
+			factory := mockSvc.factory
+			depends := mockSvc.depends
+
+			// Create the mock instance immediately using stored context
+			mockInstance := factory(b.ctx.T(), b.ctx)
+			if mockInstance == nil {
+				return nil, nil, fmt.Errorf("mock service factory for '%s' returned nil", id)
+			}
+
+			// Add to services list with a no-op factory
+			allServices = append(allServices, core.ServiceInfo{
+				ID: id,
+				Factory: func() (core.Service, []core.ContextBuilderOption, error) {
+					return nil, nil, nil
+				},
+				Depends: depends,
+			})
+		}
+
+		// Process mock service factories - add to services list with no-op factories
+		for _, mockSvcFactory := range b.mockServiceFactories {
+			id := mockSvcFactory.id
+			factory := mockSvcFactory.factory
+			depends := mockSvcFactory.depends
+
+			// Call the factory function immediately with stored context's TB
+			factoryValue := reflect.ValueOf(factory)
+			tbValue := reflect.ValueOf(b.ctx.T())
+			results := factoryValue.Call([]reflect.Value{tbValue})
+
+			// Get the mock instance from the results
+			if len(results) == 0 {
+				return nil, nil, fmt.Errorf("mock service factory for '%s' returned no values", id)
+			}
+
+			mockInstance := results[0].Interface()
+			if mockInstance == nil {
+				return nil, nil, fmt.Errorf("mock service factory for '%s' returned nil", id)
+			}
+
+			// Add to services list with a no-op factory
+			allServices = append(allServices, core.ServiceInfo{
+				ID: id,
+				Factory: func() (core.Service, []core.ContextBuilderOption, error) {
+					return mockInstance.(core.Service), nil, nil
+				},
+				Depends: depends,
+			})
+		}
+
 		b.plugin.Services = func() ([]core.ServiceInfo, error) {
-			return b.services, nil
+			return allServices, nil
 		}
 	}
 
-	return b
+	return nil, []core.ContextBuilderOption{}, nil
 }
 
 // PluginOption returns a ContextBuilderOption that registers the built plugin.
 func (b *MockPluginBuilder) BuilderOption() TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
+		b.ctx = ctx // Store the context
+		_, _, err := b.Build()
+		if err != nil {
+			return ctx, err
+		}
 		core.RegisterPlugin(b.plugin)
 		return ctx, nil
 	}

--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -136,6 +136,10 @@ func (b *MockPluginBuilder) WithTargetApps(targetApps ...string) *MockPluginBuil
 
 // Build returns the constructed PluginInfo.
 func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, error) {
+	if b.ctx == nil {
+		return nil, nil, fmt.Errorf("test context is nil - Build() requires a non-nil context")
+	}
+
 	if len(b.extensions) > 0 {
 		b.plugin.APIExtensions = func(context core.Context) ([]core.APIExtensionFactory, error) {
 			return b.extensions, nil
@@ -158,11 +162,14 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 				return nil, nil, fmt.Errorf("mock service factory for '%s' returned nil", id)
 			}
 
-			// Add to services list with a no-op factory
+			// Capture the mock instance in the closure
+			mockInst := mockInstance
+
+			// Add to services list with a factory that returns the mock instance
 			allServices = append(allServices, core.ServiceInfo{
 				ID: id,
 				Factory: func() (core.Service, []core.ContextBuilderOption, error) {
-					return nil, nil, nil
+					return mockInst.(core.Service), nil, nil
 				},
 				Depends: depends,
 			})
@@ -189,11 +196,14 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 				return nil, nil, fmt.Errorf("mock service factory for '%s' returned nil", id)
 			}
 
-			// Add to services list with a no-op factory
+			// Capture the mock instance in the closure
+			mockInst := mockInstance
+
+			// Add to services list with a factory that returns the mock instance
 			allServices = append(allServices, core.ServiceInfo{
 				ID: id,
 				Factory: func() (core.Service, []core.ContextBuilderOption, error) {
-					return mockInstance.(core.Service), nil, nil
+					return mockInst.(core.Service), nil, nil
 				},
 				Depends: depends,
 			})


### PR DESCRIPTION
- Replace `github.com/stretchr/testify/require` with `github.com/stretchr/testify/mock` in `core/testing/api.go`
- Remove direct router instantiation in `NewMockAPI` to allow flexible mocking
- Update `Configure` expectations to use `mock.AnythingOfType` for better type matching
- Enhance `MockPluginBuilder` to support mock services and factories with reflection-based instantiation
- Store test context in builder to enable immediate mock service creation during build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test flexibility by using dynamic, type-based expectations for API configuration.
  * Simplified mock API setup by removing strict router creation and error checks.
  * Added support for registering mock services and mock service factories for testing, with dependency tracking and runtime validation.

* **Refactor**
  * Changed builder return flow to expose constructed services and context options, streamlining assembly of real and mock services and improving error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->