### PR TITLE
feat(testing): enhance config handling and mock plugin capabilities

### DIFF
--- a/core/testing/config.go
+++ b/core/testing/config.go
@@ -164,12 +164,17 @@ func WithRandomSeedPhrase() TestContextBuilderOption {
 }
 
 // setConfigValue is a private helper that sets a configuration value on the test context.
-// It safely checks if the config manager exists before setting the value.
+// It returns an error if the config manager is not available, ensuring test setup
+// issues are not silently ignored.
 func setConfigValue(ctx TestContext, key string, value interface{}) error {
-	if tctx, ok := ctx.(*testContext); ok && tctx.cfg != nil {
-		return tctx.cfg.Set(ctx, key, value)
+	tctx, ok := ctx.(*testContext)
+	if !ok {
+		return fmt.Errorf("test context is not a *testContext instance")
 	}
-	return nil
+	if tctx.cfg == nil {
+		return fmt.Errorf("no config manager on test context")
+	}
+	return tctx.cfg.Set(ctx, key, value)
 }
 
 // WithConfig sets a configuration value
@@ -182,53 +187,57 @@ func WithConfig(key string, value interface{}) TestContextBuilderOption {
 	}
 }
 
-// WithConfigMap applies multiple configuration values from a slice of map[string]any objects.
-// Each map should contain a single key-value pair where the key is the config path
-// (e.g., "my.service.setting") and the value is the config value.
+// WithConfigMap applies multiple configuration values from a single map[string]any.
+// The keys are config paths (e.g., "my.service.setting") and values are config values.
 // This is useful for applying flattened configuration structs.
