### PR TITLE
fix(service): improve S3 upload error handling and tracking

### DIFF
--- a/service/storage.go
+++ b/service/storage.go
@@ -788,9 +788,13 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			return false, size, err
 		}
 
+		if uploadErr != nil {
+			return false, size, uploadErr
+		}
+
 		s.Logger().Debug("S3 multipart upload complete", zap.String("key", key), zap.String("bucket", bucket))
 
-		return true, size, uploadErr
+		return true, size, nil
 	})
 
 	return uploadErr

--- a/service/storage.go
+++ b/service/storage.go
@@ -782,14 +782,10 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 		}
 
 		if err = db.RetryableComponentLock(s, func(tx *gorm.DB) *gorm.DB {
-			uploadErr = tx.Delete(&s3Upload).Error
-			return tx
+			return tx.Delete(&s3Upload)
 		}); err != nil {
+			uploadErr = err
 			return false, size, err
-		}
-
-		if uploadErr != nil {
-			return false, size, uploadErr
 		}
 
 		s.Logger().Debug("S3 multipart upload complete", zap.String("key", key), zap.String("bucket", bucket))

--- a/service/storage.go
+++ b/service/storage.go
@@ -644,8 +644,8 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 		var totalUploadDuration time.Duration
 		var currentAverageDuration time.Duration
 
-		if err = db.RetryableComponentLock(s, func(db *gorm.DB) *gorm.DB {
-			return db.Model(&s3Upload).First(&s3Upload)
+		if err = db.RetryableComponentLock(s, func(tx *gorm.DB) *gorm.DB {
+			return tx.Model(&s3Upload).First(&s3Upload)
 		}); err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
 				uploadErr = err
@@ -692,8 +692,8 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			uploadId = *mu.UploadId
 
 			s3Upload.UploadID = uploadId
-			if err = db.RetryableComponentLock(s, func(db *gorm.DB) *gorm.DB {
-				return db.Create(&s3Upload)
+			if err = db.RetryableComponentLock(s, func(tx *gorm.DB) *gorm.DB {
+				return tx.Create(&s3Upload)
 			}); err != nil {
 				uploadErr = err
 				return false, size, err
@@ -781,15 +781,16 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			return false, size, err
 		}
 
-		if err = db.RetryableComponentLock(s, func(db *gorm.DB) *gorm.DB {
-			return db.Delete(&s3Upload)
+		if err = db.RetryableComponentLock(s, func(tx *gorm.DB) *gorm.DB {
+			uploadErr = tx.Delete(&s3Upload).Error
+			return tx
 		}); err != nil {
 			return false, size, err
 		}
 
 		s.Logger().Debug("S3 multipart upload complete", zap.String("key", key), zap.String("bucket", bucket))
 
-		return true, size, nil
+		return true, size, uploadErr
 	})
 
 	return uploadErr

--- a/service/storage.go
+++ b/service/storage.go
@@ -518,7 +518,10 @@ func (s StorageServiceDefault) s3PutObject(ctx context.Context, bucket string, k
 					input.ContentType = aws.String(mime.String())
 				}
 				// Reset reader position
-				_, _ = seeker.Seek(0, io.SeekStart)
+				if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+					uploadErr = fmt.Errorf("failed to reset reader after MIME detection: %w", err)
+					return false, uploadSize, uploadErr
+				}
 			}
 		}
 
@@ -607,10 +610,11 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.S3MultipartUpload")
 	defer span.End()
 
-	var result bool
+	var uploadErr error
 	core.MetricTrackGaugeWithBytes(storageMetrics.ActiveUploads, storageMetrics.S3UploadDuration, storageMetrics.S3UploadBytes, storageMetrics.S3UploadErrors, func() (bool, uint64, error) {
 		client, err := s.S3Client(ctx)
 		if err != nil {
+			uploadErr = err
 			return false, size, err
 		}
 
@@ -633,6 +637,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 
 		err = s.renter.CreateBucketIfNotExists(bucket)
 		if err != nil {
+			uploadErr = err
 			return false, size, err
 		}
 
@@ -643,6 +648,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			return db.Model(&s3Upload).First(&s3Upload)
 		}); err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				uploadErr = err
 				return false, size, err
 			}
 		} else {
@@ -679,6 +685,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 				Key:    aws.String(key),
 			})
 			if err != nil {
+				uploadErr = err
 				return false, size, err
 			}
 
