### PR TITLE
feat(testing): add support for configuring mock services with Config() expectation

### DIFF
--- a/core/testing/service.go
+++ b/core/testing/service.go
@@ -63,12 +63,19 @@ func WithMockServiceFactory[T any](id string, factory MockServiceFactory[T], ser
 			return ctx, fmt.Errorf("mock service factory for '%s' returned nil", id)
 		}
 
-		// Set up Config() expectation if service config is provided
-		if len(serviceConfig) > 0 && serviceConfig[0] != nil {
-			// Try to set up Config() expectation if the mock supports it
-			if mockWithOn, ok := any(serviceInstance).(mockWithOn); ok {
-				mockWithOn.On("Config").Return(serviceConfig[0], nil)
+		switch len(serviceConfig) {
+		case 0:
+			// no-op
+		case 1:
+			onMock, ok := any(serviceInstance).(mockWithOn)
+			if !ok {
+				return ctx, fmt.Errorf("mock service '%s' does not support On(); cannot auto-configure Config()", id)
 			}
+			// Consider whether Config() should be required or optional when provided.
+			// If optional, keep Maybe(); if required, drop it (or set Once()).
+			onMock.On("Config").Return(serviceConfig[0], nil).Maybe()
+		default:
+			return ctx, fmt.Errorf("WithMockServiceFactory('%s') expected at most 1 serviceConfig value, got %d", id, len(serviceConfig))
 		}
 
 		// Register the created service using the shared helper

--- a/core/testing/service.go
+++ b/core/testing/service.go
@@ -12,6 +12,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// Private interface types for mock configuration
+
+// mockWithOn represents a mock that has the On method for setting up expectations
+type mockWithOn interface {
+	On(methodName string, arguments ...any) *mock.Call
+}
+
 // WithMockService adds a mock service to the test context by calling the mock constructor
 // during the test context's BootEnvironment phase.
 func WithMockService(id string, mockConstructor func(tb TB, ctx TestContext) any) TestContextBuilderOption {
@@ -45,7 +52,8 @@ type MockServiceFactory[T any] func(interface {
 // by calling a factory function immediately during the ProcessCtxOptions phase.
 // This allows mocks that require the testing.TB instance to be created with the
 // correct TB for each individual test run.
-func WithMockServiceFactory[T any](id string, factory MockServiceFactory[T]) TestContextBuilderOption {
+// Optional service config can be provided to set up Config() expectations on the mock.
+func WithMockServiceFactory[T any](id string, factory MockServiceFactory[T], serviceConfig ...any) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
 		// Create the mock instance immediately using the test's TB
 		serviceInstance := factory(ctx.T())
@@ -53,6 +61,14 @@ func WithMockServiceFactory[T any](id string, factory MockServiceFactory[T]) Tes
 		// Ensure the created instance is not nil
 		if serviceInstance == nil {
 			return ctx, fmt.Errorf("mock service factory for '%s' returned nil", id)
+		}
+
+		// Set up Config() expectation if service config is provided
+		if len(serviceConfig) > 0 && serviceConfig[0] != nil {
+			// Try to set up Config() expectation if the mock supports it
+			if mockWithOn, ok := any(serviceInstance).(mockWithOn); ok {
+				mockWithOn.On("Config").Return(serviceConfig[0], nil)
+			}
 		}
 
 		// Register the created service using the shared helper
@@ -296,12 +312,12 @@ func getMock[T any](ctx core.Context, id string) *T {
 	if svc == nil {
 		panic(fmt.Sprintf("%s service not found in context", id))
 	}
-	
+
 	mockSvc, ok := svc.(*T)
 	if !ok {
 		panic(fmt.Sprintf("%s service is not a mock - expected *%T, got %T", id, mockSvc, svc))
 	}
-	
+
 	return mockSvc
 }
 


### PR DESCRIPTION
- Introduces `mockWithOn` interface to check for `On` method support in mocks
- Enhances `WithMockServiceFactory` to accept optional service config parameters
- Automatically sets up `Config()` expectation on mocks when service config is provided
- Maintains compatibility with existing mock registration patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced test tooling to allow an optional configuration value when initializing mock services so a pre-configured response can be injected before registration.
  * Preserves existing behavior when no configuration is provided.
  * Returns a clear error if more than one configuration value is supplied.
  * Minor non-functional whitespace tidy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->