### PR TITLE
feat(testing): add JWT helper and mock services for authentication testing

### DIFF
--- a/core/testing/jwt_helper.go
+++ b/core/testing/jwt_helper.go
@@ -1,0 +1,238 @@
+package testing
+
+import (
+	"fmt"
+	gjwt "github.com/golang-jwt/jwt/v5"
+	"go.lumeweb.com/portal-middleware/auth/jwt"
+	"go.lumeweb.com/portal/config"
+	"strconv"
+	"time"
+)
+
+// JWTHelper provides high-level helper functions for JWT token testing.
+// It creates and validates JWT tokens using the real JWT library but with test-friendly interfaces.
+type JWTHelper struct {
+	ctx    TestContext
+	config config.Manager
+	domain string
+}
+
+// NewJWTHelper creates a new JWTHelper.
+func NewJWTHelper(ctx TestContext) *JWTHelper {
+	cfg := ctx.Config()
+	domain := cfg.Config().Core.Domain
+
+	return &JWTHelper{
+		ctx:    ctx,
+		config: cfg,
+		domain: domain,
+	}
+}
+
+// CreateToken creates a JWT token for testing.
+func (h *JWTHelper) CreateToken(userID uint, purpose jwt.Purpose) (string, error) {
+	return jwt.CreateToken(h.config.Config().Core.Identity.PrivateKey(), h.domain, strconv.Itoa(int(userID)), purpose, time.Hour)
+}
+
+// CreateLoginToken creates a login JWT token.
+func (h *JWTHelper) CreateLoginToken(userID uint) (string, error) {
+	return h.CreateToken(userID, jwt.PurposeLogin)
+}
+
+// Create2FAToken creates a 2FA JWT token.
+func (h *JWTHelper) Create2FAToken(userID uint) (string, error) {
+	return h.CreateToken(userID, jwt.Purpose2FA)
+}
+
+// CreateAPIKeyToken creates an API key JWT token.
+func (h *JWTHelper) CreateAPIKeyToken(userID uint) (string, error) {
+	return h.CreateToken(userID, jwt.PurposeAPI)
+}
+
+// CreateLongLivedToken creates a long-lived JWT token.
+func (h *JWTHelper) CreateLongLivedToken(userID uint, days int) (string, error) {
+	duration := time.Hour * 24 * time.Duration(days)
+	return jwt.CreateToken(h.config.Config().Core.Identity.PrivateKey(), h.domain, strconv.Itoa(int(userID)), jwt.PurposeLogin, duration)
+}
+
+// CreateExpiredToken creates an expired JWT token for testing.
+func (h *JWTHelper) CreateExpiredToken(userID uint, purpose jwt.Purpose) (string, error) {
+	duration := -time.Hour // Negative duration creates an expired token
+	return jwt.CreateToken(h.config.Config().Core.Identity.PrivateKey(), h.domain, strconv.Itoa(int(userID)), purpose, duration)
+}
+
+// ValidateToken validates a JWT token.
+func (h *JWTHelper) ValidateToken(token string, purpose ...jwt.Purpose) (*gjwt.RegisteredClaims, error) {
+	// Default to login purpose if not provided
+	expectedPurpose := jwt.PurposeLogin
+	if len(purpose) > 0 {
+		expectedPurpose = purpose[0]
+	}
+	
+	claims, err := jwt.DecodeAndVerify(token, &gjwt.RegisteredClaims{}, h.domain, expectedPurpose)
+	if err != nil {
+		return nil, err
+	}
+	
+	registeredClaims, ok := claims.(*gjwt.RegisteredClaims)
+	if !ok {
+		return nil, fmt.Errorf("unexpected claims type")
+	}
+	
+	return registeredClaims, nil
+}
+
+// ValidateLoginToken validates a JWT token specifically for login purpose.
+func (h *JWTHelper) ValidateLoginToken(token string) (*gjwt.RegisteredClaims, error) {
+	return h.ValidateToken(token, jwt.PurposeLogin)
+}
+
+// ValidateAPIToken validates a JWT token specifically for API purpose.
+func (h *JWTHelper) ValidateAPIToken(token string) (*gjwt.RegisteredClaims, error) {
+	return h.ValidateToken(token, jwt.PurposeAPI)
+}
+
+// Validate2FAToken validates a JWT token specifically for 2FA purpose.
+func (h *JWTHelper) Validate2FAToken(token string) (*gjwt.RegisteredClaims, error) {
+	return h.ValidateToken(token, jwt.Purpose2FA)
+}
+
+// IsTokenValid checks if a JWT token is valid.
+func (h *JWTHelper) IsTokenValid(token string) bool {
+	_, err := h.ValidateToken(token)
+	return err == nil
+}
+
+// IsTokenExpired checks if a JWT token is expired.
+func (h *JWTHelper) IsTokenExpired(token string) bool {
+	claims, err := h.ValidateToken(token)
+	if err != nil {
+		return err.Error() == "token is expired" || err.Error() == "Token is expired"
+	}
+	if claims.ExpiresAt == nil {
+		return false
+	}
+	return claims.ExpiresAt.Time.Before(time.Now())
+}
+
+// GetTokenUserID extracts user ID from JWT token.
+func (h *JWTHelper) GetTokenUserID(token string) (uint, error) {
+	claims, err := h.ValidateToken(token)
+	if err != nil {
+		return 0, err
+	}
+
+	userID, err := strconv.ParseUint(claims.Subject, 10, 32)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint(userID), nil
+}
+
+// GetTokenPurpose extracts purpose from JWT token.
+func (h *JWTHelper) GetTokenPurpose(token string) (jwt.Purpose, error) {
+	claims, err := h.ValidateToken(token)
+	if err != nil {
+		return "", err
+	}
+
+	// Purpose is stored in the Audience field
+	if len(claims.Audience) > 0 {
+		return jwt.Purpose(claims.Audience[0]), nil
+	}
+
+	return jwt.PurposeNone, nil
+}
+
+// GetTokenExpiration extracts expiration time from JWT token.
+func (h *JWTHelper) GetTokenExpiration(token string) (time.Time, error) {
+	claims, err := h.ValidateToken(token)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if claims.ExpiresAt == nil {
+		return time.Time{}, fmt.Errorf("token has no expiration")
+	}
+
+	return claims.ExpiresAt.Time, nil
+}
+
+// CreateTokenPair creates a pair of JWT tokens (login and 2FA) for testing.
+func (h *JWTHelper) CreateTokenPair(userID uint) (string, string, error) {
+	loginToken, err := h.CreateLoginToken(userID)
+	if err != nil {
+		return "", "", err
+	}
+
+	twoFactorToken, err := h.Create2FAToken(userID)
+	if err != nil {
+		return "", "", err
+	}
+
+	return loginToken, twoFactorToken, nil
+}
+
+// CreateMultipleTokens creates multiple JWT tokens for the same user.
+func (h *JWTHelper) CreateMultipleTokens(userID uint, count int, purpose jwt.Purpose) ([]string, error) {
+	tokens := make([]string, 0, count)
+
+	for i := 0; i < count; i++ {
+		token, err := h.CreateToken(userID, purpose)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, token)
+	}
+
+	return tokens, nil
+}
+
+// CreateTokensForMultipleUsers creates JWT tokens for multiple users.
+func (h *JWTHelper) CreateTokensForMultipleUsers(userIDs []uint, purpose jwt.Purpose) (map[uint]string, error) {
+	tokens := make(map[uint]string)
+
+	for _, userID := range userIDs {
+		token, err := h.CreateToken(userID, purpose)
+		if err != nil {
+			return nil, err
+		}
+		tokens[userID] = token
+	}
+
+	return tokens, nil
+}
+
+// SimulateTokenRefresh simulates a token refresh by creating a new token.
+func (h *JWTHelper) SimulateTokenRefresh(oldToken string) (string, error) {
+	userID, err := h.GetTokenUserID(oldToken)
+	if err != nil {
+		return "", err
+	}
+
+	purpose, err := h.GetTokenPurpose(oldToken)
+	if err != nil {
+		return "", err
+	}
+
+	return h.CreateToken(userID, purpose)
+}
+
+// GenerateTestToken generates a simple test token (not a real JWT).
+// Useful for tests that don't need actual JWT validation.
+func (h *JWTHelper) GenerateTestToken(userID uint) string {
+	return fmt.Sprintf("test_token_%d", userID)
+}
+
+// GenerateExpiredTestToken generates a simple expired test token.
+// Useful for tests that need to simulate expired tokens.
+func (h *JWTHelper) GenerateExpiredTestToken(userID uint) string {
+	return fmt.Sprintf("expired_token_%d", userID)
+}
+
+// GenerateInvalidTestToken generates an invalid test token.
+// Useful for tests that need to simulate invalid tokens.
+func (h *JWTHelper) GenerateInvalidTestToken() string {
+	return "invalid_test_token"
+}

