### PR TITLE
refactor(event): move context.Context to first parameter position in event constructors and handlers

### DIFF
--- a/event/download.go
+++ b/event/download.go
@@ -11,27 +11,27 @@ const EVENT_DOWNLOAD_COMPLETED = "download.completed"
 // DownloadCompletedEvent represents a completed download event.
 // UserID is optional - nil indicates an anonymous download (no associated user).
 type DownloadCompletedEvent struct {
+	Ctx      context.Context
 	UserID   *uint // Optional user ID; nil means anonymous download
 	UploadID uint
 	Bytes    uint64
 	IP       string
-	Ctx      context.Context
 }
 
-func NewDownloadCompletedEvent(uploadID uint, bytes uint64, ip string, userID *uint, eventCtx context.Context) *DownloadCompletedEvent {
+func NewDownloadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userID *uint) *DownloadCompletedEvent {
 	return &DownloadCompletedEvent{
+		Ctx:      eventCtx,
 		UserID:   userID,
 		UploadID: uploadID,
 		Bytes:    bytes,
 		IP:       ip,
-		Ctx:      eventCtx,
 	}
 }
 
 // OnDownloadCompleted registers a handler to run when a download is completed.
 // This is a convenience wrapper around Listen for the EVENT_DOWNLOAD_COMPLETED event.
-func OnDownloadCompleted(ctx core.Context, handler func(uploadID uint, bytes uint64, ip string, userID *uint, eventCtx context.Context) error, priority ...int) {
+func OnDownloadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint) error, priority ...int) {
 	core.Listen[DownloadCompletedEvent](ctx, EVENT_DOWNLOAD_COMPLETED, func(e *core.CoreEvent[DownloadCompletedEvent]) error {
-		return handler(e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID, e.Data.Ctx)
+		return handler(e.Data.Ctx, e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID)
 	}, priority...)
 }

