### PR TITLE
refactor(testing): add TestMainContext options and improve error namespace handling in ResetAllState

### DIFF
--- a/core/testing/core.go
+++ b/core/testing/core.go
@@ -3,6 +3,7 @@ package testing
 
 import (
 	"fmt"
+	"log"
 	"reflect"
 	"sync"
 	"testing"
@@ -440,7 +441,9 @@ func ResetAllState() {
 	core.ResetState()
 	
 	// Restore error namespaces to preserve them across test isolation
-	_ = core.ReplaceAllErrorNamespaces(savedNamespaces)
+	if err := core.ReplaceAllErrorNamespaces(savedNamespaces); err != nil {
+		log.Fatalf("failed to restore error namespaces: %v", err)
+	}
 
 	// Reset testing state (only clears test case specific options)
 	ClearTestCaseContextOptions()

--- a/core/testing/core.go
+++ b/core/testing/core.go
@@ -431,10 +431,16 @@ func RunTestCaseWithComponents(t TB, testFunc func(tb TB, ctx TestContext), comp
 }
 
 // ResetAllState resets all global state in the core package and testing package
-// while preserving package-level configuration like DB settings
+// while preserving package-level configuration like DB settings and error namespaces
 func ResetAllState() {
-	// Reset core state
+	// Save current error namespaces before reset
+	savedNamespaces := core.ExportAllErrorNamespaces()
+	
+	// Reset core state (including error registry)
 	core.ResetState()
+	
+	// Restore error namespaces to preserve them across test isolation
+	_ = core.ReplaceAllErrorNamespaces(savedNamespaces)
 
 	// Reset testing state (only clears test case specific options)
 	ClearTestCaseContextOptions()
@@ -530,4 +536,54 @@ func ShouldSetupMockDB() bool {
 	setupMockDBMu.RLock()
 	defer setupMockDBMu.RUnlock()
 	return setupMockDB
+}
+
+// TestMainOption is a callback function that receives a TestContext and returns TestContextBuilderOptions.
+// This allows creating options that need access to the test context during TestMain setup.
+type TestMainOption func(ctx TestContext) ([]TestContextBuilderOption, error)
+
+// WithTestMainContext creates a TestContextBuilderOption that executes a callback with access to the test context.
+// This is useful in TestMain when you need to build options that depend on the test context.
+//
+// Example usage in TestMain:
+//
+//	func TestMain(m *testing.M) {
+//		coreTesting.RunTests(m, coreTesting.TestMainOpts{
+//			WithDB: true,
+//			CustomSetup: func() {
+//				coreTesting.AddGlobalTestContextOptions(
+//					coreTesting.WithTestMainContext(func(ctx coreTesting.TestContext) ([]coreTesting.TestContextBuilderOption, error) {
+//						// Now you have access to the test context
+//						db := ctx.DB()
+//						if db != nil {
+//							// Create options based on the database connection
+//							return []coreTesting.TestContextBuilderOption{
+//								coreTesting.WithConfig("custom.db.setting", "value"),
+//							}, nil
+//						}
+//						return nil, nil
+//					}),
+//				)
+//			},
+//		})
+//	}
+func WithTestMainContext(callback TestMainOption) TestContextBuilderOption {
+	return func(ctx TestContext) (TestContext, error) {
+		// Execute the callback with the current test context
+		options, err := callback(ctx)
+		if err != nil {
+			return ctx, fmt.Errorf("TestMain callback failed: %w", err)
+		}
+
+		// Apply all returned options using the existing ProcessCtxOptions function
+		return ProcessCtxOptions(ctx, options...)
+	}
+}
+
+// WithTestMainContextSimple is a convenience function that doesn't return an error.
+// Use this when your callback logic cannot fail.
+func WithTestMainContextSimple(callback func(ctx TestContext) []TestContextBuilderOption) TestContextBuilderOption {
+	return WithTestMainContext(func(ctx TestContext) ([]TestContextBuilderOption, error) {
+		return callback(ctx), nil
+	})
 }

--- a/core/testing/plugin.go
+++ b/core/testing/plugin.go
@@ -634,20 +634,6 @@ func WithErrorNamespaces(namespaces core.ErrorNamespaces) TestContextBuilderOpti
 			return ctx, fmt.Errorf("failed to import error namespaces: %w", err)
 		}
 
-		// Register cleanup to remove the namespaces we added
-		ctx.RegisterCleanup(func() {
-			// Get current state
-			current := core.ExportAllErrorNamespaces()
-
-			// Remove the namespaces we added
-			for ns := range namespaces {
-				delete(current, ns)
-			}
-
-			// Replace registry with cleaned state
-			_ = core.ReplaceAllErrorNamespaces(current)
-		})
-
 		return ctx, nil
 	}
 }


### PR DESCRIPTION
- Introduces `TestMainOption` and `WithTestMainContext`/`WithTestMainContextSimple` to enable context-aware TestContextBuilderOption creation in TestMain
- Enhances `ResetAllState()` to preserve error namespaces across resets by saving/restoring them
- Removes redundant error namespace cleanup logic from `WithErrorNamespaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TestMain customization API to allow flexible test context setup via callback-based options.

* **Changes**
  * Test state reset now preserves imported error namespaces; cleanup no longer removes those namespaces, so imports persist beyond individual test cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->