--- a/core/testing/jwt_helper.go
+++ b/core/testing/jwt_helper.go
@@ -1,12 +1,14 @@
 package testing
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
+	"time"
+
 	gjwt "github.com/golang-jwt/jwt/v5"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	"go.lumeweb.com/portal/config"
-	"strconv"
-	"time"
 )
 
 // JWTHelper provides high-level helper functions for JWT token testing.
@@ -107,7 +109,7 @@ func (h *JWTHelper) IsTokenValid(token string) bool {
 func (h *JWTHelper) IsTokenExpired(token string) bool {
 	claims, err := h.ValidateToken(token)
 	if err != nil {
-		return err.Error() == "token is expired" || err.Error() == "Token is expired"
+		return errors.Is(err, gjwt.ErrTokenExpired)
 	}
 	if claims.ExpiresAt == nil {
 		return false

--- a/core/testing/mock_auth.go
+++ b/core/testing/mock_auth.go
@@ -1,0 +1,214 @@
+package testing
+
+import (
+	"fmt"
+
+	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal/core/testing/mocks"
+	"go.lumeweb.com/portal/db/models"
+	"gorm.io/gorm"
+
+	"time"
+)
+
+// MockAuthService provides high-level helper functions that embed MockAuthService.
+// It automatically sets up mock expectations and provides convenient methods for common auth operations.
+type MockAuthService struct {
+	*mocks.MockAuthService
+	userSvc *mocks.MockUserService
+	ctx     TestContext
+}
+
+// NewMockAuthService creates a new MockAuthService that embeds auth mock and has private user mock.
+func NewMockAuthService(ctx TestContext) *MockAuthService {
+	mockAuth := &MockAuthService{
+		MockAuthService: mocks.NewMockAuthService(ctx.T()),
+		ctx:             ctx,
+	}
+
+	// Register a startup function to get the user service
+	ctx.OnStartup(func(coreCtx core.Context) error {
+		mockAuth.userSvc = core.GetService[*mocks.MockUserService](coreCtx, core.USER_SERVICE)
+		return nil
+	})
+
+	return mockAuth
+}
+
+// CreateAndLoginUser creates a test user and returns JWT token with automatic mock setup.
+func (m *MockAuthService) CreateAndLoginUser(email, password string) (string, *models.User, error) {
+	// Create test user object
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     true,
+	}
+
+	// Setup mock expectations for login
+	m.setupLoginExpectations(user, "127.0.0.1", false)
+
+	// Mock the login response
+	token := m.generateTestToken(user.ID)
+	m.EXPECT().LoginPassword(email, password, "127.0.0.1", false).Return(token, user, nil)
+
+	return token, user, nil
+}
+
+// CreateAndLoginUserWithRemember creates a test user and returns long-lived JWT token with automatic mock setup.
+func (m *MockAuthService) CreateAndLoginUserWithRemember(email, password string) (string, *models.User, error) {
+	// Create test user object
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     true,
+	}
+
+	// Setup mock expectations for login
+	m.setupLoginExpectations(user, "127.0.0.1", true)
+
+	// Mock the login response
+	token := m.generateTestToken(user.ID)
+	m.EXPECT().LoginPassword(email, password, "127.0.0.1", true).Return(token, user, nil)
+
+	return token, user, nil
+}
+
+// LoginUser logs in an existing user and returns JWT token with automatic mock setup.
+func (m *MockAuthService) LoginUser(email, password string) (string, *models.User, error) {
+	// Create test user object (would normally be found via user service)
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     true,
+	}
+
+	// Setup mock expectations for login
+	m.setupLoginExpectations(user, "127.0.0.1", false)
+
+	// Mock the login response
+	token := m.generateTestToken(user.ID)
+	m.EXPECT().LoginPassword(email, password, "127.0.0.1", false).Return(token, user, nil)
+
+	return token, user, nil
+}
+
+// LoginUserWithIP logs in an existing user with custom IP and returns JWT token with automatic mock setup.
+func (m *MockAuthService) LoginUserWithIP(email, password, ip string) (string, *models.User, error) {
+	// Create test user object
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     true,
+	}
+
+	// Setup mock expectations for login
+	m.setupLoginExpectations(user, ip, false)
+
+	// Mock the login response
+	token := m.generateTestToken(user.ID)
+	m.EXPECT().LoginPassword(email, password, ip, false).Return(token, user, nil)
+
+	return token, user, nil
+}
+
+// LoginUserByID logs in by user ID and returns JWT token with automatic mock setup.
+func (m *MockAuthService) LoginUserByID(userID uint) (string, error) {
+	// Create test user object
+	user := &models.User{
+		Model:        gorm.Model{ID: userID},
+		Email:        fmt.Sprintf("user%d@example.com", userID),
+		PasswordHash: m.hashPassword("password"),
+		Verified:     true,
+	}
+
+	// Setup mock expectations for login
+	m.setupLoginExpectations(user, "127.0.0.1", false)
+
+	// Mock the login response
+	token := m.generateTestToken(user.ID)
+	m.EXPECT().LoginID(userID, "127.0.0.1", false).Return(token, nil)
+
+	return token, nil
+}
+
+// LoginUserWithOTP logs in using OTP and returns JWT token with automatic mock setup.
+func (m *MockAuthService) LoginUserWithOTP(userID uint, otpCode string) (string, error) {
+	// Setup mock expectations for OTP login
+	m.setupOTPLoginExpectations(userID)
+
+	// Mock the OTP login response
+	token := m.generateTestToken(userID)
+	m.EXPECT().LoginOTP(userID, otpCode, false).Return(token, nil)
+
+	return token, nil
+}
+
+// ValidatePassword validates password for a user with automatic mock setup.
+func (m *MockAuthService) ValidatePassword(user *models.User, password string) bool {
+	// Mock the password validation
+	isValid := m.validatePasswordHash(user.PasswordHash, password)
+	m.EXPECT().ValidLoginByUserObj(user, password).Return(isValid)
+
+	return isValid
+}
+
+// SetupLoginExpectations manually sets up login expectations for a user.
+func (m *MockAuthService) SetupLoginExpectations(user *models.User, ip string, rememberMe bool) {
+	m.setupLoginExpectations(user, ip, rememberMe)
+}
+
+// SetupOTPLoginExpectations manually sets up OTP login expectations.
+func (m *MockAuthService) SetupOTPLoginExpectations(userID uint, otpCode string) {
+	m.setupOTPLoginExpectations(userID)
+}
+
+// setupLoginExpectations sets up mock expectations for login operations.
+func (m *MockAuthService) setupLoginExpectations(user *models.User, ip string, rememberMe bool) {
+	// Expect pending deletion check
+	m.userSvc.EXPECT().IsAccountPendingDeletion(user.ID).Return(false, nil)
+
+	// Expect account info update
+	updateData := map[string]any{
+		"last_login_ip": ip,
+		"last_login":    &[]time.Time{time.Now()}[0],
+	}
+	m.userSvc.EXPECT().UpdateAccountInfo(user.ID, updateData).Return(nil)
+}
+
+// setupOTPLoginExpectations sets up mock expectations for OTP login operations.
+func (m *MockAuthService) setupOTPLoginExpectations(userID uint) {
+	// Expect pending deletion check
+	m.userSvc.EXPECT().IsAccountPendingDeletion(userID).Return(false, nil)
+
+	// Expect account info update
+	updateData := map[string]any{
+		"last_login_ip": "127.0.0.1",
+		"last_login":    &[]time.Time{time.Now()}[0],
+	}
+	m.userSvc.EXPECT().UpdateAccountInfo(userID, updateData).Return(nil)
+}
+
+// hashPassword creates a simple hash for testing (in real scenario would use bcrypt)
+func (m *MockAuthService) hashPassword(password string) string {
+	// Simple hash for testing - in real implementation would use bcrypt
+	return fmt.Sprintf("hashed_%s", password)
+}
+
+// validatePasswordHash validates a simple hash for testing
+func (m *MockAuthService) validatePasswordHash(hash, password string) bool {
+	return hash == fmt.Sprintf("hashed_%s", password)
+}
+
+// generateTestToken generates a simple JWT token for testing
+func (m *MockAuthService) generateTestToken(userID uint) string {
+	return fmt.Sprintf("test_token_%d", userID)
+}
+
+// GetUserService returns the embedded user service for advanced usage.
+func (m *MockAuthService) GetUserService() *mocks.MockUserService {
+	return m.userSvc
+}

