### PR TITLE
refactor(testing): add snake_case key conversion and default value filtering

### DIFF
--- a/core/testing/config.go
+++ b/core/testing/config.go
@@ -4,6 +4,7 @@ package testing
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/fatih/structs"
@@ -257,9 +258,9 @@ func ApplyConfig(ctx TestContext, prefix string, cfg config.Defaults) error {
 			return true
 		}
 
-		// Filter out values that match defaults (not explicitly set)
+		// Filter out values that match defaults
 		if defaultValue, exists := flatDefaults[key]; exists {
-			return value == defaultValue
+			return reflect.DeepEqual(value, defaultValue)
 		}
 
 		return false

--- a/core/testing/config.go
+++ b/core/testing/config.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 
 	"github.com/fatih/structs"
+	"github.com/kenshaw/snaker"
 	"github.com/knadh/koanf/maps"
 	"github.com/samber/lo"
-	"go.uber.org/zap"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"go.sia.tech/coreutils/wallet"
+	"go.uber.org/zap"
 )
 
 // ConfigBuilder is a generic builder for any config type that implements
@@ -201,32 +202,39 @@ func WithConfigMap(configs map[string]any) TestContextBuilderOption {
 	}
 }
 
-// flattenConfigMap converts a struct implementing config.Defaults to a flattened map[string]any.
-// It uses fatih/structs to convert struct to a map, then uses knadh/koanf/maps
-// to flatten nested maps with dot notation delimiters.
+// flattenAndSnakeCase converts a map to a flattened map[string]any with snake_case keys.
+// It uses knadh/koanf/maps to flatten nested maps with dot notation delimiters.
+// Keys are converted from CamelCase to snake_case using snaker.CamelToSnake.
 // Returns a single flattened map and any error from the flattening operation.
-func flattenConfigMap(cfg config.Defaults) (map[string]any, error) {
-	// Convert struct to map using fatih/structs
-	structMap := structs.Map(cfg)
-
+func flattenAndSnakeCase(inputMap map[string]any) (map[string]any, error) {
 	// Flatten the nested map structure
-	flatMap, err := maps.Flatten(structMap, nil, ".")
+	flatMap, err := maps.Flatten(inputMap, nil, ".")
 	if err != nil {
 		return nil, fmt.Errorf("failed to flatten config map: %w", err)
 	}
 
-	// Convert []map[string]any to map[string]any
+	// Convert []map[string]any to map[string]any and convert keys to snake_case
 	result := make(map[string]any, len(flatMap))
 	for key, value := range flatMap {
-		result[key] = value
+		snakeKey := snaker.CamelToSnake(key)
+		result[snakeKey] = value
 	}
 
 	return result, nil
 }
 
+// flattenConfigMap converts a struct implementing config.Defaults to a flattened map[string]any.
+// It uses fatih/structs to convert struct to a map, then calls flattenAndSnakeCase.
+// Returns a single flattened map and any error from the flattening operation.
+func flattenConfigMap(cfg config.Defaults) (map[string]any, error) {
+	// Convert struct to map using fatih/structs
+	structMap := structs.Map(cfg)
+	return flattenAndSnakeCase(structMap)
+}
+
 // ApplyConfig flattens a config struct and applies all values to the test context.
 // It converts the config struct to a flattened map using flattenConfigMap,
-// then calls setConfigValue for each key-value pair.
+// then filters out nil values and keys that match defaults (unchanged values).
 // The prefix is prepended to each key (e.g., "plugin.myservice.service.").
 // Returns an error if flattening fails or any config value fails to set.
 func ApplyConfig(ctx TestContext, prefix string, cfg config.Defaults) error {
@@ -234,6 +242,29 @@ func ApplyConfig(ctx TestContext, prefix string, cfg config.Defaults) error {
 	if err != nil {
 		return err
 	}
+
+	// Get defaults to filter out unchanged values
+	defaultsMap := cfg.Defaults()
+	flatDefaults, err := flattenAndSnakeCase(defaultsMap)
+	if err != nil {
+		return err
+	}
+
+	// Filter out nil values and values that match defaults
+	flatConfig = lo.OmitBy(flatConfig, func(key string, value any) bool {
+		// Filter out nil values
+		if value == nil {
+			return true
+		}
+
+		// Filter out values that match defaults (not explicitly set)
+		if defaultValue, exists := flatDefaults[key]; exists {
+			return value == defaultValue
+		}
+
+		return false
+	})
+
 	for key, value := range flatConfig {
 		fullKey := prefix + key
 		if err := setConfigValue(ctx, fullKey, value); err != nil {
@@ -260,14 +291,14 @@ func getEnvValue(envVars []string, defaultValues []interface{}) (string, error) 
 			// Return the value (even if empty) when var is present
 			return value, nil
 		}
-		
+
 		// Try default value if env var not set
 		if i < len(defaultValues) && defaultValues[i] != nil {
 			defaultValue := defaultValues[i]
 			return fmt.Sprintf("%v", defaultValue), nil
 		}
 	}
-	
+
 	// If we get here, no env vars were set
 	if len(defaultValues) > 0 {
 		return "", fmt.Errorf("none of the environment variables %v are set and no valid default values provided", envVars)

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/invopop/jsonschema v0.13.0
 	github.com/ipfs/go-cid v0.6.0
 	github.com/johannesboyne/gofakes3 v0.0.0-20250916175020-ebf3e50324d3
+	github.com/kenshaw/snaker v0.4.3
 	github.com/knadh/koanf/parsers/json v1.0.0
 	github.com/knadh/koanf/providers/confmap v1.0.0
 	github.com/knadh/koanf/providers/rawbytes v1.0.0
@@ -93,7 +94,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.5 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/knadh/koanf/maps v0.1.2 // indirect
+	github.com/knadh/koanf/maps v0.1.2
 	github.com/knadh/koanf/parsers/yaml v1.1.0 // indirect
 	github.com/knadh/koanf/providers/file v1.2.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kenshaw/snaker v0.4.3 h1:KhB7v9iouD5RdMvAIRfaj7y3tGTpufLjxQiF7NIikwo=
+github.com/kenshaw/snaker v0.4.3/go.mod h1:SChlK7Kp/gq+iwlBqzIW4rimhwpw40HGqRtZbn38M+w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
- Introduce `snaker.CamelToSnake` for converting config keys to snake_case
- Refactor `flattenConfigMap` to use new `flattenAndSnakeCase` helper
- Add filtering logic to omit nil values and values matching defaults in `ApplyConfig`
- Update dependencies in go.mod and go.sum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration now filters out nils and default values before applying settings, preventing unintended overrides.

* **Refactor**
  * Configuration flattening and key normalization were consolidated and standardized to consistently use snake_case keys.

* **Chores**
  * Updated dependencies and cleaned up import/formatting for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->