### PR TITLE
feat(db): sanitize binary UUIDs in SQL traces to prevent UTF-8 errors

### DIFF
--- a/core/otel_setup.go
+++ b/core/otel_setup.go
@@ -13,14 +13,14 @@ import (
 // ContextWithTelemetry sets up the OpenTelemetry pipeline based on observability config.
 func ContextWithTelemetry() ContextBuilderOption {
 	return func(ctx Context) (Context, error) {
-		cfg := ctx.Config().Config().Core.Observability
-
-		// Skip all setup if observability is disabled
-		if !cfg.Enabled {
-			return ctx, nil
-		}
-
 		ctx.OnStartup(func(ctx Context) error {
+			cfg := ctx.Config().Config().Core.Observability
+
+			// Skip all setup if observability is disabled
+			if !cfg.Enabled {
+				return nil
+			}
+
 			// Validate DSN format
 			if cfg.DSN == "" {
 				return nil

--- a/db/db.go
+++ b/db/db.go
@@ -28,6 +28,22 @@ import (
 	"gorm.io/plugin/prometheus"
 )
 
+// Pre-compiled regex patterns for sanitizing binary UUIDs in SQL queries
+var (
+	sanitizerRegexes = []struct {
+		re      *regexp.Regexp
+		replace string
+	}{
+		{regexp.MustCompile(`"<binary>"`), `"<uuid>"`},
+		{regexp.MustCompile(`'<binary>'`), `'<uuid>'`},
+		{regexp.MustCompile(`X'[0-9a-fA-F]+'`), `"<uuid>"`},
+		{regexp.MustCompile(`"[^"]*�[^"]*"`), `"<uuid>"`},
+		{regexp.MustCompile(`'[^']*�[^']*'`), `'<uuid>'`},
+		{regexp.MustCompile(`"[^"]*[\x00-\x08\x0b\x0c\x0e-\x1f][^"]*"`), `"<uuid>"`},
+		{regexp.MustCompile(`'[^']*[\x00-\x08\x0b\x0c\x0e-\x1f][^']*'`), `'<uuid>'`},
+	}
+)
+
 // NewDatabase creates a new database connection and returns it along with context options.
 // It configures the database based on the application configuration and sets up caching if enabled.
 func NewDatabase(ctx core.Context) (*gorm.DB, []core.ContextBuilderOption) {
@@ -122,23 +138,9 @@ func getCacher(cm config.Manager, logger *core.Logger) caches.Cacher {
 // invalid UTF-8 errors in OpenTelemetry/proto serialization.
 // Binary UUIDs appear as 16-byte sequences in SQL and are replaced with a placeholder.
 func sanitizeTracingQuery(query string) string {
-	// GORM's placeholder for binary values: "<binary>" or '<binary>'
-	// This is produced by GORM's ExplainSQL when it encounters non-printable byte slices
-	query = regexp.MustCompile(`"<binary>"`).ReplaceAllString(query, `"<uuid>"`)
-	query = regexp.MustCompile(`'<binary>'`).ReplaceAllString(query, `'<uuid>'`)
-	
-	// Hex-encoded binary pattern: X'[0-9a-fA-F]+'
-	query = regexp.MustCompile(`X'[0-9a-fA-F]+'`).ReplaceAllString(query, `"<uuid>"`)
-	
-	// Replace quoted strings containing the UTF-8 replacement character (U+FFFD)
-	// This character appears when invalid UTF-8 sequences are present (e.g., raw binary UUID bytes)
-	query = regexp.MustCompile(`"[^"]*�[^"]*"`).ReplaceAllString(query, `"<uuid>"`)
-	query = regexp.MustCompile(`'[^']*�[^']*'`).ReplaceAllString(query, `'<uuid>'`)
-	
-	// Also target strings with control characters (0x00-0x1F except \t, \n, \r)
-	query = regexp.MustCompile(`"[^"]*[\x00-\x08\x0b\x0c\x0e-\x1f][^"]*"`).ReplaceAllString(query, `"<uuid>"`)
-	query = regexp.MustCompile(`'[^']*[\x00-\x08\x0b\x0c\x0e-\x1f][^']*'`).ReplaceAllString(query, `'<uuid>'`)
-	
+	for _, s := range sanitizerRegexes {
+		query = s.re.ReplaceAllString(query, s.replace)
+	}
 	return query
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -10,6 +10,7 @@ import (
 	"math/rand/v2"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -117,6 +118,30 @@ func getCacher(cm config.Manager, logger *core.Logger) caches.Cacher {
 	return nil
 }
 
+// sanitizeTracingQuery removes binary UUID values from SQL queries to prevent
+// invalid UTF-8 errors in OpenTelemetry/proto serialization.
+// Binary UUIDs appear as 16-byte sequences in SQL and are replaced with a placeholder.
+func sanitizeTracingQuery(query string) string {
+	// GORM's placeholder for binary values: "<binary>" or '<binary>'
+	// This is produced by GORM's ExplainSQL when it encounters non-printable byte slices
+	query = regexp.MustCompile(`"<binary>"`).ReplaceAllString(query, `"<uuid>"`)
+	query = regexp.MustCompile(`'<binary>'`).ReplaceAllString(query, `'<uuid>'`)
+	
+	// Hex-encoded binary pattern: X'[0-9a-fA-F]+'
+	query = regexp.MustCompile(`X'[0-9a-fA-F]+'`).ReplaceAllString(query, `"<uuid>"`)
+	
+	// Replace quoted strings containing the UTF-8 replacement character (U+FFFD)
+	// This character appears when invalid UTF-8 sequences are present (e.g., raw binary UUID bytes)
+	query = regexp.MustCompile(`"[^"]*�[^"]*"`).ReplaceAllString(query, `"<uuid>"`)
+	query = regexp.MustCompile(`'[^']*�[^']*'`).ReplaceAllString(query, `'<uuid>'`)
+	
+	// Also target strings with control characters (0x00-0x1F except \t, \n, \r)
+	query = regexp.MustCompile(`"[^"]*[\x00-\x08\x0b\x0c\x0e-\x1f][^"]*"`).ReplaceAllString(query, `"<uuid>"`)
+	query = regexp.MustCompile(`'[^']*[\x00-\x08\x0b\x0c\x0e-\x1f][^']*'`).ReplaceAllString(query, `'<uuid>'`)
+	
+	return query
+}
+
 // SetupDBObservability configures OpenTelemetry tracing and Prometheus metrics for the database connection.
 // It returns an error if any plugin cannot be registered.
 func SetupDBObservability(ctx core.Context) error {
@@ -127,7 +152,12 @@ func SetupDBObservability(ctx core.Context) error {
 
 	// Setup OpenTelemetry tracing if enabled
 	if observabilityCfg.IsTracingEnabled() {
-		if err := db.Use(tracing.NewPlugin(tracing.WithoutMetrics())); err != nil {
+		// Add a query formatter to sanitize binary UUID values from traces
+		// This prevents invalid UTF-8 errors when uptrace serializes query strings as protobuf
+		if err := db.Use(tracing.NewPlugin(
+			tracing.WithoutMetrics(),
+			tracing.WithQueryFormatter(sanitizeTracingQuery),
+		)); err != nil {
 			return err
 		}
 	}

--- a/db/sanitize_test.go
+++ b/db/sanitize_test.go
@@ -8,6 +8,13 @@ import (
 	"gorm.io/datatypes"
 )
 
+// Pre-compiled regex patterns for testing GORM behavior
+var (
+	testGORMBinaryPattern       = regexp.MustCompile(`<binary>`)
+	testGORMHexPattern          = regexp.MustCompile(`X'[0-9a-fA-F]+'`)
+	testGORMInvalidUTF8Pattern  = regexp.MustCompile(`"[^"]*�[^"]*"`)
+)
+
 func TestSanitizeTracingQuery(t *testing.T) {
 	// Generate test data dynamically
 	binaryUUID := datatypes.NewBinUUIDv4()
@@ -154,31 +161,31 @@ func TestGORMExplainBehavior(t *testing.T) {
 
 	// Case 3: Verify our regex patterns match the expected inputs
 	tests := []struct {
-		pattern string
-		input   string
-		want    bool
+		re   *regexp.Regexp
+		input string
+		want bool
 	}{
 		{
-			pattern: `<binary>`,
-			input:   `"<binary>"`,
-			want:    true,
+			re:    testGORMBinaryPattern,
+			input: `"<binary>"`,
+			want:  true,
 		},
 		{
-			pattern: `X'[0-9a-fA-F]+'`,
-			input:   `X'deadbeef'`,
-			want:    true,
+			re:    testGORMHexPattern,
+			input: `X'deadbeef'`,
+			want:  true,
 		},
 		{
-			pattern: `"[^"]*�[^"]*"`,
-			input:   `"` + string(binaryBytes) + `"`,
-			want:    true,
+			re:    testGORMInvalidUTF8Pattern,
+			input: `"` + string(binaryBytes) + `"`,
+			want:  true,
 		},
 	}
 
 	for _, tt := range tests {
-		matched := regexp.MustCompile(tt.pattern).MatchString(tt.input)
+		matched := tt.re.MatchString(tt.input)
 		if matched != tt.want {
-			t.Errorf("Pattern %q matching %q: got %v, want %v", tt.pattern, tt.input, matched, tt.want)
+			t.Errorf("Pattern matching %q: got %v, want %v", tt.input, matched, tt.want)
 		}
 	}
 }

--- a/db/sanitize_test.go
+++ b/db/sanitize_test.go
@@ -1,0 +1,194 @@
+package db
+
+import (
+	"regexp"
+	"testing"
+	"unicode/utf8"
+
+	"gorm.io/datatypes"
+)
+
+func TestSanitizeTracingQuery(t *testing.T) {
+	// Generate test data dynamically
+	binaryUUID := datatypes.NewBinUUIDv4()
+	binaryUUIDStr := binaryUUID.String() // Standard UUID string format
+
+	hexUUID := "deadbeef1234567890abcdef1234567890"
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "GORM binary placeholder",
+			input:    `SELECT * FROM cron_jobs WHERE uuid = "<binary>" AND deleted_at IS NULL`,
+			expected: `SELECT * FROM cron_jobs WHERE uuid = "<uuid>" AND deleted_at IS NULL`,
+		},
+		{
+			name:     "Hex-encoded binary",
+			input:    `SELECT * FROM cron_jobs WHERE uuid = X'` + hexUUID + `'`,
+			expected: `SELECT * FROM cron_jobs WHERE uuid = "<uuid>"`,
+		},
+		{
+			name:     "Raw binary in double quotes",
+			input:    `INSERT INTO cron_jobs (uuid, name) VALUES ("` + string(binaryUUID.Bytes()) + `", "test")`,
+			expected: `INSERT INTO cron_jobs (uuid, name) VALUES ("<uuid>", "test")`,
+		},
+		{
+			name:     "Raw binary in single quotes",
+			input:    `SELECT * FROM cron_jobs WHERE uuid = '` + string(binaryUUID.Bytes()) + `'`,
+			expected: `SELECT * FROM cron_jobs WHERE uuid = '<uuid>'`,
+		},
+		{
+			name:     "Multiple binary values",
+			input:    `SELECT * FROM cron_jobs WHERE uuid = "<binary>" AND origin = "<binary>"`,
+			expected: `SELECT * FROM cron_jobs WHERE uuid = "<uuid>" AND origin = "<uuid>"`,
+		},
+		{
+			name:     "Normal query without binary",
+			input:    `SELECT * FROM access_rules ORDER BY ID`,
+			expected: `SELECT * FROM access_rules ORDER BY ID`,
+		},
+		{
+			name:     "Query with normal UUID string",
+			input:    `SELECT * FROM cron_jobs WHERE uuid = '` + binaryUUIDStr + `'`,
+			expected: `SELECT * FROM cron_jobs WHERE uuid = '` + binaryUUIDStr + `'`,
+		},
+		{
+			name:     "INSERT query with binary placeholder",
+			input:    `INSERT INTO cron_jobs (uuid, origin) VALUES ("<binary>", "core") RETURNING id`,
+			expected: `INSERT INTO cron_jobs (uuid, origin) VALUES ("<uuid>", "core") RETURNING id`,
+		},
+		{
+			name:     "Complex INSERT from actual log",
+			input:    `INSERT INTO cron_jobs (created_at,updated_at,deleted_at,uuid,origin,source_id,job_type,args,sched_def,schedule_type,state,last_run,last_heartbeat,failures,retry_policy,version) VALUES ("2025-12-27 01:56:36.142","2025-12-27 01:56:36.142",NULL,"<binary>","core","user.process_account_deletion_requests","core.user.process_account_deletion_requests",NULL,"{\"type\":\"daily\",\"at_time\":\"0001-01-01T00:00:00Z\"}","","queued",NULL,NULL,0,"{\"max_retries\":3,\"initial_delay\":300000000000,\"backoff_factor\":1.5}",1) RETURNING id`,
+			expected: `INSERT INTO cron_jobs (created_at,updated_at,deleted_at,uuid,origin,source_id,job_type,args,sched_def,schedule_type,state,last_run,last_heartbeat,failures,retry_policy,version) VALUES ("2025-12-27 01:56:36.142","2025-12-27 01:56:36.142",NULL,"<uuid>","core","user.process_account_deletion_requests","core.user.process_account_deletion_requests",NULL,"{\"type\":\"daily\",\"at_time\":\"0001-01-01T00:00:00Z\"}","","queued",NULL,NULL,0,"{\"max_retries\":3,\"initial_delay\":300000000000,\"backoff_factor\":1.5}",1) RETURNING id`,
+		},
+		{
+			name:     "Unicode but printable characters should not be replaced",
+			input:    `SELECT * FROM cron_jobs WHERE name = 'café'`,
+			expected: `SELECT * FROM cron_jobs WHERE name = 'café'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeTracingQuery(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeTracingQuery() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeTracingQuery_UTF8Validation(t *testing.T) {
+	// Generate test data dynamically
+	binaryUUID := datatypes.NewBinUUIDv4()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "Sanitized query is valid UTF-8",
+			input:   `SELECT * FROM cron_jobs WHERE uuid = "<binary>" AND deleted_at IS NULL`,
+			wantErr: false,
+		},
+		{
+			name:    "Sanitized query with raw binary is valid UTF-8",
+			input:   `SELECT * FROM cron_jobs WHERE uuid = '` + string(binaryUUID.Bytes()) + `'`,
+			wantErr: false,
+		},
+		{
+			name:    "Hex-encoded binary sanitized to valid UTF-8",
+			input:   `SELECT * FROM cron_jobs WHERE uuid = X'deadbeef1234567890abcdef1234567890'`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeTracingQuery(tt.input)
+
+			// Verify the result is valid UTF-8
+			isValid := isValidUTF8(result)
+			if !isValid && !tt.wantErr {
+				t.Errorf("sanitizeTracingQuery() produced invalid UTF-8, want valid: %q", result)
+			}
+			if isValid && tt.wantErr {
+				t.Errorf("sanitizeTracingQuery() produced valid UTF-8, want error: %q", result)
+			}
+		})
+	}
+}
+
+// isValidUTF8 checks if a string contains only valid UTF-8 characters
+func isValidUTF8(s string) bool {
+	for _, r := range s {
+		if r == utf8.RuneError {
+			return false
+		}
+	}
+	return true
+}
+
+// TestGORMExplainBehavior demonstrates how GORM produces the "<binary>" placeholder
+func TestGORMExplainBehavior(t *testing.T) {
+	// This test documents the behavior we're working with
+	// GORM's ExplainSQL produces "<binary>" for non-printable byte slices
+
+	// Case 1: Printable bytes are kept as-is
+	printableBytes := []byte("hello world")
+	if isPrintable(string(printableBytes)) {
+		t.Logf("Printable bytes: %q -> printable", printableBytes)
+	}
+
+	// Case 2: Binary UUID bytes produce "<binary>"
+	binaryUUID := datatypes.NewBinUUIDv4()
+	binaryBytes := binaryUUID.Bytes()
+	if !isPrintable(string(binaryBytes)) {
+		t.Logf("Binary UUID bytes: produce <binary> (non-printable)")
+	}
+
+	// Case 3: Verify our regex patterns match the expected inputs
+	tests := []struct {
+		pattern string
+		input   string
+		want    bool
+	}{
+		{
+			pattern: `<binary>`,
+			input:   `"<binary>"`,
+			want:    true,
+		},
+		{
+			pattern: `X'[0-9a-fA-F]+'`,
+			input:   `X'deadbeef'`,
+			want:    true,
+		},
+		{
+			pattern: `"[^"]*�[^"]*"`,
+			input:   `"` + string(binaryBytes) + `"`,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		matched := regexp.MustCompile(tt.pattern).MatchString(tt.input)
+		if matched != tt.want {
+			t.Errorf("Pattern %q matching %q: got %v, want %v", tt.pattern, tt.input, matched, tt.want)
+		}
+	}
+}
+
+// isPrintable mimics GORM's isPrintable function
+func isPrintable(s string) bool {
+	for _, r := range s {
+		if r < 32 || r > 126 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
- Add `sanitizeTracingQuery` function to remove binary UUID values from SQL queries
- Replace binary UUIDs with "<uuid>" placeholder to prevent invalid UTF-8 in OpenTelemetry/proto serialization
- Update `SetupDBObservability` to use query formatter
- Add comprehensive tests for sanitization logic

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds query sanitization to prevent protobuf serialization errors when binary UUIDs appear in SQL traces.

**Key Changes:**
- Implemented `sanitizeTracingQuery` function in `db/db.go` that removes binary UUID values from SQL queries before sending to OpenTelemetry/Uptrace
- The function uses 6 regex patterns to replace GORM's `<binary>` placeholders, hex-encoded values, UTF-8 replacement characters, and control characters with `<uuid>` placeholder
- Integrated sanitization into the tracing plugin via `WithQueryFormatter` option
- Added comprehensive test coverage including UTF-8 validation and GORM behavior documentation
- Minor refactoring in `core/otel_setup.go` to move config check inside OnStartup callback (no functional impact)

**Impact:**
Resolves runtime UTF-8 errors that occurred when uptrace attempted to serialize SQL queries containing binary UUID bytes as protobuf messages.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one performance optimization recommended
- The implementation correctly solves the UTF-8 serialization issue with comprehensive test coverage. The logic is sound and well-documented. Score reduced from 5 to 4 due to regex compilation happening on every query execution, which could be optimized by compiling regexes once at package initialization.
- db/db.go would benefit from pre-compiling regex patterns to avoid repeated compilation overhead

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/otel_setup.go | Minor refactor to move observability config check inside OnStartup callback - no functional changes |
| db/db.go | Added `sanitizeTracingQuery` function with 6 regex replacements to remove binary UUIDs from SQL traces, integrated into tracing plugin with `WithQueryFormatter` |
| db/sanitize_test.go | Comprehensive test suite covering binary placeholders, hex encoding, raw binary, UTF-8 validation, and GORM behavior documentation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant GORM as GORM DB
    participant Tracing as Tracing Plugin
    participant Sanitizer as sanitizeTracingQuery
    participant OTel as OpenTelemetry
    participant Uptrace as Uptrace Backend

    App->>GORM: Execute SQL Query with binary UUID
    GORM->>GORM: Convert query to string via ExplainSQL
    Note over GORM: Binary UUIDs become binary or control chars
    GORM->>Tracing: Query String with binary data
    Tracing->>Sanitizer: Format query string
    Sanitizer->>Sanitizer: Apply 6 regex replacements
    Note over Sanitizer: Replace binary placeholders, hex, invalid UTF-8, control chars
    Sanitizer-->>Tracing: Return sanitized UTF-8 valid query
    Tracing->>OTel: Create trace span with sanitized query
    OTel->>Uptrace: Serialize trace as protobuf
    Note over OTel,Uptrace: UTF-8 validation passes
    Uptrace-->>App: Trace stored successfully
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

<!-- kody-pr-summary:start -->
This pull request introduces a new feature to sanitize SQL query strings within OpenTelemetry traces, preventing potential UTF-8 encoding errors.

Key changes include:

*   **SQL Query Sanitization for Tracing**: A new `sanitizeTracingQuery` function has been added to the `db` package. This function uses regular expressions to identify and replace binary UUID values and other non-UTF-8 compliant sequences in SQL queries with a generic `"<uuid>"` placeholder. This addresses issues where raw binary data or invalid UTF-8 characters in query strings could cause serialization errors in telemetry systems (e.g., when Uptrace serializes protobuf messages). The patterns targeted include GORM's `"<binary>"` placeholders, hex-encoded binary values (e.g., `X'...'`), and quoted strings containing the UTF-8 replacement character (`�`) or control characters.
*   **Integration with OpenTelemetry Tracing**: The `sanitizeTracingQuery` function is now integrated into the database's OpenTelemetry tracing plugin using `tracing.WithQueryFormatter`, ensuring all traced SQL queries are sanitized before being sent to the telemetry backend.
*   **Comprehensive Test Coverage**: A new test file (`db/sanitize_test.go`) has been added to thoroughly validate the `sanitizeTracingQuery` function, including tests for various binary formats, raw binary data, and ensuring the output is always valid UTF-8.
*   **Refactoring of Telemetry Setup**: In `core/otel_setup.go`, the check for observability being enabled has been moved inside the `ctx.OnStartup` hook. This ensures the `OnStartup` hook is always registered, but the actual telemetry setup logic is only executed if observability is enabled.
<!-- kody-pr-summary:end -->