### PR TITLE
fix(testing): correct type assignment check in mock plugin builder

### DIFF
--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -193,7 +193,7 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 			}
 
 			expectedType := reflect.TypeOf(b.ctx.T())
-			if !factoryType.In(0).AssignableTo(expectedType) {
+			if !expectedType.AssignableTo(factoryType.In(0)) {
 				return nil, nil, fmt.Errorf("mock service factory for '%s' first parameter is not assignable from %v", id, expectedType)
 			}
 

--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -169,7 +169,11 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 			allServices = append(allServices, core.ServiceInfo{
 				ID: id,
 				Factory: func() (core.Service, []core.ContextBuilderOption, error) {
-					return mockInst.(core.Service), nil, nil
+					svc, ok := mockInst.(core.Service)
+					if !ok {
+						return nil, nil, fmt.Errorf("mock service instance for '%s' does not implement core.Service", id)
+					}
+					return svc, nil, nil
 				},
 				Depends: depends,
 			})


### PR DESCRIPTION
- Changed the type assignment check in `MockPluginBuilder.Build()` to use `expectedType.AssignableTo(factoryType.In(0))` instead of `factoryType.In(0).AssignableTo(expectedType)`
- This corrects the logic for validating mock service factory parameter types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal test mock validation to ensure correct type compatibility.
* **Bug Fixes**
  * Added safer error handling for mock creation to return a clear error instead of causing a crash.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->