### PR TITLE
refactor(testing): enhance mock storage service with auto-wired expectations

### DIFF
--- a/core/testing/mock_storage.go
+++ b/core/testing/mock_storage.go
@@ -10,6 +10,7 @@ import (
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/core/testing/mocks"
 )
@@ -28,10 +29,15 @@ type MockStorageService struct {
 
 // NewMockStorageService creates a new MockStorageService with a core context.
 func NewMockStorageService(t TB, ctx core.Context) *MockStorageService {
-	return &MockStorageService{
+	mock := &MockStorageService{
 		MockStorageService: mocks.NewMockStorageService(t),
 		ctx:                ctx,
 	}
+	
+	// Auto-wire common expectations
+	mock.MockStorageService.EXPECT().GetTemporaryUploadDir(mock.Anything()).Return("/tmp").Maybe()
+	
+	return mock
 }
 
 // ID returns the service ID.

--- a/core/testing/mock_storage.go
+++ b/core/testing/mock_storage.go
@@ -29,15 +29,15 @@ type MockStorageService struct {
 
 // NewMockStorageService creates a new MockStorageService with a core context.
 func NewMockStorageService(t TB, ctx core.Context) *MockStorageService {
-	mock := &MockStorageService{
+	m := &MockStorageService{
 		MockStorageService: mocks.NewMockStorageService(t),
 		ctx:                ctx,
 	}
-	
+
 	// Auto-wire common expectations
-	mock.MockStorageService.EXPECT().GetTemporaryUploadDir(mock.Anything()).Return("/tmp").Maybe()
-	
-	return mock
+	m.MockStorageService.EXPECT().GetTemporaryUploadDir(mock.Anything).Return("/tmp").Maybe()
+
+	return m
 }
 
 // ID returns the service ID.


### PR DESCRIPTION
- Refactor NewMockStorageService to initialize mock with proper expectations
- Add auto-wiring of GetTemporaryUploadDir expectation with "/tmp" return value
- Use Maybe() to allow the expectation to be called zero or more times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced mock storage service to auto-provide a default temporary upload directory ("/tmp") for easier test setup.
  * Minor construction cleanup of the mock service to improve readability and maintainability in test code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->