--- a/event/storage_pin.go
+++ b/event/storage_pin.go
@@ -10,23 +10,23 @@ import (
 const EVENT_STORAGE_OBJECT_PINNED = "storage.object.pinned"
 
 type StorageObjectPinnedEvent struct {
+	Ctx context.Context
 	Pin *models.Pin
 	IP  string
-	Ctx context.Context
 }
 
-func NewStorageObjectPinnedEvent(pin *models.Pin, ip string, eventCtx context.Context) *StorageObjectPinnedEvent {
+func NewStorageObjectPinnedEvent(eventCtx context.Context, pin *models.Pin, ip string) *StorageObjectPinnedEvent {
 	return &StorageObjectPinnedEvent{
+		Ctx: eventCtx,
 		Pin: pin,
 		IP:  ip,
-		Ctx: eventCtx,
 	}
 }
 
 // OnStorageObjectPinned registers a handler to run when a storage object is pinned.
 // This is a convenience wrapper around Listen for the EVENT_STORAGE_OBJECT_PINNED event.
-func OnStorageObjectPinned(ctx core.Context, handler func(*models.Pin, string, context.Context) error, priority ...int) {
+func OnStorageObjectPinned(ctx core.Context, handler func(context.Context, *models.Pin, string) error, priority ...int) {
 	core.Listen[StorageObjectPinnedEvent](ctx, EVENT_STORAGE_OBJECT_PINNED, func(e *core.CoreEvent[StorageObjectPinnedEvent]) error {
-		return handler(e.Data.Pin, e.Data.IP, e.Data.Ctx)
+		return handler(e.Data.Ctx, e.Data.Pin, e.Data.IP)
 	}, priority...)
 }

--- a/event/storage_unpin.go
+++ b/event/storage_unpin.go
@@ -10,23 +10,23 @@ import (
 const EVENT_STORAGE_OBJECT_UNPINNED = "storage.object.unpinned"
 
 type StorageObjectUnpinnedEvent struct {
+	Ctx context.Context
 	Pin *models.Pin
 	IP  string
-	Ctx context.Context
 }
 
-func NewStorageObjectUnpinnedEvent(pin *models.Pin, ip string, eventCtx context.Context) *StorageObjectUnpinnedEvent {
+func NewStorageObjectUnpinnedEvent(eventCtx context.Context, pin *models.Pin, ip string) *StorageObjectUnpinnedEvent {
 	return &StorageObjectUnpinnedEvent{
+		Ctx: eventCtx,
 		Pin: pin,
 		IP:  ip,
-		Ctx: eventCtx,
 	}
 }
 
 // OnStorageObjectUnpinned registers a handler to run when a storage object is unpinned.
 // This is a convenience wrapper around Listen for the EVENT_STORAGE_OBJECT_UNPINNED event.
-func OnStorageObjectUnpinned(ctx core.Context, handler func(*models.Pin, string, context.Context) error, priority ...int) {
+func OnStorageObjectUnpinned(ctx core.Context, handler func(context.Context, *models.Pin, string) error, priority ...int) {
 	core.Listen[StorageObjectUnpinnedEvent](ctx, EVENT_STORAGE_OBJECT_UNPINNED, func(e *core.CoreEvent[StorageObjectUnpinnedEvent]) error {
-		return handler(e.Data.Pin, e.Data.IP, e.Data.Ctx)
+		return handler(e.Data.Ctx, e.Data.Pin, e.Data.IP)
 	}, priority...)
 }

--- a/event/upload.go
+++ b/event/upload.go
@@ -9,27 +9,27 @@ import (
 const EVENT_UPLOAD_COMPLETED = "upload.completed"
 
 type UploadCompletedEvent struct {
+	Ctx      context.Context
 	UserID   *uint
 	UploadID uint
 	Bytes    uint64
 	IP       string
-	Ctx      context.Context
 }
 
-func NewUploadCompletedEvent(uploadID uint, bytes uint64, ip string, userId *uint, eventCtx context.Context) *UploadCompletedEvent {
+func NewUploadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userId *uint) *UploadCompletedEvent {
 	return &UploadCompletedEvent{
+		Ctx:      eventCtx,
 		UserID:   userId,
 		UploadID: uploadID,
 		Bytes:    bytes,
 		IP:       ip,
-		Ctx:      eventCtx,
 	}
 }
 
 // OnUploadCompleted registers a handler to run when an upload is completed.
 // This is a convenience wrapper around Listen for the EVENT_UPLOAD_COMPLETED event.
-func OnUploadCompleted(ctx core.Context, handler func(uint, uint64, string, *uint, context.Context) error, priority ...int) {
+func OnUploadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint) error, priority ...int) {
 	core.Listen[UploadCompletedEvent](ctx, EVENT_UPLOAD_COMPLETED, func(e *core.CoreEvent[UploadCompletedEvent]) error {
-		return handler(e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID, e.Data.Ctx)
+		return handler(e.Data.Ctx, e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID)
 	}, priority...)
 }

--- a/event/user_activated.go
+++ b/event/user_activated.go
@@ -10,24 +10,24 @@ import (
 const EVENT_USER_ACTIVATED = "user.activated"
 
 type UserActivatedEvent struct {
-	User *models.User
 	Ctx  context.Context
+	User *models.User
 }
 
-func NewUserActivatedEvent(user *models.User, eventCtx context.Context) *UserActivatedEvent {
+func NewUserActivatedEvent(eventCtx context.Context, user *models.User) *UserActivatedEvent {
 	if user == nil {
 		panic("user cannot be nil in NewUserActivatedEvent")
 	}
 	return &UserActivatedEvent{
-		User: user,
 		Ctx:  eventCtx,
+		User: user,
 	}
 }
 
 // OnUserActivated registers a handler to run when a user is activated.
 // This is a convenience wrapper around Listen for the EVENT_USER_ACTIVATED event.
-func OnUserActivated(ctx core.Context, handler func(*models.User, context.Context) error, priority ...int) {
+func OnUserActivated(ctx core.Context, handler func(context.Context, *models.User) error, priority ...int) {
 	core.Listen[UserActivatedEvent](ctx, EVENT_USER_ACTIVATED, func(e *core.CoreEvent[UserActivatedEvent]) error {
-		return handler(e.Data.User, e.Data.Ctx)
+		return handler(e.Data.Ctx, e.Data.User)
 	}, priority...)
 }

--- a/event/user_created.go
+++ b/event/user_created.go
@@ -10,24 +10,24 @@ import (
 const EVENT_USER_CREATED = "user.created"
 
 type UserCreatedEvent struct {
-	User *models.User
 	Ctx  context.Context
+	User *models.User
 }
 
-func NewUserCreatedEvent(user *models.User, eventCtx context.Context) *UserCreatedEvent {
+func NewUserCreatedEvent(eventCtx context.Context, user *models.User) *UserCreatedEvent {
 	if user == nil {
 		panic("user cannot be nil in NewUserCreatedEvent")
 	}
 	return &UserCreatedEvent{
-		User: user,
 		Ctx:  eventCtx,
+		User: user,
 	}
 }
 
 // OnUserCreated registers a handler to run when a user is created.
 // This is a convenience wrapper around Listen for the EVENT_USER_CREATED event.
-func OnUserCreated(ctx core.Context, handler func(*models.User, context.Context) error, priority ...int) {
+func OnUserCreated(ctx core.Context, handler func(context.Context, *models.User) error, priority ...int) {
 	core.Listen[UserCreatedEvent](ctx, EVENT_USER_CREATED, func(e *core.CoreEvent[UserCreatedEvent]) error {
-		return handler(e.Data.User, e.Data.Ctx)
+		return handler(e.Data.Ctx, e.Data.User)
 	}, priority...)
 }

--- a/service/user.go
+++ b/service/user.go
@@ -281,12 +281,12 @@ func (u UserServiceDefault) CreateAccount(ctx context.Context, email string, pas
 				return nil, core.NewAccountError(core.ErrKeyAssigningUserRoleFailed, err)
 			}
 
-			if err := u.Context().Fire(event.EVENT_USER_CREATED, event.NewUserCreatedEvent(&_user, ctx)); err != nil {
+			if err := u.Context().Fire(event.EVENT_USER_CREATED, event.NewUserCreatedEvent(ctx, &_user)); err != nil {
 				return nil, err
 			}
 
 			if isFirstUser || !verifyEmail {
-				if err := u.Context().Fire(event.EVENT_USER_ACTIVATED, event.NewUserActivatedEvent(&_user, ctx)); err != nil {
+				if err := u.Context().Fire(event.EVENT_USER_ACTIVATED, event.NewUserActivatedEvent(ctx, &_user)); err != nil {
 					return nil, err
 				}
 			}
@@ -615,7 +615,7 @@ func (u UserServiceDefault) VerifyEmail(ctx context.Context, email string, token
 				return core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
 			}
 
-			err := u.Context().Fire(event.EVENT_USER_ACTIVATED, event.NewUserActivatedEvent(&verification.User, ctx))
+			err := u.Context().Fire(event.EVENT_USER_ACTIVATED, event.NewUserActivatedEvent(ctx, &verification.User))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- Reorder struct fields to place Ctx context.Context first
- Update New*Event functions to accept eventCtx as first parameter
- Update handler function signatures to have context.Context as first parameter
- Apply consistent ordering across all event types (download, upload, storage, user)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refactors all event constructors and handlers to follow Go's convention of placing `context.Context` as the first parameter. The changes affect 6 event types (download, upload, storage pin/unpin, user created/activated) and update all call sites in `service/user.go`.

**Key changes:**
- Moved `Ctx context.Context` to first field in all event structs
- Updated `New*Event()` constructors to accept `eventCtx` as first parameter
- Updated `On*()` handler function signatures to have `context.Context` as first parameter
- Updated all call sites in `service/user.go` to pass context first

**Review findings:**
- All changes are consistent and follow the same pattern across all event types
- No usages of the handler registration functions (`On*()`) were found in the codebase, so no breaking changes to existing handlers
- All call sites to event constructors have been correctly updated
- The refactoring aligns with Go idioms and best practices

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it's a clean mechanical refactoring
- The refactoring is systematic, consistent, and complete. All call sites have been updated correctly. The changes follow Go conventions (context as first parameter) and there are no existing handler implementations that would be broken by the signature changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| event/download.go | Moved `Ctx context.Context` to first struct field and updated `NewDownloadCompletedEvent` constructor and `OnDownloadCompleted` handler signature to place context first |
| event/upload.go | Moved `Ctx context.Context` to first struct field and updated `NewUploadCompletedEvent` constructor and `OnUploadCompleted` handler signature to place context first |
| event/storage_pin.go | Moved `Ctx context.Context` to first struct field and updated `NewStorageObjectPinnedEvent` constructor and `OnStorageObjectPinned` handler signature to place context first |
| event/storage_unpin.go | Moved `Ctx context.Context` to first struct field and updated `NewStorageObjectUnpinnedEvent` constructor and `OnStorageObjectUnpinned` handler signature to place context first |
| event/user_created.go | Moved `Ctx context.Context` to first struct field and updated `NewUserCreatedEvent` constructor and `OnUserCreated` handler signature to place context first |
| event/user_activated.go | Moved `Ctx context.Context` to first struct field and updated `NewUserActivatedEvent` constructor and `OnUserActivated` handler signature to place context first |
| service/user.go | Updated all calls to `NewUserCreatedEvent` and `NewUserActivatedEvent` to pass context as first parameter (lines 284, 289, 618) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Service as Service Layer
    participant EventSystem as Event System
    participant Handler as Event Handler

    Note over Service,Handler: User Account Creation Flow
    Service->>EventSystem: Fire(EVENT_USER_CREATED, NewUserCreatedEvent(ctx, user))
    Note over EventSystem: ctx as first parameter
    EventSystem->>Handler: OnUserCreated handler(ctx, user)
    Handler-->>EventSystem: return error/nil
    EventSystem-->>Service: return error/nil

    Note over Service,Handler: Upload/Download Event Flow
    Service->>EventSystem: Fire(EVENT_UPLOAD_COMPLETED, NewUploadCompletedEvent(ctx, uploadID, bytes, ip, userID))
    Note over EventSystem: ctx as first parameter
    EventSystem->>Handler: OnUploadCompleted handler(ctx, uploadID, bytes, ip, userID)
    Handler-->>EventSystem: return error/nil
    EventSystem-->>Service: return error/nil

    Note over Service,Handler: Storage Pin/Unpin Flow
    Service->>EventSystem: Fire(EVENT_STORAGE_OBJECT_PINNED, NewStorageObjectPinnedEvent(ctx, pin, ip))
    Note over EventSystem: ctx as first parameter
    EventSystem->>Handler: OnStorageObjectPinned handler(ctx, pin, ip)
    Handler-->>EventSystem: return error/nil
    EventSystem-->>Service: return error/nil
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

<!-- kody-pr-summary:start -->
This pull request refactors the event system to standardize the placement of `context.Context`.

Key changes include:
*   Moving the `context.Context` field to the first position within event structs (e.g., `DownloadCompletedEvent`, `StorageObjectPinnedEvent`, `UploadCompletedEvent`, `UserActivatedEvent`, `UserCreatedEvent`).
*   Updating event constructor functions (`New...Event`) to accept `context.Context` as their first parameter.
*   Modifying event handler registration functions (`On...Event`) and their corresponding handler signatures to expect `context.Context` as the first argument.
*   Adjusting calls to event constructors in `service/user.go` to reflect the new parameter order.

This refactoring ensures consistent `context.Context` propagation across all event definitions and handlers.
<!-- kody-pr-summary:end -->