### PR TITLE
fix(testing): add error handling to service configuration

### DIFF
--- a/core/testing/plugin.go
+++ b/core/testing/plugin.go
@@ -342,14 +342,20 @@ func RegisterService(ctx TestContext, id string, factory core.ServiceFactory, pl
 // - Actual configuration through the config manager
 func configureService(ctx TestContext, svcInfo core.ServiceInfo, svc any) error {
 	// Detect a Config() provider
-	type serviceWithConfig interface{ Config() config.ServiceConfig }
+	type serviceWithConfig interface{ Config() (any, error) }
 	provider, ok := svc.(serviceWithConfig)
 	if !ok {
 		return nil // service has no config
 	}
 
 	// Get the concrete config object from the service
-	cfgResult := provider.Config()
+	cfgResult, err := provider.Config()
+	if err != nil {
+		ctx.Logger().Error("Error getting service config",
+			zap.String("service", svcInfo.ID),
+			zap.Error(err))
+		return err
+	}
 
 	// Ensure the config type is compliant with ServiceConfig interface
 	// This handles cases where the service returns a non-pointer but needs pointer semantics


### PR DESCRIPTION
- Updated `serviceWithConfig` interface to return error from `Config()` method
- Added error propagation and logging when retrieving service configuration
- Ensures configuration errors are properly reported during service setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service configuration error handling to properly surface and communicate configuration errors to callers, preventing silent failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->