### PR TITLE
refactor(testing): delay database setup until after test options are applied

### DIFF
--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -709,6 +709,23 @@ func WithCoreEvents() TestContextBuilderOption {
 	}
 }
 
+// SetupDatabaseOptions creates and returns database-related test context options
+// based on the current mock DB and migration settings. This helper centralizes
+// the database setup logic that was previously embedded in DefaultTestContextOptions.
+func SetupDatabaseOptions() []TestContextBuilderOption {
+	var opts []TestContextBuilderOption
+	
+	// Add DB setup first if enabled
+	if ShouldSetupMockDB() {
+		opts = append(opts, WithSQLite())
+		if ShouldRunDBMigrations() {
+			opts = append(opts, WithDBMigrations())
+		}
+	}
+	
+	return opts
+}
+
 // DefaultTestContextOptions returns the default options used for new test contexts.
 // These include mock implementations of common core services.
 func DefaultTestContextOptions() ([]TestContextBuilderOption, error) {
@@ -722,14 +739,6 @@ func DefaultTestContextOptions() ([]TestContextBuilderOption, error) {
 		WithRandomSeedPhrase(),
 		WithCoreEvents(),
 		WithErrorNamespaces(core.ExportAllErrorNamespaces()),
-	}
-
-	// Add DB setup first if enabled
-	if ShouldSetupMockDB() {
-		opts = append(opts, WithSQLite())
-		if ShouldRunDBMigrations() {
-			opts = append(opts, WithDBMigrations())
-		}
 	}
 
 	// Add remaining mock services
@@ -827,6 +836,15 @@ func BootEnvironment(tb TB, ctx TestContext) error {
 	ctx, err = ProcessTestCaseOptions(ctx)
 	if err != nil {
 		return fmt.Errorf("test case options processing failed: %w", err)
+	}
+
+	// Add DB setup first if enabled
+	dbOpts := SetupDatabaseOptions()
+	if len(dbOpts) > 0 {
+		ctx, err = ProcessCtxOptions(ctx, dbOpts...)
+		if err != nil {
+			return fmt.Errorf("database setup failed: %w", err)
+		}
 	}
 
 	// Phase 2: Component Registration

--- a/core/testing/plugin.go
+++ b/core/testing/plugin.go
@@ -72,6 +72,19 @@ func WithMockProtocol(protocolName string, configureMock ...func(protocol *MockP
 	}
 }
 
+// WithCustomMockProtocol creates a TestContextBuilderOption that registers a mock protocol
+// using a custom callback function that returns a core.Protocol implementation.
+// This allows for more flexible mock protocol creation beyond the standard MockProtocol.
+func WithCustomMockProtocol(protocolName string, protocolFactory func(TestContext) core.Protocol) TestContextBuilderOption {
+	return func(tctx TestContext) (TestContext, error) {
+		// Create a protocol factory that passes the context to the user's callback
+		factory := func() (core.Protocol, []core.ContextBuilderOption, error) {
+			return protocolFactory(tctx), nil, nil
+		}
+		return registerProtocolWithHelper(tctx, protocolName, factory)
+	}
+}
+
 // WithAPIExtension registers an API extension and automatically creates and registers
 // a mock version of its target API.
 func WithAPIExtension(extFactory core.APIExtensionFactory) TestContextBuilderOption {


### PR DESCRIPTION
- Moved database setup in `BootEnvironment` to occur after all test context options have been processed
- This ensures test options that affect database configuration are applied before database initialization
- Improves test reliability by maintaining proper initialization order and avoiding configuration conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined database configuration setup for test environments.
  * Extended mock protocol registration with context-aware factory support for more flexible testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->