### PR TITLE
feat(storage): add S3TemporaryUploadExists method

### DIFF
--- a/core/storage.go
+++ b/core/storage.go
@@ -141,6 +141,7 @@ type StorageService interface {
 	S3TemporaryUpload(ctx context.Context, data io.ReadCloser, size uint64, protocol StorageProtocol, opts ...func(*S3TempUploadOptions)) (string, error)
 	S3GetTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) (io.ReadCloser, error)
 	S3DeleteTemporaryUpload(ctx context.Context, protocol StorageProtocol, uploadId string) error
+	S3TemporaryUploadExists(ctx context.Context, protocol StorageProtocol, uploadId string) (bool, error)
 	S3Exists(ctx context.Context, bucket string, key string) (bool, error)
 	UploadStatus(ctx context.Context, protocol StorageProtocol, objectName string) (StorageUploadStatus, *time.Time, error)
 	GetTemporaryUploadDir(protocol StorageProtocol) string

--- a/core/testing/mocks/StorageService.go
+++ b/core/testing/mocks/StorageService.go
@@ -1147,6 +1147,78 @@ func (_c *MockStorageService_S3TemporaryUpload_Call) RunAndReturn(run func(ctx c
 	return _c
 }
 
+// S3TemporaryUploadExists provides a mock function for the type MockStorageService
+func (_mock *MockStorageService) S3TemporaryUploadExists(ctx context.Context, protocol core.StorageProtocol, uploadId string) (bool, error) {
+	ret := _mock.Called(ctx, protocol, uploadId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for S3TemporaryUploadExists")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, core.StorageProtocol, string) (bool, error)); ok {
+		return returnFunc(ctx, protocol, uploadId)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, core.StorageProtocol, string) bool); ok {
+		r0 = returnFunc(ctx, protocol, uploadId)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, core.StorageProtocol, string) error); ok {
+		r1 = returnFunc(ctx, protocol, uploadId)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockStorageService_S3TemporaryUploadExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'S3TemporaryUploadExists'
+type MockStorageService_S3TemporaryUploadExists_Call struct {
+	*mock.Call
+}
+
+// S3TemporaryUploadExists is a helper method to define mock.On call
+//   - ctx context.Context
+//   - protocol core.StorageProtocol
+//   - uploadId string
+func (_e *MockStorageService_Expecter) S3TemporaryUploadExists(ctx interface{}, protocol interface{}, uploadId interface{}) *MockStorageService_S3TemporaryUploadExists_Call {
+	return &MockStorageService_S3TemporaryUploadExists_Call{Call: _e.mock.On("S3TemporaryUploadExists", ctx, protocol, uploadId)}
+}
+
+func (_c *MockStorageService_S3TemporaryUploadExists_Call) Run(run func(ctx context.Context, protocol core.StorageProtocol, uploadId string)) *MockStorageService_S3TemporaryUploadExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 core.StorageProtocol
+		if args[1] != nil {
+			arg1 = args[1].(core.StorageProtocol)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStorageService_S3TemporaryUploadExists_Call) Return(b bool, err error) *MockStorageService_S3TemporaryUploadExists_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockStorageService_S3TemporaryUploadExists_Call) RunAndReturn(run func(ctx context.Context, protocol core.StorageProtocol, uploadId string) (bool, error)) *MockStorageService_S3TemporaryUploadExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // S3Upload provides a mock function for the type MockStorageService
 func (_mock *MockStorageService) S3Upload(ctx context.Context, bucket string, key string, data io.Reader) error {
 	ret := _mock.Called(ctx, bucket, key, data)

--- a/service/storage.go
+++ b/service/storage.go
@@ -819,6 +819,20 @@ func (s StorageServiceDefault) S3DeleteTemporaryUpload(ctx context.Context, prot
 	return nil
 }
 
+// S3TemporaryUploadExists checks if a temporary upload exists in S3 storage.
+// protocol: The storage protocol being used
+// uploadId: The ID of the temporary upload to check
+// Returns true if the upload exists, false otherwise, and error if check fails
+func (s StorageServiceDefault) S3TemporaryUploadExists(ctx context.Context, protocol core.StorageProtocol, uploadId string) (bool, error) {
+	// Validate uploadId to prevent path traversal
+	if err := validateUploadID(uploadId); err != nil {
+		return false, err
+	}
+	key := s.GetTemporaryUploadPath(protocol, uploadId)
+
+	return s.S3Exists(ctx, s.config.Config().Core.Storage.S3.BufferBucket, key)
+}
+
 func (s StorageServiceDefault) getProofPath(protocol core.StorageProtocol, objectHash core.StorageHash) string {
 	return fmt.Sprintf("%s%s", protocol.EncodeFileName(objectHash), core.PROOF_EXTENSION)
 }


### PR DESCRIPTION
- Added `S3TemporaryUploadExists` method to `StorageService` interface
- Updated mock
- Added concrete implementation in `StorageServiceDefault`
- Includes validation for upload ID to prevent path traversal
- Uses existing `S3Exists` functionality for checking upload existence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to check for existing temporary file uploads in S3 storage.

* **Tests**
  * Expanded storage service test infrastructure with new mock implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->