--- a/core/testing/mock_auth.go
+++ b/core/testing/mock_auth.go
@@ -3,19 +3,18 @@ package testing
 import (
 	"fmt"
 
+	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/core/testing/mocks"
 	"go.lumeweb.com/portal/db/models"
 	"gorm.io/gorm"
-
-	"time"
 )
 
 // MockAuthService provides high-level helper functions that embed MockAuthService.
 // It automatically sets up mock expectations and provides convenient methods for common auth operations.
 type MockAuthService struct {
 	*mocks.MockAuthService
-	userSvc *mocks.MockUserService
+	userSvc *MockUserService
 	ctx     TestContext
 }
 
@@ -28,7 +27,7 @@ func NewMockAuthService(ctx TestContext) *MockAuthService {
 
 	// Register a startup function to get the user service
 	ctx.OnStartup(func(coreCtx core.Context) error {
-		mockAuth.userSvc = core.GetService[*mocks.MockUserService](coreCtx, core.USER_SERVICE)
+		mockAuth.userSvc = core.GetService[*MockUserService](coreCtx, core.USER_SERVICE)
 		return nil
 	})
 
@@ -169,27 +168,19 @@ func (m *MockAuthService) SetupOTPLoginExpectations(userID uint, otpCode string)
 // setupLoginExpectations sets up mock expectations for login operations.
 func (m *MockAuthService) setupLoginExpectations(user *models.User, ip string, rememberMe bool) {
 	// Expect pending deletion check
-	m.userSvc.EXPECT().IsAccountPendingDeletion(user.ID).Return(false, nil)
+	m.userSvc.MockUserService.EXPECT().IsAccountPendingDeletion(user.ID).Return(false, nil)
 
-	// Expect account info update
-	updateData := map[string]any{
-		"last_login_ip": ip,
-		"last_login":    &[]time.Time{time.Now()}[0],
-	}
-	m.userSvc.EXPECT().UpdateAccountInfo(user.ID, updateData).Return(nil)
+	// Expect account info update - use mock.Anything for time to avoid flaky tests
+	m.userSvc.MockUserService.EXPECT().UpdateAccountInfo(user.ID, mock.Anything).Return(nil)
 }
 
 // setupOTPLoginExpectations sets up mock expectations for OTP login operations.
 func (m *MockAuthService) setupOTPLoginExpectations(userID uint) {
 	// Expect pending deletion check
-	m.userSvc.EXPECT().IsAccountPendingDeletion(userID).Return(false, nil)
+	m.userSvc.MockUserService.EXPECT().IsAccountPendingDeletion(userID).Return(false, nil)
 
-	// Expect account info update
-	updateData := map[string]any{
-		"last_login_ip": "127.0.0.1",
-		"last_login":    &[]time.Time{time.Now()}[0],
-	}
-	m.userSvc.EXPECT().UpdateAccountInfo(userID, updateData).Return(nil)
+	// Expect account info update - use mock.Anything for time to avoid flaky tests
+	m.userSvc.MockUserService.EXPECT().UpdateAccountInfo(userID, mock.Anything).Return(nil)
 }
 
 // hashPassword creates a simple hash for testing (in real scenario would use bcrypt)
@@ -209,6 +200,6 @@ func (m *MockAuthService) generateTestToken(userID uint) string {
 }
 
 // GetUserService returns the embedded user service for advanced usage.
-func (m *MockAuthService) GetUserService() *mocks.MockUserService {
+func (m *MockAuthService) GetUserService() *MockUserService {
 	return m.userSvc
 }

--- a/core/testing/mock_otp.go
+++ b/core/testing/mock_otp.go
@@ -1,0 +1,227 @@
+package testing
+
+import (
+	"fmt"
+
+	"go.lumeweb.com/portal/core/testing/mocks"
+	"go.lumeweb.com/portal/db/models"
+	"gorm.io/gorm"
+)
+
+// MockOTPService provides high-level helper functions that embed MockOTPService.
+// It automatically sets up mock expectations and provides convenient methods for common OTP operations.
+type MockOTPService struct {
+	*mocks.MockOTPService
+	ctx TestContext
+}
+
+// NewMockOTPService creates a new MockOTPService that embeds OTP mock service.
+func NewMockOTPService(ctx TestContext) *MockOTPService {
+	return &MockOTPService{
+		MockOTPService: mocks.NewMockOTPService(ctx.T()),
+		ctx:            ctx,
+	}
+}
+
+// GenerateSecret generates an OTP secret with automatic mock setup.
+func (m *MockOTPService) GenerateSecret(userID uint) (string, error) {
+	secret := "test_otp_secret_12345"
+
+	// Mock the OTPGenerate response
+	m.EXPECT().OTPGenerate(userID).Return(secret, nil)
+
+	return secret, nil
+}
+
+// GenerateSecretFails simulates OTP secret generation failure with automatic mock setup.
+func (m *MockOTPService) GenerateSecretFails(userID uint) (string, error) {
+	// Mock the OTPGenerate response with error
+	m.EXPECT().OTPGenerate(userID).Return("", fmt.Errorf("generation failed"))
+
+	return "", fmt.Errorf("generation failed")
+}
+
+// GenerateAuthURL generates an OTP auth URL with automatic mock setup.
+func (m *MockOTPService) GenerateAuthURL(secret, accountName string) (string, error) {
+	return fmt.Sprintf("otpauth://totp/%s?secret=%s&issuer=test", accountName, secret), nil
+}
+
+// VerifyOTP verifies an OTP code for a user with automatic mock setup.
+func (m *MockOTPService) VerifyOTP(userID uint, code string) (bool, error) {
+	// Mock the OTPVerify response
+	isValid := code == "123456" // Accept test code "123456"
+	m.EXPECT().OTPVerify(userID, code).Return(isValid, nil)
+
+	return isValid, nil
+}
+
+// VerifyOTPFails simulates OTP verification failure with automatic mock setup.
+func (m *MockOTPService) VerifyOTPFails(userID uint, code string) (bool, error) {
+	// Mock the OTPVerify response with error
+	m.EXPECT().OTPVerify(userID, code).Return(false, fmt.Errorf("verification failed"))
+
+	return false, fmt.Errorf("verification failed")
+}
+
+// CreateOTPUser creates a user with OTP enabled with automatic mock setup.
+func (m *MockOTPService) CreateOTPUser(email, password string) (*models.User, string, string, error) {
+	userID := uint(1)
+	// Generate OTP secret and auth URL
+	secret, err := m.GenerateSecret(userID)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	authURL, err := m.GenerateAuthURL(secret, email)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	// Create user with OTP
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     true,
+		OTPEnabled:   true,
+		OTPVerified:  true,
+		OTPSecret:    secret,
+		OTPAuthUrl:   authURL,
+	}
+
+	return user, secret, authURL, nil
+}
+
+// SetupOTPForUser sets up OTP for an existing user with automatic mock setup.
+func (m *MockOTPService) SetupOTPForUser(userID uint, accountName string) (string, string, error) {
+	// Generate OTP secret and auth URL
+	secret, err := m.GenerateSecret(userID)
+	if err != nil {
+		return "", "", err
+	}
+
+	authURL, err := m.GenerateAuthURL(secret, accountName)
+	if err != nil {
+		return "", "", err
+	}
+
+	return secret, authURL, nil
+}
+
+// EnableOTPForUser enables and verifies OTP for an existing user with automatic mock setup.
+func (m *MockOTPService) EnableOTPForUser(userID uint, accountName string) (string, string, error) {
+	secret, authURL, err := m.SetupOTPForUser(userID, accountName)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Verify OTP with test code
+	_, err = m.VerifyOTP(userID, "123456")
+	if err != nil {
+		return "", "", err
+	}
+
+	return secret, authURL, nil
+}
+
+// DisableOTPForUser disables OTP for an existing user with automatic mock setup.
+func (m *MockOTPService) DisableOTPForUser(userID uint) error {
+	// No mock expectations needed for disable operation
+	return nil
+}
+
+// TestOTPLoginWorkflow tests a complete OTP login workflow with automatic mock setup.
+func (m *MockOTPService) TestOTPLoginWorkflow(email, password string) (string, *models.User, error) {
+	// Create user with OTP
+	user, _, _, err := m.CreateOTPUser(email, password)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Generate test OTP code
+	testCode := "123456"
+
+	// Verify OTP
+	_, err = m.VerifyOTP(user.ID, testCode)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Generate test token (would normally be done by auth service)
+	token := fmt.Sprintf("otp_token_%d", user.ID)
+
+	return token, user, nil
+}
+
+// TestOTPSetupWorkflow tests a complete OTP setup workflow with automatic mock setup.
+func (m *MockOTPService) TestOTPSetupWorkflow(email, password string) (string, string, error) {
+	// Create regular user first
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     true,
+	}
+
+	// Setup OTP for the user
+	secret, authURL, err := m.EnableOTPForUser(user.ID, email)
+	if err != nil {
+		return "", "", err
+	}
+
+	return secret, authURL, nil
+}
+
+// TestOTPDisableWorkflow tests disabling OTP for a user with automatic mock setup.
+func (m *MockOTPService) TestOTPDisableWorkflow(email, password string) error {
+	// Create user with OTP
+	user, _, _, err := m.CreateOTPUser(email, password)
+	if err != nil {
+		return err
+	}
+
+	// Disable OTP
+	err = m.DisableOTPForUser(user.ID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateOTPConfiguration validates that OTP is properly configured for a user.
+func (m *MockOTPService) ValidateOTPConfiguration(user *models.User) bool {
+	return user.OTPEnabled &&
+		user.OTPVerified &&
+		user.OTPSecret != "" &&
+		user.OTPAuthUrl != ""
+}
+
+// GetOTPStatus returns OTP status for a user.
+func (m *MockOTPService) GetOTPStatus(user *models.User) map[string]interface{} {
+	return map[string]interface{}{
+		"enabled":    user.OTPEnabled,
+		"verified":   user.OTPVerified,
+		"secret":     user.OTPSecret,
+		"auth_url":   user.OTPAuthUrl,
+		"configured": m.ValidateOTPConfiguration(user),
+	}
+}
+
+// SetupOTPExpectations manually sets up OTP expectations for testing.
+func (m *MockOTPService) SetupOTPExpectations(userID uint, validCode string, invalidCode string) {
+	// Setup expectations for valid and invalid codes
+	m.EXPECT().OTPVerify(userID, validCode).Return(true, nil)
+	m.EXPECT().OTPVerify(userID, invalidCode).Return(false, nil)
+}
+
+// SetupOTPGenerationExpectations manually sets up OTP generation expectations.
+func (m *MockOTPService) SetupOTPGenerationExpectations(userID uint, secret string, err error) {
+	m.EXPECT().OTPGenerate(userID).Return(secret, err)
+}
+
+// hashPassword creates a simple hash for testing (in real scenario would use bcrypt)
+func (m *MockOTPService) hashPassword(password string) string {
+	// Simple hash for testing - in real implementation would use bcrypt
+	return fmt.Sprintf("hashed_%s", password)
+}

--- a/core/testing/mock_otp.go
+++ b/core/testing/mock_otp.go
@@ -64,8 +64,7 @@ func (m *MockOTPService) VerifyOTPFails(userID uint, code string) (bool, error) 
 }
 
 // CreateOTPUser creates a user with OTP enabled with automatic mock setup.
-func (m *MockOTPService) CreateOTPUser(email, password string) (*models.User, string, string, error) {
-	userID := uint(1)
+func (m *MockOTPService) CreateOTPUser(userID uint, email, password string) (*models.User, string, string, error) {
 	// Generate OTP secret and auth URL
 	secret, err := m.GenerateSecret(userID)
 	if err != nil {
@@ -79,7 +78,7 @@ func (m *MockOTPService) CreateOTPUser(email, password string) (*models.User, st
 
 	// Create user with OTP
 	user := &models.User{
-		Model:        gorm.Model{ID: 1},
+		Model:        gorm.Model{ID: userID},
 		Email:        email,
 		PasswordHash: m.hashPassword(password),
 		Verified:     true,
@@ -133,7 +132,7 @@ func (m *MockOTPService) DisableOTPForUser(userID uint) error {
 // TestOTPLoginWorkflow tests a complete OTP login workflow with automatic mock setup.
 func (m *MockOTPService) TestOTPLoginWorkflow(email, password string) (string, *models.User, error) {
 	// Create user with OTP
-	user, _, _, err := m.CreateOTPUser(email, password)
+	user, _, _, err := m.CreateOTPUser(1, email, password)
 	if err != nil {
 		return "", nil, err
 	}
@@ -175,7 +174,7 @@ func (m *MockOTPService) TestOTPSetupWorkflow(email, password string) (string, s
 // TestOTPDisableWorkflow tests disabling OTP for a user with automatic mock setup.
 func (m *MockOTPService) TestOTPDisableWorkflow(email, password string) error {
 	// Create user with OTP
-	user, _, _, err := m.CreateOTPUser(email, password)
+	user, _, _, err := m.CreateOTPUser(1, email, password)
 	if err != nil {
 		return err
 	}

--- a/core/testing/mock_storage.go
+++ b/core/testing/mock_storage.go
@@ -1,0 +1,98 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"go.lumeweb.com/portal/core"
+	"go.lumeweb.com/portal/core/testing/mocks"
+)
+
+var _ core.StorageService = (*MockStorageService)(nil)
+
+// MockStorageService provides a simplified mock for the StorageService that uses a real S3 client.
+// It embeds the mock storage service to handle all the storage operations, but overrides S3Client
+// to provide a real S3 client configured like the actual storage service.
+type MockStorageService struct {
+	*mocks.MockStorageService
+	ctx        core.Context
+	s3Client   *s3.Client
+	s3ClientMu sync.RWMutex
+}
+
+// NewMockStorageServiceWithContext creates a new MockStorageService with a core context.
+func NewMockStorageService(t TB, ctx core.Context) *MockStorageService {
+	return &MockStorageService{
+		MockStorageService: mocks.NewMockStorageService(t),
+		ctx:                ctx,
+	}
+}
+
+// ID returns the service ID.
+func (m *MockStorageService) ID() string {
+	return core.STORAGE_SERVICE
+}
+
+// S3Client returns a real S3 client configured like the storage service.
+// This method is overridden to provide a real S3 client instead of a mock.
+func (m *MockStorageService) S3Client(ctx context.Context) (*s3.Client, error) {
+	m.s3ClientMu.RLock()
+	if m.s3Client != nil {
+		m.s3ClientMu.RUnlock()
+		return m.s3Client, nil
+	}
+	m.s3ClientMu.RUnlock()
+
+	// Initialize S3 client lazily
+	m.s3ClientMu.Lock()
+	defer m.s3ClientMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if m.s3Client != nil {
+		return m.s3Client, nil
+	}
+
+	// Use the stored core context to get config
+	if m.ctx == nil {
+		return nil, fmt.Errorf("mock storage service not initialized with context - use NewMockStorageServiceWithContext")
+	}
+
+	// Create S3 client using the same logic as the real storage service
+	s3Config := m.ctx.Config().Config().Core.Storage.S3
+
+	awsCfg, err := awsConfig.LoadDefaultConfig(ctx,
+		awsConfig.WithRegion(s3Config.Region),
+		awsConfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			s3Config.AccessKey,
+			s3Config.SecretKey,
+			"",
+		)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	// Create S3 client with endpoint configuration
+	m.s3Client = s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		if s3Config.Endpoint != "" {
+			o.BaseEndpoint = aws.String(ensureHttpPrefix(s3Config.Endpoint))
+		}
+		o.UsePathStyle = true
+	})
+
+	return m.s3Client, nil
+}
+
+// ensureHttpPrefix ensures the endpoint has an http:// or https:// prefix
+func ensureHttpPrefix(endpoint string) string {
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		return "http://" + endpoint
+	}
+	return endpoint
+}

--- a/core/testing/mock_storage.go
+++ b/core/testing/mock_storage.go
@@ -60,7 +60,7 @@ func (m *MockStorageService) S3Client(ctx context.Context) (*s3.Client, error) {
 
 	// Use the stored core context to get config
 	if m.ctx == nil {
-		return nil, fmt.Errorf("mock storage service not initialized with context - use NewMockStorageServiceWithContext")
+		return nil, fmt.Errorf("mock storage service not initialized with context - use NewMockStorageService")
 	}
 
 	// Create S3 client using the same logic as the real storage service

--- a/core/testing/mock_storage.go
+++ b/core/testing/mock_storage.go
@@ -26,7 +26,7 @@ type MockStorageService struct {
 	s3ClientMu sync.RWMutex
 }
 
-// NewMockStorageServiceWithContext creates a new MockStorageService with a core context.
+// NewMockStorageService creates a new MockStorageService with a core context.
 func NewMockStorageService(t TB, ctx core.Context) *MockStorageService {
 	return &MockStorageService{
 		MockStorageService: mocks.NewMockStorageService(t),

--- a/core/testing/mock_user.go
+++ b/core/testing/mock_user.go
@@ -8,7 +8,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// MockUserService provides high-level helper functions that embed MockUserService.
+// MockUserService provides high-level helper functions that embed mocks.MockUserService.
 // It automatically sets up mock expectations and provides convenient methods for common user operations.
 type MockUserService struct {
 	*mocks.MockUserService

--- a/core/testing/mock_user.go
+++ b/core/testing/mock_user.go
@@ -1,0 +1,242 @@
+package testing
+
+import (
+	"fmt"
+
+	"go.lumeweb.com/portal/core/testing/mocks"
+	"go.lumeweb.com/portal/db/models"
+	"gorm.io/gorm"
+)
+
+// MockUserService provides high-level helper functions that embed MockUserService.
+// It automatically sets up mock expectations and provides convenient methods for common user operations.
+type MockUserService struct {
+	*mocks.MockUserService
+	ctx TestContext
+}
+
+// NewMockUserService creates a new MockUserService that embeds user mock service.
+func NewMockUserService(ctx TestContext) *MockUserService {
+	return &MockUserService{
+		MockUserService: mocks.NewMockUserService(ctx.T()),
+		ctx:             ctx,
+	}
+}
+
+// CreateTestUser creates a test user account with automatic mock setup.
+func (m *MockUserService) CreateTestUser(email, password string) (*models.User, error) {
+	// Create test user object
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     true,
+	}
+
+	// Mock the CreateAccount response
+	m.EXPECT().CreateAccount(email, password, true).Return(user, nil)
+
+	return user, nil
+}
+
+// CreateUnverifiedUser creates an unverified test user with automatic mock setup.
+func (m *MockUserService) CreateUnverifiedUser(email, password string) (*models.User, error) {
+	// Create test user object
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     false,
+	}
+
+	// Mock the CreateAccount response
+	m.EXPECT().CreateAccount(email, password, false).Return(user, nil)
+
+	return user, nil
+}
+
+// CreateAdminUser creates a test admin user with automatic mock setup.
+func (m *MockUserService) CreateAdminUser(email, password string) (*models.User, error) {
+	// Create test user object
+	user := &models.User{
+		Model:        gorm.Model{ID: 1},
+		Email:        email,
+		PasswordHash: m.hashPassword(password),
+		Verified:     true,
+		Role:         "admin",
+	}
+
+	// Mock the CreateAccount response
+	m.EXPECT().CreateAccount(email, password, true).Return(user, nil)
+
+	// Mock the UpdateAccountInfo response for role change
+	updateData := map[string]any{"role": "admin"}
+	m.EXPECT().UpdateAccountInfo(user.ID, updateData).Return(nil)
+
+	return user, nil
+}
+
+// UpdateUserName updates user's first and last name with automatic mock setup.
+func (m *MockUserService) UpdateUserName(userID uint, firstName, lastName string) error {
+	// Mock the UpdateAccountName response
+	m.EXPECT().UpdateAccountName(userID, firstName, lastName).Return(nil)
+
+	return nil
+}
+
+// UpdateUserEmail updates user's email with automatic mock setup.
+func (m *MockUserService) UpdateUserEmail(userID uint, newEmail, password string) error {
+	// Mock the UpdateAccountEmail response
+	m.EXPECT().UpdateAccountEmail(userID, newEmail, password).Return(nil)
+
+	return nil
+}
+
+// UpdateUserPassword updates user's password with automatic mock setup.
+func (m *MockUserService) UpdateUserPassword(userID uint, currentPassword, newPassword string) error {
+	// Mock the UpdateAccountPassword response
+	m.EXPECT().UpdateAccountPassword(userID, currentPassword, newPassword).Return(nil)
+
+	return nil
+}
+
+// DeleteUser deletes a user account with automatic mock setup.
+func (m *MockUserService) DeleteUser(userID uint) error {
+	// Mock the DeleteAccount response
+	m.EXPECT().DeleteAccount(userID).Return(nil)
+
+	return nil
+}
+
+// UserExists checks if user exists by ID with automatic mock setup.
+func (m *MockUserService) UserExists(userID uint) (bool, *models.User, error) {
+	// Create test user object
+	user := &models.User{
+		Model:    gorm.Model{ID: userID},
+		Email:    fmt.Sprintf("user%d@example.com", userID),
+		Verified: true,
+	}
+
+	// Mock the AccountExists response
+	m.EXPECT().AccountExists(userID).Return(true, user, nil)
+
+	return true, user, nil
+}
+
+// UserDoesNotExist checks if user does not exist by ID with automatic mock setup.
+func (m *MockUserService) UserDoesNotExist(userID uint) (bool, *models.User, error) {
+	// Mock the AccountExists response for not found
+	m.EXPECT().AccountExists(userID).Return(false, nil, nil)
+
+	return false, nil, nil
+}
+
+// EmailExists checks if email exists with automatic mock setup.
+func (m *MockUserService) EmailExists(email string) (bool, *models.User, error) {
+	// Create test user object
+	user := &models.User{
+		Model:    gorm.Model{ID: 1},
+		Email:    email,
+		Verified: true,
+	}
+
+	// Mock the EmailExists response
+	m.EXPECT().EmailExists(email).Return(true, user, nil)
+
+	return true, user, nil
+}
+
+// EmailDoesNotExist checks if email does not exist with automatic mock setup.
+func (m *MockUserService) EmailDoesNotExist(email string) (bool, *models.User, error) {
+	// Mock the EmailExists response for not found
+	m.EXPECT().EmailExists(email).Return(false, nil, nil)
+
+	return false, nil, nil
+}
+
+// IsUserVerified checks if user is verified with automatic mock setup.
+func (m *MockUserService) IsUserVerified(userID uint) (bool, error) {
+	// Mock the IsAccountVerified response
+	m.EXPECT().IsAccountVerified(userID).Return(true, nil)
+
+	return true, nil
+}
+
+// IsUserUnverified checks if user is not verified with automatic mock setup.
+func (m *MockUserService) IsUserUnverified(userID uint) (bool, error) {
+	// Mock the IsAccountVerified response
+	m.EXPECT().IsAccountVerified(userID).Return(false, nil)
+
+	return false, nil
+}
+
+// VerifyUserEmail verifies user's email with automatic mock setup.
+func (m *MockUserService) VerifyUserEmail(email string) error {
+	// Mock the VerifyEmail response
+	m.EXPECT().VerifyEmail(email, "test_verification_token").Return(nil)
+
+	return nil
+}
+
+// VerifyUserEmailFails simulates email verification failure with automatic mock setup.
+func (m *MockUserService) VerifyUserEmailFails(email string) error {
+	// Mock the VerifyEmail response with error
+	m.EXPECT().VerifyEmail(email, "test_verification_token").Return(fmt.Errorf("verification failed"))
+
+	return fmt.Errorf("verification failed")
+}
+
+// AddPublicKey adds public key to user account with automatic mock setup.
+func (m *MockUserService) AddPublicKey(user *models.User, publicKey string) error {
+	// Mock the AddPubkeyToAccount response
+	m.EXPECT().AddPubkeyToAccount(*user, publicKey).Return(nil)
+
+	return nil
+}
+
+// AddPublicKeyFails simulates public key addition failure with automatic mock setup.
+func (m *MockUserService) AddPublicKeyFails(user *models.User, publicKey string) error {
+	// Mock the AddPubkeyToAccount response with error
+	m.EXPECT().AddPubkeyToAccount(*user, publicKey).Return(fmt.Errorf("key already exists"))
+
+	return fmt.Errorf("key already exists")
+}
+
+// HashPassword hashes a password with automatic mock setup.
+func (m *MockUserService) HashPassword(password string) (string, error) {
+	hash := m.hashPassword(password)
+
+	// Mock the HashPassword response
+	m.EXPECT().HashPassword(password).Return(hash, nil)
+
+	return hash, nil
+}
+
+// HashPasswordFails simulates password hashing failure with automatic mock setup.
+func (m *MockUserService) HashPasswordFails(password string) (string, error) {
+	// Mock the HashPassword response with error
+	m.EXPECT().HashPassword(password).Return("", fmt.Errorf("hashing failed"))
+
+	return "", fmt.Errorf("hashing failed")
+}
+
+// SetupUserExistsExpectation sets up user existence expectation.
+func (m *MockUserService) SetupUserExistsExpectation(userID uint, exists bool, user *models.User, err error) {
+	m.EXPECT().AccountExists(userID).Return(exists, user, err)
+}
+
+// SetupEmailExistsExpectation sets up email existence expectation.
+func (m *MockUserService) SetupEmailExistsExpectation(email string, exists bool, user *models.User, err error) {
+	m.EXPECT().EmailExists(email).Return(exists, user, err)
+}
+
+// SetupUpdateAccountInfoExpectation sets up account info update expectation.
+func (m *MockUserService) SetupUpdateAccountInfoExpectation(userID uint, updateData map[string]any, err error) {
+	m.EXPECT().UpdateAccountInfo(userID, updateData).Return(err)
+}
+
+// hashPassword creates a simple hash for testing (in real scenario would use bcrypt)
+func (m *MockUserService) hashPassword(password string) string {
+	// Simple hash for testing - in real implementation would use bcrypt
+	return fmt.Sprintf("hashed_%s", password)
+}

--- a/core/testing/service.go
+++ b/core/testing/service.go
@@ -179,7 +179,7 @@ func WithMockAccessService() TestContextBuilderOption {
 
 // WithMockAuthService adds a mock AuthService to the test context.
 func WithMockAuthService() TestContextBuilderOption {
-	return WithMockService(core.AUTH_SERVICE, func(tb TB, ctx TestContext) any {
+	return WithMockService(core.AUTH_SERVICE, func(_ TB, ctx TestContext) any {
 		return NewMockAuthService(ctx)
 	})
 }
@@ -233,7 +233,7 @@ func WithMockMailerService() TestContextBuilderOption {
 
 // WithMockOTPService adds a mock OTPService to the test context.
 func WithMockOTPService() TestContextBuilderOption {
-	return WithMockService(core.OTP_SERVICE, func(tb TB, ctx TestContext) any {
+	return WithMockService(core.OTP_SERVICE, func(_ TB, ctx TestContext) any {
 		return NewMockOTPService(ctx)
 	})
 }
@@ -289,7 +289,7 @@ func WithMockTUSService() TestContextBuilderOption {
 
 // WithMockUserService adds a mock UserService to the test context.
 func WithMockUserService() TestContextBuilderOption {
-	return WithMockService(core.USER_SERVICE, func(tb TB, ctx TestContext) any {
+	return WithMockService(core.USER_SERVICE, func(_ TB, ctx TestContext) any {
 		return NewMockUserService(ctx)
 	})
 }

--- a/core/testing/service.go
+++ b/core/testing/service.go
@@ -179,8 +179,8 @@ func WithMockAccessService() TestContextBuilderOption {
 
 // WithMockAuthService adds a mock AuthService to the test context.
 func WithMockAuthService() TestContextBuilderOption {
-	return WithMockService(core.AUTH_SERVICE, func(tb TB, _ TestContext) any {
-		return mocks.NewMockAuthService(tb)
+	return WithMockService(core.AUTH_SERVICE, func(tb TB, ctx TestContext) any {
+		return NewMockAuthService(ctx)
 	})
 }
 
@@ -215,6 +215,8 @@ func WithMockHTTPService() TestContextBuilderOption {
 	})
 }
 
+
+
 // WithMockHashMappingService adds a mock HashMappingService to the test context.
 func WithMockHashMappingService() TestContextBuilderOption {
 	return WithMockService(core.HASH_MAPPING_SERVICE, func(tb TB, _ TestContext) any {
@@ -231,8 +233,8 @@ func WithMockMailerService() TestContextBuilderOption {
 
 // WithMockOTPService adds a mock OTPService to the test context.
 func WithMockOTPService() TestContextBuilderOption {
-	return WithMockService(core.OTP_SERVICE, func(tb TB, _ TestContext) any {
-		return mocks.NewMockOTPService(tb)
+	return WithMockService(core.OTP_SERVICE, func(tb TB, ctx TestContext) any {
+		return NewMockOTPService(ctx)
 	})
 }
 
@@ -273,8 +275,8 @@ func WithStatefulMockRenterService() TestContextBuilderOption {
 
 // WithMockStorageService adds a mock StorageService to the test context.
 func WithMockStorageService() TestContextBuilderOption {
-	return WithMockService(core.STORAGE_SERVICE, func(tb TB, _ TestContext) any {
-		return mocks.NewMockStorageService(tb)
+	return WithMockService(core.STORAGE_SERVICE, func(tb TB, ctx TestContext) any {
+		return NewMockStorageService(tb, ctx)
 	})
 }
 
@@ -287,8 +289,8 @@ func WithMockTUSService() TestContextBuilderOption {
 
 // WithMockUserService adds a mock UserService to the test context.
 func WithMockUserService() TestContextBuilderOption {
-	return WithMockService(core.USER_SERVICE, func(tb TB, _ TestContext) any {
-		return mocks.NewMockUserService(tb)
+	return WithMockService(core.USER_SERVICE, func(tb TB, ctx TestContext) any {
+		return NewMockUserService(ctx)
 	})
 }
 
@@ -336,8 +338,8 @@ func GetMockAccessService(ctx core.Context) *MockAccessService {
 
 // GetMockAuthService returns the mock auth service from the context for testing
 // Panics if the auth service is not a mock
-func GetMockAuthService(ctx core.Context) *mocks.MockAuthService {
-	return getMock[mocks.MockAuthService](ctx, core.AUTH_SERVICE)
+func GetMockAuthService(ctx core.Context) *MockAuthService {
+	return getMock[MockAuthService](ctx, core.AUTH_SERVICE)
 }
 
 // GetMockContentScannerService returns the mock content scanner service from the context for testing
@@ -372,8 +374,8 @@ func GetMockMailerService(ctx core.Context) *mocks.MockMailerService {
 
 // GetMockOTPService returns the mock otp service from the context for testing
 // Panics if the otp service is not a mock
-func GetMockOTPService(ctx core.Context) *mocks.MockOTPService {
-	return getMock[mocks.MockOTPService](ctx, core.OTP_SERVICE)
+func GetMockOTPService(ctx core.Context) *MockOTPService {
+	return getMock[MockOTPService](ctx, core.OTP_SERVICE)
 }
 
 // GetMockPasswordResetService returns the mock password reset service from the context for testing
@@ -402,8 +404,8 @@ func GetMockRenterService(ctx core.Context) *mocks.MockRenterService {
 
 // GetMockStorageService returns the mock storage service from the context for testing
 // Panics if the storage service is not a mock
-func GetMockStorageService(ctx core.Context) *mocks.MockStorageService {
-	return getMock[mocks.MockStorageService](ctx, core.STORAGE_SERVICE)
+func GetMockStorageService(ctx core.Context) *MockStorageService {
+	return getMock[MockStorageService](ctx, core.STORAGE_SERVICE)
 }
 
 // GetMockTUSService returns the mock tus service from the context for testing
@@ -414,8 +416,8 @@ func GetMockTUSService(ctx core.Context) *mocks.MockTUSService {
 
 // GetMockUserService returns the mock user service from the context for testing
 // Panics if the user service is not a mock
-func GetMockUserService(ctx core.Context) *mocks.MockUserService {
-	return getMock[mocks.MockUserService](ctx, core.USER_SERVICE)
+func GetMockUserService(ctx core.Context) *MockUserService {
+	return getMock[MockUserService](ctx, core.USER_SERVICE)
 }
 
 // GetMockWorkflowService returns the mock workflow service from the context for testing


### PR DESCRIPTION
- Introduces `JWTHelper` for creating and validating JWT tokens in tests
- Adds `MockAuthService`, `MockOTPService`, and `MockUserService` for comprehensive authentication mocking
- Provides convenience methods for common auth operations like user creation, login, and OTP setup
- Includes mock storage service that uses real S3 client for integration testing
- Updates test context builders to use new mock service wrappers
- Adds helper functions for setting up mock expectations and validating auth states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced concrete mock services for auth, OTP, user, and storage with higher-level test workflows and helpers.
  * Added comprehensive JWT test utilities for creating, validating, inspecting, expiring, refreshing, and batch-generating tokens.
  * Improved test scaffolding for user lifecycle, login (OTP and remember-me), OTP setup/disable flows, and lazy-initialized S3 client support for storage tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->