### PR TITLE
refactor(tus): export GetEchoContext function

### DIFF
--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -421,7 +421,7 @@ func DefaultUploadCreatedHandler(ctx core.Context, verifyFunc core.TUSUploadCrea
 	return func(handlr core.TusHandler, hook handler.HookEvent) {
 		var errMessage string
 
-		echoCtx, ok := getEchoContext(hook.Context)
+		echoCtx, ok := GetEchoContext(hook.Context)
 		if !ok {
 			errMessage = "Failed to get echo context"
 			handlr.HandleEventResponseError(errMessage, http.StatusInternalServerError, hook)
@@ -641,7 +641,7 @@ func wrapContextHandler(h http.Handler) echo.HandlerFunc {
 	}
 }
 
-func getEchoContext(ctx context.Context) (echo.Context, bool) {
+func GetEchoContext(ctx context.Context) (echo.Context, bool) {
 	c, ok := ctx.Value(echoContextKey).(echo.Context)
 	return c, ok
 }

--- a/service/tus.go
+++ b/service/tus.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
+	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
 	tusHandler "github.com/tus/tusd/v2/pkg/handler"
 	"go.lumeweb.com/portal/core"
@@ -530,4 +531,8 @@ func TUSDefaultPreFinishResponse(handlerFactory TusHandlerFactory, hashFunc TUSH
 			Body: string(jsonBody),
 		}, nil
 	}
+}
+
+func TusGetEchoContext(ctx context.Context) (echo.Context, bool) {
+	return tus.GetEchoContext(ctx)
 }


### PR DESCRIPTION
- Made `getEchoContext` function public as `GetEchoContext` to follow Go naming conventions
- Updated all references to use the new exported function name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new public API function for accessing Echo context.

* **Refactor**
  * Updated internal naming conventions for consistency across the service module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->