@@ -688,6 +695,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			if err = db.RetryableComponentLock(s, func(db *gorm.DB) *gorm.DB {
 				return db.Create(&s3Upload)
 			}); err != nil {
+				uploadErr = err
 				return false, size, err
 			}
 		}
@@ -697,6 +705,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			partData := make([]byte, partSize)
 			readSize, err := data.Read(partData)
 			if err != nil && err != io.EOF {
+				uploadErr = err
 				return false, size, err
 			}
 
@@ -721,6 +730,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 				if abortErr != nil {
 					s.Logger().Error("error aborting multipart upload", zap.Error(abortErr))
 				}
+				uploadErr = err
 				return false, size, err
 			}
 
@@ -767,6 +777,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 		})
 		if err != nil {
 			storageMetrics.MultipartUploadErrors.Inc()
+			uploadErr = err
 			return false, size, err
 		}
 
@@ -778,14 +789,10 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 
 		s.Logger().Debug("S3 multipart upload complete", zap.String("key", key), zap.String("bucket", bucket))
 
-		result = true
 		return true, size, nil
 	})
 
-	if !result {
-		return fmt.Errorf("S3MultipartUpload failed")
-	}
-	return nil
+	return uploadErr
 }
 
 func (s StorageServiceDefault) UploadStatus(ctx context.Context, protocol core.StorageProtocol, objectName string) (core.StorageUploadStatus, *time.Time, error) {

--- a/service/storage.go
+++ b/service/storage.go
@@ -784,8 +784,8 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 		if err = db.RetryableComponentLock(s, func(tx *gorm.DB) *gorm.DB {
 			return tx.Delete(&s3Upload)
 		}); err != nil {
-			uploadErr = err
-			return false, size, err
+			s.Logger().Error("failed to delete S3Upload record after successful upload", zap.Error(err), zap.String("bucket", bucket), zap.String("key", key))
+			// Don't return error since upload succeeded
 		}
 
 		s.Logger().Debug("S3 multipart upload complete", zap.String("key", key), zap.String("bucket", bucket))

--- a/service/storage.go
+++ b/service/storage.go
@@ -483,10 +483,12 @@ func (s StorageServiceDefault) s3PutObject(ctx context.Context, bucket string, k
 		uploadSize = uint64(size)
 	}
 
-	return core.MetricTrackWithBytes(storageMetrics.S3UploadDuration, storageMetrics.S3UploadBytes, storageMetrics.S3UploadErrors, func() (error, uint64) {
+	var uploadErr error
+	core.MetricTrackWithBytes(storageMetrics.S3UploadDuration, storageMetrics.S3UploadBytes, storageMetrics.S3UploadErrors, func() (bool, uint64, error) {
 		client, err := s.S3Client(ctx)
 		if err != nil {
-			return err, uploadSize
+			uploadErr = err
+			return false, uploadSize, err
 		}
 
 		input := &s3.PutObjectInput{
@@ -521,8 +523,10 @@ func (s StorageServiceDefault) s3PutObject(ctx context.Context, bucket string, k
 		}
 
 		_, err = client.PutObject(ctx, input)
-		return err, uploadSize
+		uploadErr = err
+		return err == nil, uploadSize, err
 	})
+	return uploadErr
 }
 
 // s3GetObject is an internal helper for getting objects from S3 storage.
@@ -603,10 +607,11 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.S3MultipartUpload")
 	defer span.End()
 
-	return core.MetricTrackGaugeWithBytes(storageMetrics.ActiveUploads, storageMetrics.S3UploadDuration, storageMetrics.S3UploadBytes, storageMetrics.S3UploadErrors, size, func() error {
+	var result bool
+	core.MetricTrackGaugeWithBytes(storageMetrics.ActiveUploads, storageMetrics.S3UploadDuration, storageMetrics.S3UploadBytes, storageMetrics.S3UploadErrors, func() (bool, uint64, error) {
 		client, err := s.S3Client(ctx)
 		if err != nil {
-			return err
+			return false, size, err
 		}
 
 		var uploadId string
@@ -628,7 +633,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 
 		err = s.renter.CreateBucketIfNotExists(bucket)
 		if err != nil {
-			return err
+			return false, size, err
 		}
 
 		var totalUploadDuration time.Duration
@@ -638,7 +643,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			return db.Model(&s3Upload).First(&s3Upload)
 		}); err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
-				return err
+				return false, size, err
 			}
 		} else {
 			uploadId = s3Upload.UploadID
@@ -674,7 +679,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 				Key:    aws.String(key),
 			})
 			if err != nil {
-				return err
+				return false, size, err
 			}
 
 			uploadId = *mu.UploadId
@@ -683,7 +688,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			if err = db.RetryableComponentLock(s, func(db *gorm.DB) *gorm.DB {
 				return db.Create(&s3Upload)
 			}); err != nil {
-				return err
+				return false, size, err
 			}
 		}
 
@@ -692,7 +697,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			partData := make([]byte, partSize)
 			readSize, err := data.Read(partData)
 			if err != nil && err != io.EOF {
-				return err
+				return false, size, err
 			}
 
 			if partNum <= int(lastPartNumber) {
@@ -716,7 +721,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 				if abortErr != nil {
 					s.Logger().Error("error aborting multipart upload", zap.Error(abortErr))
 				}
-				return err
+				return false, size, err
 			}
 
 			completedParts = append(completedParts, types.CompletedPart{
@@ -762,19 +767,25 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 		})
 		if err != nil {
 			storageMetrics.MultipartUploadErrors.Inc()
-			return err
+			return false, size, err
 		}
 
 		if err = db.RetryableComponentLock(s, func(db *gorm.DB) *gorm.DB {
 			return db.Delete(&s3Upload)
 		}); err != nil {
-			return err
+			return false, size, err
 		}
 
 		s.Logger().Debug("S3 multipart upload complete", zap.String("key", key), zap.String("bucket", bucket))
 
-		return nil
+		result = true
+		return true, size, nil
 	})
