### PR TITLE
feat(storage): add configurable S3 temporary upload ID

### DIFF
--- a/core/storage.go
+++ b/core/storage.go
@@ -24,6 +24,18 @@ const (
 	StorageUploadStatusActive     StorageUploadStatus = "completed"
 )
 
+// S3TempUploadOptions represents options for S3 temporary uploads
+type S3TempUploadOptions struct {
+	UploadID string
+}
+
+// WithS3TempUploadID sets a custom upload ID for the temporary upload
+func WithS3TempUploadID(id string) func(*S3TempUploadOptions) {
+	return func(opts *S3TempUploadOptions) {
+		opts.UploadID = id
+	}
+}
+
 var (
 	ErrProofNotSupported = errors.New("protocol does not support proofs")
 	ErrInvalidHashFormat = errors.New("could not parse hash string: not a valid multihash format")
@@ -126,7 +138,7 @@ type StorageService interface {
 	S3Client(ctx context.Context) (*s3.Client, error)
 	S3Download(ctx context.Context, bucket string, key string) (io.ReadCloser, error)
 	S3MultipartUpload(ctx context.Context, data io.ReadCloser, bucket, key string, size uint64) error
-	S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol StorageProtocol) (string, error)
+	S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol StorageProtocol, opts ...func(*S3TempUploadOptions)) (string, error)
 	S3GetTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) (io.ReadCloser, error)
 	S3DeleteTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) error
 	S3Exists(ctx context.Context, bucket string, key string) (bool, error)

--- a/service/storage.go
+++ b/service/storage.go
@@ -714,13 +714,25 @@ func (s StorageServiceDefault) UploadStatus(ctx context.Context, protocol core.S
 
 }
 
+
+
 // S3TemporaryUpload uploads data to temporary S3 storage.
 // data: The data to upload
 // size: The size of the data in bytes
 // protocol: The storage protocol being used
+// opts: Optional configuration functions (e.g., WithUploadID)
 // Returns upload ID and error if upload fails
-func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol core.StorageProtocol) (string, error) {
-	uploadId := uuid.NewString()
+func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol core.StorageProtocol, opts ...func(*core.S3TempUploadOptions)) (string, error) {
+	options := &core.S3TempUploadOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	uploadId := options.UploadID
+	if uploadId == "" {
+		uploadId = uuid.NewString()
+	}
+
 	key := s.GetTemporaryUploadPath(protocol, uploadId)
 
 	defer func(data io.ReadCloser) {

--- a/service/storage.go
+++ b/service/storage.go
@@ -725,7 +725,7 @@ func (s StorageServiceDefault) UploadStatus(ctx context.Context, protocol core.S
 // validateUploadID checks if uploadId contains path traversal sequences
 func validateUploadID(uploadId string) error {
 	if strings.Contains(uploadId, "..") || strings.Contains(uploadId, "\\") {
-		return fmt.Errorf("invalid upload ID: must not contain path separators or traversal sequences")
+		return fmt.Errorf("invalid upload ID: must not contain path traversal sequences or backslashes")
 	}
 	return nil
 }

--- a/service/storage.go
+++ b/service/storage.go
@@ -720,8 +720,16 @@ func (s StorageServiceDefault) UploadStatus(ctx context.Context, protocol core.S
 // data: The data to upload
 // size: The size of the data in bytes
 // protocol: The storage protocol being used
-// opts: Optional configuration functions (e.g., WithUploadID)
+// opts: Optional configuration functions (e.g., WithS3TempUploadID)
 // Returns upload ID and error if upload fails
+// validateUploadID checks if uploadId contains path traversal sequences
+func validateUploadID(uploadId string) error {
+	if strings.Contains(uploadId, "..") || strings.Contains(uploadId, "\\") {
+		return fmt.Errorf("invalid upload ID: must not contain path separators or traversal sequences")
+	}
+	return nil
+}
+
 func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol core.StorageProtocol, opts ...func(*core.S3TempUploadOptions)) (string, error) {
 	options := &core.S3TempUploadOptions{}
 	for _, opt := range opts {
@@ -729,6 +737,12 @@ func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.Re
 	}
 
 	uploadId := options.UploadID
+	// Validate custom uploadId to prevent path traversal
+	if uploadId != "" {
+		if err := validateUploadID(uploadId); err != nil {
+			return "", err
+		}
+	}
 	if uploadId == "" {
 		uploadId = uuid.NewString()
 	}
@@ -755,6 +769,10 @@ func (s StorageServiceDefault) S3TemporaryUpload(ctx context.Context, data io.Re
 // uploadId: The ID of the temporary upload
 // Returns io.ReadCloser for the upload data and error if retrieval fails
 func (s StorageServiceDefault) S3GetTemporaryUpload(ctx context.Context, protocol core.StorageProtocol, uploadId string) (io.ReadCloser, error) {
+	// Validate uploadId to prevent path traversal
+	if err := validateUploadID(uploadId); err != nil {
+		return nil, err
+	}
 	return s.s3GetObject(ctx, s.config.Config().Core.Storage.S3.BufferBucket, s.GetTemporaryUploadPath(protocol, uploadId))
 }
 
@@ -787,6 +805,10 @@ func (s StorageServiceDefault) S3Exists(ctx context.Context, bucket string, key 
 }
 
 func (s StorageServiceDefault) S3DeleteTemporaryUpload(ctx context.Context, protocol core.StorageProtocol, uploadId string) error {
+	// Validate uploadId to prevent path traversal
+	if err := validateUploadID(uploadId); err != nil {
+		return err
+	}
 	key := s.GetTemporaryUploadPath(protocol, uploadId)
 
 	err := s.s3DeleteObject(ctx, s.config.Config().Core.Storage.S3.BufferBucket, key)


### PR DESCRIPTION
- Introduces `S3TempUploadOptions` struct to encapsulate S3 temporary upload settings
- Adds `WithS3TempUploadID` helper function for setting custom upload IDs
- Updates `S3TemporaryUpload` method signature to accept variadic option functions
- Implements logic to use provided upload ID or generate a new one via UUID
- Maintains backward compatibility by generating UUID when no custom ID is provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 temporary uploads can accept optional custom upload IDs, allowing callers to control temporary file identifiers.
  * When no custom ID is provided a secure ID is still generated automatically.

* **Bug Fixes / Reliability**
  * Upload IDs are validated to block invalid or unsafe values.
  * Retrieval and deletion of temporary uploads enforce the same validation for safer operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->