### PR TITLE
refactor(core): implement BaseComponent inheritance for services

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -341,6 +341,43 @@ func ContextWithStartupFunc(f LifecycleFunc) ContextBuilderOption {
 	}
 }
 
+// findBaseComponentField searches for a BaseComponent field in the struct hierarchy,
+// including embedded structs, using BFS traversal.
+func findBaseComponentField(componentElem reflect.Value) reflect.Value {
+	var baseComponentField reflect.Value
+
+	queue := []reflect.Value{componentElem}
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+
+		if v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				continue
+			}
+			v = v.Elem()
+		}
+
+		if v.Kind() != reflect.Struct {
+			continue
+		}
+
+		f := v.FieldByName("BaseComponent")
+		if f.IsValid() {
+			baseComponentField = f
+			break
+		}
+
+		for i := 0; i < v.NumField(); i++ {
+			if v.Type().Field(i).Anonymous {
+				queue = append(queue, v.Field(i))
+			}
+		}
+	}
+
+	return baseComponentField
+}
+
 func ContextWithStartupComponent(component Component) ContextBuilderOption {
 	return func(ctx Context) (Context, error) {
 		ctx.OnStartup(func(startupCtx Context) error {
@@ -355,7 +392,7 @@ func ContextWithStartupComponent(component Component) ContextBuilderOption {
 				return nil
 			}
 
-			baseComponentField := componentElem.FieldByName("BaseComponent")
+			baseComponentField := findBaseComponentField(componentElem)
 			if !baseComponentField.IsValid() || !baseComponentField.Type().AssignableTo(reflect.TypeOf((*BaseComponent)(nil))) {
 				return nil
 			}

--- a/core/context.go
+++ b/core/context.go
@@ -344,6 +344,27 @@ func ContextWithStartupFunc(f LifecycleFunc) ContextBuilderOption {
 func ContextWithStartupComponent(component Component) ContextBuilderOption {
 	return func(ctx Context) (Context, error) {
 		ctx.OnStartup(func(startupCtx Context) error {
+			// Initialize nil BaseComponent field if present
+			componentValue := reflect.ValueOf(component)
+			if componentValue.Kind() != reflect.Ptr || componentValue.IsNil() {
+				return nil
+			}
+
+			componentElem := componentValue.Elem()
+			if componentElem.Kind() != reflect.Struct {
+				return nil
+			}
+
+			baseComponentField := componentElem.FieldByName("BaseComponent")
+			if !baseComponentField.IsValid() || !baseComponentField.Type().AssignableTo(reflect.TypeOf((*BaseComponent)(nil))) {
+				return nil
+			}
+
+			if baseComponentField.IsNil() {
+				newBaseComponent := NewBaseComponent(startupCtx)
+				baseComponentField.Set(reflect.ValueOf(newBaseComponent))
+			}
+
 			// Wire up the component with database and config
 			component.SetDB(startupCtx.DB())
 			component.SetConfig(startupCtx.Config())

--- a/core/otel.go
+++ b/core/otel.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 )
 
 const (
@@ -29,6 +30,10 @@ type tracerSubsystemKey struct{}
 // GetTracerService extracts the tracer service name from context
 // Returns DefaultTracerService as default if no service is set
 func GetTracerService(ctx context.Context) string {
+	if ctx == nil {
+		zap.L().Warn("nil context provided to GetTracerService, using default tracer service")
+		return DefaultTracerService
+	}
 	if service, ok := ctx.Value(tracerServiceKey{}).(string); ok && service != "" {
 		return service
 	}
@@ -38,6 +43,10 @@ func GetTracerService(ctx context.Context) string {
 // GetTracerSubsystem extracts the subsystem name from context
 // Returns empty string if no subsystem is set
 func GetTracerSubsystem(ctx context.Context) string {
+	if ctx == nil {
+		zap.L().Warn("nil context provided to GetTracerSubsystem, using empty subsystem")
+		return ""
+	}
 	if subsystem, ok := ctx.Value(tracerSubsystemKey{}).(string); ok {
 		return subsystem
 	}
@@ -121,6 +130,10 @@ func WithServiceSubcomponent(ctx context.Context, serviceName, subcomponentName 
 
 // getTracerName generates the appropriate tracer name from context
 func getTracerName(ctx context.Context) string {
+	if ctx == nil {
+		zap.L().Warn("nil context provided to getTracerName, using default tracer name")
+		return DefaultTracerService
+	}
 	service := GetTracerService(ctx)
 	subsystem := GetTracerSubsystem(ctx)
 
@@ -177,6 +190,11 @@ func WithSpanKind(kind trace.SpanKind) SpanOption {
 
 // StartSpan creates and starts a new span with the given configuration
 func StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Context, trace.Span) {
+	if ctx == nil {
+		zap.L().Warn("nil context provided to StartSpan, using context.Background()")
+		ctx = context.Background()
+	}
+
 	config := &SpanConfig{
 		Name: name,
 		Kind: trace.SpanKindInternal,

--- a/portal.go
+++ b/portal.go
@@ -684,7 +684,7 @@ func (p *PortalImpl) startCron(ctx core.Context) error {
 		return errors.New("cron service not found")
 	}
 
-	err := cronSvc.(core.CronService).Start(nil)
+	err := cronSvc.(core.CronService).Start(ctx)
 	if err != nil {
 		return err
 	}

--- a/service/access.go
+++ b/service/access.go
@@ -18,8 +18,9 @@ import (
 var _ core.AccessService = (*AccessServiceDefault)(nil)
 
 type AccessServiceDefault struct {
+	*core.BaseComponent
+
 	enforcer *casbin.Enforcer
-	core.Service
 }
 
 func init() {

--- a/service/auth.go
+++ b/service/auth.go
@@ -26,10 +26,10 @@ func init() {
 }
 
 type AuthServiceDefault struct {
+	*core.BaseComponent
 	db   *gorm.DB
 	user core.UserService
 	otp  core.OTPService
-	core.Service
 }
 
 func NewAuthService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/auth.go
+++ b/service/auth.go
@@ -27,7 +27,6 @@ func init() {
 
 type AuthServiceDefault struct {
 	*core.BaseComponent
-	db   *gorm.DB
 	user core.UserService
 	otp  core.OTPService
 }
@@ -104,8 +103,8 @@ func (a AuthServiceDefault) LoginPubkey(ctx context.Context, pubkey string, ip s
 	var model models.PublicKey
 	var rowsAffected int64
 
-	err := db.RetryOnLock(a.db, func(db *gorm.DB) *gorm.DB {
-		tx := db.Model(&models.PublicKey{}).Preload("User").Where(&models.PublicKey{Key: pubkey}).First(&model)
+	err := db.RetryableComponentTransaction(a, ctx, func(tx *gorm.DB) *gorm.DB {
+		tx = tx.Model(&models.PublicKey{}).Preload("User").Where(&models.PublicKey{Key: pubkey}).First(&model)
 		rowsAffected = tx.RowsAffected
 		return tx
 	})
@@ -137,8 +136,8 @@ func (a AuthServiceDefault) LoginID(ctx context.Context, id uint, ip string, rem
 
 	user.ID = id
 
-	err := db.RetryOnLock(a.db, func(db *gorm.DB) *gorm.DB {
-		tx := db.Model(&user).Where(&user).First(&user)
+	err := db.RetryableComponentTransaction(a, ctx, func(tx *gorm.DB) *gorm.DB {
+		tx = tx.Model(&user).Where(&user).First(&user)
 		rowsAffected = tx.RowsAffected
 		return tx
 	})
@@ -173,8 +172,8 @@ func (a AuthServiceDefault) ValidLoginByEmail(ctx context.Context, email string,
 	var user models.User
 	var rowsAffected int64
 
-	err := db.RetryOnLock(a.db, func(db *gorm.DB) *gorm.DB {
-		tx := db.Model(&models.User{}).Where(&models.User{Email: email}).First(&user)
+	err := db.RetryableComponentTransaction(a, ctx, func(tx *gorm.DB) *gorm.DB {
+		tx = tx.Model(&models.User{}).Where(&models.User{Email: email}).First(&user)
 		rowsAffected = tx.RowsAffected
 		return tx
 	})

--- a/service/content_scan.go
+++ b/service/content_scan.go
@@ -29,9 +29,9 @@ func init() {
 
 // Default implementation
 type ContentScannerServiceDefault struct {
+	*core.BaseComponent
 	scanners []core.ContentScanner
 	mu       sync.RWMutex
-	core.Service
 }
 
 func NewContentScannerService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/cron.go
+++ b/service/cron.go
@@ -40,6 +40,7 @@ func init() {
 }
 
 type CronServiceDefault struct {
+	*core.BaseComponent
 	coordinator        core.CronCoordinator
 	jobFactory         core.CronJobFactory
 	scheduleRegistry   core.CronScheduleRegistry
@@ -50,7 +51,6 @@ type CronServiceDefault struct {
 	monitor            core.CronMonitor
 	entities           []core.Cronable
 	defaultRetryPolicy *core.RetryPolicy
-	core.Service
 }
 
 func (c *CronServiceDefault) initializeComponents(ctx core.Context) error {

--- a/service/hash_mapping.go
+++ b/service/hash_mapping.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 type HashMappingServiceDefault struct {
-	core.Service
+	*core.BaseComponent
 }
 
 func NewHashMappingService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/http.go
+++ b/service/http.go
@@ -71,8 +71,7 @@ func init() {
 }
 
 type HTTPServiceDefault struct {
-	ctx           core.Context
-	logger        *core.Logger
+	*core.BaseComponent
 	router        router.Router
 	srv           *http.Server
 	access        core.AccessService
@@ -82,7 +81,6 @@ type HTTPServiceDefault struct {
 	globalPathsMu sync.RWMutex
 	wg            sync.WaitGroup
 	stopOnce      sync.Once
-	core.Service
 }
 
 func NewHTTPService() (core.Service, []core.ContextBuilderOption, error) {
@@ -144,7 +142,7 @@ func (h *HTTPServiceDefault) Init() error {
 			return err
 		},
 	}))
-	h.srv.Addr = ":" + strconv.FormatUint(uint64(h.ctx.Config().Config().Core.Port), 10)
+	h.srv.Addr = ":" + strconv.FormatUint(uint64(h.Config().Config().Core.Port), 10)
 	for _, api := range core.GetAPIs() {
 		domain := h.getAPIDomain(api)
 
@@ -183,7 +181,7 @@ func (h *HTTPServiceDefault) Init() error {
 
 		// Apply any registered extensions using the *same* gswagger router
 		for _, ext := range core.GetAPIExtensions(api.Name()) {
-			h.logger.Info("Applying API extension",
+			h.Logger().Info("Applying API extension",
 				zap.String("api", api.Name()),
 				zap.String("extension", fmt.Sprintf("%T", ext)))
 
@@ -268,7 +266,7 @@ func (h *HTTPServiceDefault) Init() error {
 		return err
 	}
 
-	ocfg := h.ctx.Config().Config().Core.Observability
+	ocfg := h.Config().Config().Core.Observability
 
 	// Register metrics endpoints if observability is enabled
 	if ocfg.IsMetricsEnabled() {
@@ -292,7 +290,7 @@ func (h *HTTPServiceDefault) apiMetaHandler(e echo.Context) error {
 	// Get app type from query param (empty string means no filter)
 	appType := ctx.QueryParam("app")
 
-	metaBuilder := NewPortalMetaBuilder(h.ctx.Config().Config().Core.Domain)
+	metaBuilder := NewPortalMetaBuilder(h.Config().Config().Core.Domain)
 
 	// Add core build info from build.Default
 	metaBuilder.AddCoreBuildInfo(build.Default.Info())
@@ -307,7 +305,7 @@ func (h *HTTPServiceDefault) apiMetaHandler(e echo.Context) error {
 		// Get plugin meta builder
 		pluginBuilder, err := metaBuilder.AddPlugin(plugin.ID)
 		if err != nil {
-			h.logger.Error("Failed to add plugin to meta builder",
+			h.Logger().Error("Failed to add plugin to meta builder",
 				zap.String("plugin", plugin.ID),
 				zap.Error(err))
 			continue
@@ -328,8 +326,8 @@ func (h *HTTPServiceDefault) apiMetaHandler(e echo.Context) error {
 
 		// Let plugin add its own metadata
 		if plugin.Meta != nil {
-			if err := plugin.Meta(h.ctx, metaBuilder); err != nil {
-				h.logger.Error("Failed to process plugin meta",
+			if err := plugin.Meta(h.Context(), metaBuilder); err != nil {
+				h.Logger().Error("Failed to process plugin meta",
 					zap.String("plugin", plugin.ID),
 					zap.Error(err))
 			}
@@ -437,7 +435,7 @@ func (h *HTTPServiceDefault) apiPluginWebBundleFileServerHandler(e echo.Context)
 			manifest, err := h.getProcessedManifest(&plugin, bundle, bundleIndex)
 			if err != nil {
 				http.Error(w, "Failed to process manifest", http.StatusInternalServerError)
-				h.logger.Error("Failed to process manifest", zap.Error(err))
+				h.Logger().Error("Failed to process manifest", zap.Error(err))
 				return
 			}
 
@@ -445,7 +443,7 @@ func (h *HTTPServiceDefault) apiPluginWebBundleFileServerHandler(e echo.Context)
 			err = json.NewEncoder(w).Encode(manifest)
 			if err != nil {
 				http.Error(w, "Failed to encode manifest", http.StatusInternalServerError)
-				h.logger.Error("Failed to encode manifest", zap.Error(err))
+				h.Logger().Error("Failed to encode manifest", zap.Error(err))
 			}
 			return
 		}
@@ -478,7 +476,7 @@ func (h *HTTPServiceDefault) Serve() error {
 		defer h.wg.Done()
 		err := h.srv.Serve(ln)
 		if err != nil && err != http.ErrServerClosed {
-			h.logger.Fatal("Failed to serve", zap.Error(err))
+			h.Logger().Fatal("Failed to serve", zap.Error(err))
 		}
 	}()
 
@@ -551,7 +549,7 @@ func (h *HTTPServiceDefault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return // Request handled by the root framework router
 		}
 		// This should not happen if the router is properly configured
-		h.logger.Error("Root router does not implement http.Handler")
+		h.Logger().Error("Root router does not implement http.Handler")
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
@@ -578,12 +576,12 @@ func (h *HTTPServiceDefault) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// This should not happen if the router is properly configured
-	h.logger.Error("Target router does not implement http.Handler", zap.String("host", host))
+	h.Logger().Error("Target router does not implement http.Handler", zap.String("host", host))
 	http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 }
 
 func (h *HTTPServiceDefault) getAPIDomain(api core.API) string {
-	root := strings.Trim(strings.ToLower(h.ctx.Config().Config().Core.Domain), ".")
+	root := strings.Trim(strings.ToLower(h.Config().Config().Core.Domain), ".")
 	sub := strings.Trim(strings.ToLower(strings.TrimSpace(api.Subdomain())), ".")
 	host := root
 	if sub != "" {
@@ -594,9 +592,9 @@ func (h *HTTPServiceDefault) getAPIDomain(api core.API) string {
 
 func (h *HTTPServiceDefault) getActivePort() uint16 {
 	var port uint
-	port = h.ctx.Config().Config().Core.Port
-	if h.ctx.Config().Config().Core.ExternalPort != 0 {
-		port = h.ctx.Config().Config().Core.ExternalPort
+	port = h.Config().Config().Core.Port
+	if h.Config().Config().Core.ExternalPort != 0 {
+		port = h.Config().Config().Core.ExternalPort
 	}
 	return uint16(port)
 }
@@ -625,7 +623,7 @@ func (h *HTTPServiceDefault) APISubdomain(id string, proto bool) string {
 	formatter := ""
 
 	protocol := "http"
-	if h.ctx.Config().Config().Core.Secure {
+	if h.Config().Config().Core.Secure {
 		protocol = "https"
 	}
 
@@ -639,7 +637,7 @@ func (h *HTTPServiceDefault) APISubdomain(id string, proto bool) string {
 		return ""
 	}
 
-	return fmt.Sprintf(formatter, core.GetAPI(id).Subdomain(), h.ctx.Config().Config().Core.Domain)
+	return fmt.Sprintf(formatter, core.GetAPI(id).Subdomain(), h.Config().Config().Core.Domain)
 }
 
 func mapSchemaType(typ reflect.Type) *jsonschema.Schema {
@@ -788,7 +786,7 @@ func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string) error 
 		Registerer: core.CoreMetricsRegistry(),
 	}))
 
-	h.logger.Info("Registered core metrics endpoint", zap.String("path", metricsPath))
+	h.Logger().Info("Registered core metrics endpoint", zap.String("path", metricsPath))
 
 	// Register per-vhost metrics endpoints for each API
 	for _, api := range core.GetAPIs() {
@@ -796,7 +794,7 @@ func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string) error 
 		domain := h.getAPIDomain(api)
 		hostRouter := h.router.GetHostRouter(h.normalizeHost(domain))
 		if hostRouter == nil {
-			h.logger.Warn("Failed to get host router for metrics",
+			h.Logger().Warn("Failed to get host router for metrics",
 				zap.String("api", apiName))
 			continue
 		}
@@ -806,7 +804,7 @@ func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string) error 
 			Registerer: core.PluginMetricsRegistry(apiName),
 		}))
 
-		h.logger.Info("Registered API metrics endpoint",
+		h.Logger().Info("Registered API metrics endpoint",
 			zap.String("api", apiName),
 			zap.String("domain", domain),
 			zap.String("path", metricsPath))

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -27,10 +27,10 @@ func init() {
 }
 
 type Mailer struct {
+	*core.BaseComponent
 	client           *mail.Client
 	templateRegistry *mailer.TemplateRegistry
 	connDialed       bool
-	core.Service
 }
 
 func (m *Mailer) ID() string {

--- a/service/otp.go
+++ b/service/otp.go
@@ -19,8 +19,8 @@ func init() {
 }
 
 type OTPServiceDefault struct {
+	*core.BaseComponent
 	user core.UserService
-	core.Service
 }
 
 func NewOTPService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/password.go
+++ b/service/password.go
@@ -28,11 +28,11 @@ func init() {
 }
 
 type PasswordResetServiceDefault struct {
+	*core.BaseComponent
 	user      core.UserService
 	mailer    core.MailerService
 	mu        *sync.RWMutex
 	subdomain string
-	core.Service
 }
 
 func NewPasswordResetService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/pin.go
+++ b/service/pin.go
@@ -30,10 +30,10 @@ func init() {
 }
 
 type PinServiceDefault struct {
+	*core.BaseComponent
 	metadata core.UploadService
 	models   map[string]data_models.PinDataModel
 	mutex    *sync.RWMutex
-	core.Service
 }
 
 func (p *PinServiceDefault) RegisterPinModel(protocol string, model data_models.PinDataModel) {

--- a/service/renter.go
+++ b/service/renter.go
@@ -37,11 +37,11 @@ func init() {
 }
 
 type RenterDefault struct {
+	*core.BaseComponent
 	busClient       *busClient.Client
 	workerClient    *workerClient.Client
 	autoPilotClient *autoPilotClient.Client
 	clientManager   *renterInternal.ClientManager
-	core.Service
 }
 
 func NewRenterService() (*RenterDefault, []core.ContextBuilderOption, error) {

--- a/service/request.go
+++ b/service/request.go
@@ -32,10 +32,10 @@ func init() {
 }
 
 type RequestServiceDefault struct {
+	*core.BaseComponent
 	models map[string]data_models.RequestDataModel
 	mutex  sync.RWMutex
 	ops    core.OperationFinder
-	core.Service
 }
 
 func (r *RequestServiceDefault) RegisterRequestModel(operation string, model data_models.RequestDataModel) {

--- a/service/storage.go
+++ b/service/storage.go
@@ -117,9 +117,9 @@ func NewStorageUploadRequest(options ...core.StorageUploadOption) core.StorageUp
 }
 
 type StorageServiceDefault struct {
+	*core.BaseComponent
 	renter   core.RenterService
 	metadata core.UploadService
-	core.Service
 }
 
 func NewStorageService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/tus.go
+++ b/service/tus.go
@@ -33,8 +33,8 @@ func init() {
 }
 
 type TUSServiceDefault struct {
+	*core.BaseComponent
 	requests core.RequestService
-	core.Service
 }
 
 func NewTUSService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/upload.go
+++ b/service/upload.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 type UploadServiceDefault struct {
-	core.Service
+	*core.BaseComponent
 }
 
 func NewMetadataService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/user.go
+++ b/service/user.go
@@ -37,11 +37,11 @@ func init() {
 }
 
 type UserServiceDefault struct {
+	*core.BaseComponent
 	mailer    core.MailerService
 	cron      core.CronService
 	subdomain string
 	access    core.AccessService
-	core.Service
 }
 
 func NewUserService() (core.Service, []core.ContextBuilderOption, error) {

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -153,12 +153,12 @@ type WorkflowMetadata struct {
 
 // WorkflowCoordinatorDefault implements the WorkflowCoordinator interface
 type WorkflowCoordinatorDefault struct {
+	*core.BaseComponent
 	requestSvc  core.RequestService
 	cronService core.CronService
 	workflows   map[string]*core.WorkflowDefinition
 	disabled    map[string]bool
 	workflowsMu sync.RWMutex
-	core.Service
 }
 
 func (w *WorkflowCoordinatorDefault) RegisterTasks(ctx context.Context, cron core.CronService) error {


### PR DESCRIPTION
- Replace direct embedding of core.Service with *core.BaseComponent in service structs
- Update service initialization to use BaseComponent methods (Config(), Logger(), etc.)
- Add nil context checks and logging for OpenTelemetry tracing functions
- Pass context to cron service Start() method instead of nil
- Update HTTP service to use BaseComponent methods for config access and logging

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refactors the service architecture by replacing embedded `core.Service` with pointer-based inheritance using `*core.BaseComponent`, providing cleaner access to shared functionality (Config, Logger, DB, Context). The refactoring systematically updates 17 service files to use the new pattern and adds reflection-based automatic initialization in `ContextWithStartupComponent`.

## Key Changes

- **Core infrastructure**: Added automatic `BaseComponent` initialization via reflection in core/context.go:347-366, eliminating manual setup code
- **OpenTelemetry safety**: Added nil context checks with logging to 4 OTel functions (GetTracerService, GetTracerSubsystem, getTracerName, StartSpan) to prevent panics
- **Context propagation**: Fixed cron service startup to pass context instead of nil (portal.go:687)
- **Service refactoring**: All 17 services now use `*core.BaseComponent` for inherited functionality
- **HTTP service cleanup**: Replaced local ctx/logger fields with BaseComponent methods throughout service/http.go

## Issues Found

- `service/cron.go:47` retains redundant logger field that duplicates BaseComponent.Logger()
- `service/auth.go:30` retains redundant db field that duplicates BaseComponent.DB()

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor cleanup recommended
- The refactoring is well-executed with consistent patterns across all services. The reflection-based initialization is safe with proper nil/type checks. OpenTelemetry nil guards prevent potential panics. Two services have redundant fields (cron.logger, auth.db) that should be removed for consistency, but they don't break functionality - hence score of 4 instead of 5.
- service/cron.go and service/auth.go have redundant fields that duplicate BaseComponent functionality

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/context.go | Added automatic BaseComponent initialization in ContextWithStartupComponent using reflection to detect and initialize nil BaseComponent fields |
| core/otel.go | Added nil context checks with logging to GetTracerService, GetTracerSubsystem, getTracerName, and StartSpan functions for safer tracing |
| portal.go | Fixed cron service Start() call to pass context instead of nil, enabling proper context propagation |
| service/auth.go | Replaced embedded core.Service with *core.BaseComponent, but retains redundant db field that duplicates BaseComponent.DB() |
| service/cron.go | Replaced embedded core.Service with *core.BaseComponent, but retains redundant logger field and uses c.logger instead of Logger() method |
| service/http.go | Replaced ctx/logger fields with *core.BaseComponent and updated all references to use Config() and Logger() methods consistently |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant Ctx as Context
    participant Startup as ContextWithStartupComponent
    participant Reflection as Reflection API
    participant Service as Service Struct
    participant BaseComp as BaseComponent

    App->>Ctx: NewContext with ContextWithStartupComponent(service)
    Ctx->>Startup: Register startup function
    
    Note over App,Ctx: Startup phase begins
    
    Startup->>Reflection: Inspect component structure
    Reflection->>Reflection: Check if pointer to struct
    Reflection->>Reflection: Look for BaseComponent field
    
    alt BaseComponent field is nil
        Reflection->>BaseComp: NewBaseComponent(ctx)
        BaseComp-->>Reflection: Return initialized BaseComponent
        Reflection->>Service: Set BaseComponent field
    end
    
    Startup->>Service: SetDB(ctx.DB())
    Startup->>Service: SetConfig(ctx.Config())
    
    alt Service type
        Startup->>Ctx: WithServiceTracer(service.ID())
        Startup->>Service: SetLogger(ServiceLogger)
        Startup->>Service: SetContext(tracedCtx)
    else Protocol type
        Startup->>Ctx: WithProtocolTracer(protocol.Name())
        Startup->>Service: SetLogger(ProtocolLogger)
        Startup->>Service: SetContext(tracedCtx)
    else API type
        Startup->>Ctx: WithAPITracer(api.Name())
        Startup->>Service: SetLogger(APILogger)
        Startup->>Service: SetContext(tracedCtx)
    end
    
    Service-->>App: Fully initialized with BaseComponent
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

<!-- kody-pr-summary:start -->
This pull request refactors core services to leverage `*core.BaseComponent` for common functionalities, promoting code reuse and simplifying service implementations.

Key changes include:
*   **Service Refactoring**: Most core services (e.g., Access, Auth, Cron, HTTP, Mailer, OTP, Password Reset, Pin, Renter, Request, Storage, TUS, Upload, User, Workflow) now embed `*core.BaseComponent` instead of `core.Service`. This allows them to inherit methods for accessing `Context`, `Logger`, `Config`, and `DB` directly, reducing boilerplate and improving consistency.
*   **Automatic BaseComponent Initialization**: The `ContextWithStartupComponent` function now automatically initializes the embedded `*core.BaseComponent` field within a service during startup if it is `nil`, using reflection.
*   **HTTP Service Simplification**: The `HTTPServiceDefault` has been updated to utilize the inherited `Context()`, `Logger()`, and `Config()` methods from `BaseComponent`, removing direct `ctx` and `logger` fields.
*   **Context Handling Improvements**: Added nil context checks and warnings in OpenTelemetry functions (`GetTracerService`, `GetTracerSubsystem`, `getTracerName`, `StartSpan`) to improve robustness and debugging. `StartSpan` now falls back to `context.Background()` if a nil context is provided.
*   **Cron Service Context**: The `CronService.Start` method now correctly receives the application's `core.Context` instead of `nil`.

This refactor streamlines service development by centralizing common dependencies and initialization logic within `BaseComponent`.
<!-- kody-pr-summary:end -->