-func WithConfigMap(configs []map[string]any) TestContextBuilderOption {
+func WithConfigMap(configs map[string]any) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
-		for _, cfg := range configs {
-			for key, value := range cfg {
-				if err := setConfigValue(ctx, key, value); err != nil {
-					return ctx, err
-				}
+		for key, value := range configs {
+			if err := setConfigValue(ctx, key, value); err != nil {
+				return ctx, err
 			}
 		}
 		return ctx, nil
 	}
 }
 
-// flattenConfigMap converts a struct implementing config.Defaults to a flattened []map[string]any.
+// flattenConfigMap converts a struct implementing config.Defaults to a flattened map[string]any.
 // It uses fatih/structs to convert struct to a map, then uses knadh/koanf/maps
 // to flatten nested maps with dot notation delimiters.
-// Returns a slice of key-value pairs as map[string]any objects.
-func flattenConfigMap(cfg config.Defaults) []map[string]any {
+// Returns a single flattened map and any error from the flattening operation.
+func flattenConfigMap(cfg config.Defaults) (map[string]any, error) {
 	// Convert struct to map using fatih/structs
 	structMap := structs.Map(cfg)
 
 	// Flatten the nested map structure
-	flatMap, _ := maps.Flatten(structMap, nil, ".")
+	flatMap, err := maps.Flatten(structMap, nil, ".")
+	if err != nil {
+		return nil, fmt.Errorf("failed to flatten config map: %w", err)
+	}
 
-	// Convert to slice of map[string]any objects using samber/lo
-	return lo.Map(lo.Entries(flatMap), func(entry lo.Entry[string, any], _ int) map[string]any {
-		return map[string]any{entry.Key: entry.Value}
-	})
+	// Convert []map[string]any to map[string]any
+	result := make(map[string]any, len(flatMap))
+	for key, value := range flatMap {
+		result[key] = value
+	}
+
+	return result, nil
 }
 
 // ApplyConfig flattens a config struct and applies all values to the test context.
 // It converts the config struct to a flattened map using flattenConfigMap,
 // then calls setConfigValue for each key-value pair.
 // The prefix is prepended to each key (e.g., "plugin.myservice.service.").
-// Returns an error if any config value fails to set.
+// Returns an error if flattening fails or any config value fails to set.
 func ApplyConfig(ctx TestContext, prefix string, cfg config.Defaults) error {
-	flatConfigs := flattenConfigMap(cfg)
-	for _, flatCfg := range flatConfigs {
-		for key, value := range flatCfg {
-			fullKey := prefix + key
-			if err := setConfigValue(ctx, fullKey, value); err != nil {
-				return err
-			}
+	flatConfig, err := flattenConfigMap(cfg)
+	if err != nil {
+		return err
+	}
+	for key, value := range flatConfig {
+		fullKey := prefix + key
+		if err := setConfigValue(ctx, fullKey, value); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/core/testing/config.go
+++ b/core/testing/config.go
@@ -3,10 +3,12 @@ package testing
 
 import (
 	"fmt"
-	"maps"
 	"os"
 	"strings"
 
+	"github.com/fatih/structs"
+	"github.com/knadh/koanf/maps"
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
@@ -35,7 +37,7 @@ func (b *ConfigBuilder) With(key string, value any) *ConfigBuilder {
 // Build creates a config object implementing the Defaults interface
 func (b *ConfigBuilder) Build() config.Defaults {
 	// Create a copy to avoid shared reference issues
-	return &genericConfig{values: maps.Clone(b.values)}
+	return &genericConfig{values: maps.Copy(b.values)}
 }
 
 // AsOptions converts the ConfigBuilder's values into TestContextBuilderOption functions
@@ -80,9 +82,12 @@ func GetRealConfig(ctx core.Context) *config.ManagerDefault {
 func WithAPIConfig(apiID string, apiConfig config.APIConfig) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
 		cfg := ctx.Config()
-		err := cfg.ConfigureAPI(apiID, apiConfig)
-		if err != nil {
+		if err := cfg.ConfigureAPI(apiID, apiConfig); err != nil {
 			return ctx, fmt.Errorf("failed to configure API %s: %w", apiID, err)
+		}
+		prefix := fmt.Sprintf(config.APISpecifier, apiID)
+		if err := ApplyConfig(ctx, prefix, apiConfig); err != nil {
+			return ctx, err
 		}
 		return ctx, nil
 	}
@@ -97,9 +102,12 @@ func WithCustomAPIConfig(apiID string, builder *ConfigBuilder) TestContextBuilde
 func WithProtocolConfig(protocolID string, protocolConfig config.ProtocolConfig) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
 		cfg := ctx.Config()
-		err := cfg.ConfigureProtocol(protocolID, protocolConfig)
-		if err != nil {
+		if err := cfg.ConfigureProtocol(protocolID, protocolConfig); err != nil {
 			return ctx, fmt.Errorf("failed to configure protocol %s: %w", protocolID, err)
+		}
+		prefix := fmt.Sprintf(config.ProtocolSpecifier, protocolID)
+		if err := ApplyConfig(ctx, prefix, protocolConfig); err != nil {
+			return ctx, err
 		}
 		return ctx, nil
 	}
@@ -114,9 +122,12 @@ func WithCustomProtocolConfig(protocolID string, builder *ConfigBuilder) TestCon
 func WithServiceConfig(pluginName string, serviceName string, serviceConfig config.ServiceConfig) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
 		cfg := ctx.Config()
-		err := cfg.ConfigureService(pluginName, serviceName, serviceConfig)
-		if err != nil {
+		if err := cfg.ConfigureService(pluginName, serviceName, serviceConfig); err != nil {
 			return ctx, fmt.Errorf("failed to configure service %s for plugin %s: %w", serviceName, pluginName, err)
+		}
+		prefix := fmt.Sprintf(config.ServiceSpecifier, pluginName, serviceName)
+		if err := ApplyConfig(ctx, prefix, serviceConfig); err != nil {
+			return ctx, err
 		}
 		return ctx, nil
 	}
@@ -152,15 +163,75 @@ func WithRandomSeedPhrase() TestContextBuilderOption {
 	return WithSeedPhrase(wallet.NewSeedPhrase())
 }
 
+// setConfigValue is a private helper that sets a configuration value on the test context.
+// It safely checks if the config manager exists before setting the value.
+func setConfigValue(ctx TestContext, key string, value interface{}) error {
+	if tctx, ok := ctx.(*testContext); ok && tctx.cfg != nil {
+		return tctx.cfg.Set(ctx, key, value)
+	}
+	return nil
+}
+
 // WithConfig sets a configuration value
 func WithConfig(key string, value interface{}) TestContextBuilderOption {
 	return func(ctx TestContext) (TestContext, error) {
-		if ctx.(*testContext).cfg != nil {
-			// Use Update method from config.Manager interface
-			_ = ctx.(*testContext).cfg.Set(ctx, key, value)
+		if err := setConfigValue(ctx, key, value); err != nil {
+			return ctx, err
 		}
 		return ctx, nil
 	}
+}
+
+// WithConfigMap applies multiple configuration values from a slice of map[string]any objects.
+// Each map should contain a single key-value pair where the key is the config path
+// (e.g., "my.service.setting") and the value is the config value.
+// This is useful for applying flattened configuration structs.
+func WithConfigMap(configs []map[string]any) TestContextBuilderOption {
+	return func(ctx TestContext) (TestContext, error) {
+		for _, cfg := range configs {
+			for key, value := range cfg {
+				if err := setConfigValue(ctx, key, value); err != nil {
+					return ctx, err
+				}
+			}
+		}
+		return ctx, nil
+	}
+}
+
+// flattenConfigMap converts a struct implementing config.Defaults to a flattened []map[string]any.
+// It uses fatih/structs to convert struct to a map, then uses knadh/koanf/maps
+// to flatten nested maps with dot notation delimiters.
+// Returns a slice of key-value pairs as map[string]any objects.
+func flattenConfigMap(cfg config.Defaults) []map[string]any {
+	// Convert struct to map using fatih/structs
+	structMap := structs.Map(cfg)
+
+	// Flatten the nested map structure
+	flatMap, _ := maps.Flatten(structMap, nil, ".")
+
+	// Convert to slice of map[string]any objects using samber/lo
+	return lo.Map(lo.Entries(flatMap), func(entry lo.Entry[string, any], _ int) map[string]any {
+		return map[string]any{entry.Key: entry.Value}
+	})
+}
+
+// ApplyConfig flattens a config struct and applies all values to the test context.
+// It converts the config struct to a flattened map using flattenConfigMap,
+// then calls setConfigValue for each key-value pair.
+// The prefix is prepended to each key (e.g., "plugin.myservice.service.").
+// Returns an error if any config value fails to set.
+func ApplyConfig(ctx TestContext, prefix string, cfg config.Defaults) error {
+	flatConfigs := flattenConfigMap(cfg)
+	for _, flatCfg := range flatConfigs {
+		for key, value := range flatCfg {
+			fullKey := prefix + key
+			if err := setConfigValue(ctx, fullKey, value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // envVarName converts a config key to an environment variable name

--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -101,14 +101,25 @@ func (b *MockPluginBuilder) WithServiceConfig(id string, config any) *MockPlugin
 }
 
 // applyServiceConfig applies configuration to a mock instance.
+// It first checks if mockInstance implements the Configurable interface before
+// setting mock expectations. If the mock doesn't implement Configurable, it
+// returns a descriptive error so the mismatch fails early.
 func (b *MockPluginBuilder) applyServiceConfig(id string, mockInstance any) error {
 	if cfg, hasConfig := b.serviceConfigs[id]; hasConfig {
+		// Check if mockInstance implements core.Configurable interface
+		configurable, ok := mockInstance.(core.Configurable)
+		if !ok {
+			return fmt.Errorf("mock service '%s' does not implement core.Configurable interface (Config() (any, error))", id)
+		}
+
+		// Now we can safely set up the mock Config() expectation
 		onMock, ok := mockInstance.(interface {
 			On(methodName string, arguments ...any) *mock.Call
 		})
 		if ok {
-			onMock.On("Config").Return(cfg, nil).Maybe()
+			onMock.On("Config").Return(configurable.Config).Maybe()
 		}
+
 		cfgDefaults, ok := cfg.(config.Defaults)
 		if ok {
 			prefix := fmt.Sprintf(config.ServiceSpecifier, b.plugin.ID, id)

--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -107,7 +107,7 @@ func (b *MockPluginBuilder) WithServiceConfig(id string, config any) *MockPlugin
 func (b *MockPluginBuilder) applyServiceConfig(id string, mockInstance any) error {
 	if cfg, hasConfig := b.serviceConfigs[id]; hasConfig {
 		// Check if mockInstance implements core.Configurable interface
-		configurable, ok := mockInstance.(core.Configurable)
+		_, ok := mockInstance.(core.Configurable)
 		if !ok {
 			return fmt.Errorf("mock service '%s' does not implement core.Configurable interface (Config() (any, error))", id)
 		}
@@ -117,7 +117,7 @@ func (b *MockPluginBuilder) applyServiceConfig(id string, mockInstance any) erro
 			On(methodName string, arguments ...any) *mock.Call
 		})
 		if ok {
-			onMock.On("Config").Return(configurable.Config).Maybe()
+			onMock.On("Config").Return(cfg, nil).Maybe()
 		}
 
 		cfgDefaults, ok := cfg.(config.Defaults)

--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal/build"
+	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 )
 
@@ -27,6 +29,7 @@ type MockPluginBuilder struct {
 	extensions           []core.APIExtensionFactory
 	mockServices         []mockServiceEntry
 	mockServiceFactories []mockServiceFactoryEntry
+	serviceConfigs       map[string]any
 	ctx                  TestContext
 }
 
@@ -84,6 +87,35 @@ func (b *MockPluginBuilder) WithMockService(id string, factory func(tb TB, ctx T
 func (b *MockPluginBuilder) WithMockServiceFactory(id string, factory interface{}, depends ...string) *MockPluginBuilder {
 	b.mockServiceFactories = append(b.mockServiceFactories, mockServiceFactoryEntry{id: id, factory: factory, depends: depends})
 	return b
+}
+
+// WithServiceConfig adds a config expectation for a mock service's Config() method.
+// The provided config will be set up as a "Maybe" expectation, allowing the mock
+// to return the config when Config() is called, or not to be called at all.
+func (b *MockPluginBuilder) WithServiceConfig(id string, config any) *MockPluginBuilder {
+	if b.serviceConfigs == nil {
+		b.serviceConfigs = make(map[string]any)
+	}
+	b.serviceConfigs[id] = config
+	return b
+}
+
+// applyServiceConfig applies configuration to a mock instance.
+func (b *MockPluginBuilder) applyServiceConfig(id string, mockInstance any) error {
+	if cfg, hasConfig := b.serviceConfigs[id]; hasConfig {
+		onMock, ok := mockInstance.(interface {
+			On(methodName string, arguments ...any) *mock.Call
+		})
+		if ok {
+			onMock.On("Config").Return(cfg, nil).Maybe()
+		}
+		cfgDefaults, ok := cfg.(config.Defaults)
+		if ok {
+			prefix := fmt.Sprintf(config.ServiceSpecifier, b.plugin.ID, id)
+			return ApplyConfig(b.ctx, prefix, cfgDefaults)
+		}
+	}
+	return nil
 }
 
 // WithAPIExtension adds individual API extensions to the plugin with their dependencies.
@@ -162,6 +194,11 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 				return nil, nil, fmt.Errorf("mock service factory for '%s' returned nil", id)
 			}
 
+			// Apply config if provided for this service
+			if err := b.applyServiceConfig(id, mockInstance); err != nil {
+				return nil, nil, err
+			}
+
 			// Capture the mock instance in the closure
 			mockInst := mockInstance
 
@@ -203,7 +240,7 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 
 			// Call the factory function immediately with stored context's TB
 			tbValue := reflect.ValueOf(b.ctx.T())
-			
+
 			// Wrap the call in a recover to prevent panics from crashing the process
 			var results []reflect.Value
 			var callErr error
@@ -215,7 +252,7 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 				}()
 				results = factoryValue.Call([]reflect.Value{tbValue})
 			}()
-			
+
 			if callErr != nil {
 				return nil, nil, callErr
 			}
@@ -228,6 +265,11 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 			mockInstance := results[0].Interface()
 			if mockInstance == nil {
 				return nil, nil, fmt.Errorf("mock service factory for '%s' returned nil", id)
+			}
+
+			// Apply config if provided for this service
+			if err := b.applyServiceConfig(id, mockInstance); err != nil {
+				return nil, nil, err
 			}
 
 			// Validate that mockInstance implements core.Service


### PR DESCRIPTION
- Introduce `ApplyConfig` function to flatten and apply configuration structs
- Add `flattenConfigMap` helper using `fatih/structs`, `knadh/koanf/maps`, and `samber/lo`
- Implement `WithConfigMap` for applying multiple config values from maps
- Enhance `WithAPIConfig`, `WithProtocolConfig`, and `WithServiceConfig` to apply nested configs
- Add `WithServiceConfig` to `MockPluginBuilder` for configuring mock services
- Improve config value setting with `setConfigValue` helper
- Update `maps.Clone` usage to `maps.Copy`
- Add `github.com/stretchr/testify/mock` dependency to `mock_plugin.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ApplyConfig: populate test-context configuration from structured defaults using flattened keys and a prefix.
  * WithConfigMap: apply multiple configuration entries to test contexts in one operation.
  * Per-service mock configs: register per-service configs and have them applied when mock services are created so Config() can return configured values.

* **Documentation**
  * Added descriptive comments for the new config APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->