+
+	if !result {
+		return fmt.Errorf("S3MultipartUpload failed")
+	}
+	return nil
 }
 
 func (s StorageServiceDefault) UploadStatus(ctx context.Context, protocol core.StorageProtocol, objectName string) (core.StorageUploadStatus, *time.Time, error) {


### PR DESCRIPTION
- Refactor `s3PutObject` to properly capture and return upload errors
- Update `S3MultipartUpload` to use new error tracking pattern and ensure proper result handling
- Add explicit error return handling in multiple failure paths
- Improve error reporting for multipart uploads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust and consistent error handling across S3 uploads and multipart flows; upload failures are now reliably surfaced.
  * Improved propagation of reader-reset and other error conditions to callers.

* **Improvements**
  * Automatic detection and setting of content type during uploads.
  * Enhanced upload metrics and success tracking; multipart uploads standardized to a unified result pattern.
  * Downloads use a fixed 1MB chunked reader for more predictable streaming performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Refactored S3 upload error handling to align with new metric tracking API that returns `(bool, uint64, error)` instead of `(error, uint64)`. Both `s3PutObject` and `S3MultipartUpload` now properly capture and return errors through an `uploadErr` variable, ensuring consistent error tracking. Key improvement: database cleanup errors after successful S3 uploads are now logged but don't cause the entire operation to fail, preventing inconsistent state where data exists in S3 but the function reports failure.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk
- The refactoring properly adapts to the new metric tracking API pattern and improves error handling consistency. The critical fix of not failing on database cleanup errors after successful S3 uploads addresses a previous logical issue. All error paths correctly propagate through the new `uploadErr` variable pattern.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| service/storage.go | Refactored S3 upload functions to use new metric tracking pattern with explicit success/error handling; improved error propagation and cleanup handling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant StorageService
    participant MetricTracker
    participant S3Client
    participant Database

    alt s3PutObject Flow
        Client->>StorageService: s3PutObject(ctx, bucket, key, data, size)
        StorageService->>MetricTracker: MetricTrackWithBytes(callback)
        MetricTracker->>StorageService: Execute callback
        StorageService->>S3Client: S3Client(ctx)
        alt Client creation fails
            S3Client-->>StorageService: error
            StorageService->>MetricTracker: return (false, size, err)
            MetricTracker->>MetricTracker: Increment error counter
            MetricTracker-->>StorageService: Return from callback
            StorageService-->>Client: return uploadErr
        end
        S3Client-->>StorageService: client
        StorageService->>StorageService: Detect MIME type
        alt Seek fails
            StorageService->>MetricTracker: return (false, size, err)
            MetricTracker->>MetricTracker: Increment error counter
            MetricTracker-->>StorageService: Return from callback
            StorageService-->>Client: return uploadErr
        end
        StorageService->>S3Client: PutObject(ctx, input)
        alt Upload fails
            S3Client-->>StorageService: error
            StorageService->>MetricTracker: return (false, size, err)
            MetricTracker->>MetricTracker: Increment error counter
        else Upload succeeds
            S3Client-->>StorageService: success
            StorageService->>MetricTracker: return (true, size, nil)
            MetricTracker->>MetricTracker: Add bytes to counter
        end
        MetricTracker-->>StorageService: Return from callback
        StorageService-->>Client: return uploadErr
    end

    alt S3MultipartUpload Flow
        Client->>StorageService: S3MultipartUpload(ctx, data, bucket, key, size)
        StorageService->>MetricTracker: MetricTrackGaugeWithBytes(callback)
        MetricTracker->>MetricTracker: Increment active uploads gauge
        MetricTracker->>StorageService: Execute callback
        StorageService->>S3Client: S3Client(ctx)
        alt Client creation fails
            S3Client-->>StorageService: error
            StorageService->>MetricTracker: return (false, size, err)
            MetricTracker->>MetricTracker: Decrement gauge, increment error counter
            StorageService-->>Client: return uploadErr
        end
        StorageService->>Database: Check for existing upload
        alt Record exists
            Database-->>StorageService: s3Upload record
            StorageService->>S3Client: ListParts to resume
        else No record
            StorageService->>S3Client: CreateMultipartUpload
            S3Client-->>StorageService: uploadId
            StorageService->>Database: Create s3Upload record
        end
        loop For each part
            StorageService->>S3Client: UploadPart
            alt Part upload fails
                S3Client-->>StorageService: error
                StorageService->>S3Client: AbortMultipartUpload
                StorageService->>MetricTracker: return (false, size, err)
                MetricTracker->>MetricTracker: Decrement gauge, increment error counter
                StorageService-->>Client: return uploadErr
            end
        end
        StorageService->>S3Client: CompleteMultipartUpload
        alt Complete fails
            S3Client-->>StorageService: error
            StorageService->>MetricTracker: return (false, size, err)
            MetricTracker->>MetricTracker: Decrement gauge, increment error counter
            StorageService-->>Client: return uploadErr
        end
        StorageService->>Database: Delete s3Upload record
        alt Delete fails (non-critical)
            Database-->>StorageService: error
            StorageService->>StorageService: Log error (don't fail)
        end
        StorageService->>MetricTracker: return (true, size, nil)
        MetricTracker->>MetricTracker: Decrement gauge, add bytes to counter
        MetricTracker-->>StorageService: Return from callback
        StorageService-->>Client: return nil
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

<!-- kody-pr-summary:start -->
This pull request improves S3 upload error handling and tracking within the storage service.

Key changes include:
*   **Enhanced Error Tracking for Metrics:** Modified S3 upload functions (`s3PutObject` and `S3MultipartUpload`) to provide more precise error tracking to metrics. The `core.MetricTrackWithBytes` and `core.MetricTrackGaugeWithBytes` now receive a callback that explicitly indicates whether an operation was successful or failed, along with the associated error.
*   **Consistent Error Propagation:** Errors encountered during S3 `PutObject` and `MultipartUpload` operations are now consistently captured and returned, ensuring that the final error state is accurately propagated.
*   **Improved MIME Detection Robustness:** Added explicit error handling when resetting the reader position after MIME type detection in `s3PutObject`, preventing potential issues if the seek operation fails.
*   **Graceful Cleanup Failure:** In `S3MultipartUpload`, if the deletion of the temporary `s3Upload` record fails after a successful S3 upload, the error is now logged but the overall upload is still considered successful, preventing a successful upload from being marked as a failure due to a non-critical cleanup issue.
<!-- kody-pr-summary:end -->