### PR TITLE
fix(testing): properly wire up service with ContextWithStartupComponent

### DIFF
--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -1188,6 +1188,11 @@ func RegisterServices(ctx TestContext) ([]TestContextBuilderOption, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize service %s: %w", svcInfo.ID, err)
 		}
+
+		// Use ContextWithStartupComponent to properly wire up the service with BaseComponent, DB, Config, Logger, and Context
+		startupOpt := core.ContextOptions(core.ContextWithStartupComponent(svc))
+		opts = append(opts, WrapCoreOptions(startupOpt)...)
+
 		if svcOpts != nil {
 			opts = append(opts, WrapCoreOptions(svcOpts)...)
 		}


### PR DESCRIPTION
- Add ContextWithStartupComponent to initialize services with BaseComponent, DB, Config, Logger, and Context


---

<!-- kody-pr-summary:start -->
Fixes an issue where services registered within the testing context were not properly initialized with core dependencies.

This change modifies the `RegisterServices` function to use `core.ContextWithStartupComponent` for each initialized service. This ensures that services are correctly wired up with essential components such as `BaseComponent`, `DB`, `Config`, `Logger`, and `Context`, allowing them to function as expected in a test environment.
<!-- kody-pr-summary:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a critical initialization gap in the test framework where services were registered but not properly wired up with their required dependencies.

- Adds `core.ContextWithStartupComponent(svc)` call to ensure services get BaseComponent, DB, Config, Logger, and Context properly initialized
- Aligns test service initialization with production code pattern used in `portal.go:482`
- Prevents potential nil pointer dereferences and uninitialized component issues in test scenarios

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified risks
- The change is a straightforward bug fix that adds missing initialization code, follows established patterns from production code, and has no side effects. The 3-line addition properly wires up service dependencies that were previously missing, preventing potential runtime issues in tests.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/testing/context.go | Adds `ContextWithStartupComponent` to properly initialize services with BaseComponent, DB, Config, Logger, and Context - aligning test initialization with production patterns |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Code
    participant RS as RegisterServices()
    participant Factory as Service Factory
    participant Svc as Service Instance
    participant Ctx as TestContext
    participant Startup as OnStartup Hook
    
    Test->>RS: Call RegisterServices(ctx)
    RS->>Factory: svc, svcOpts, err = svcInfo.Factory()
    Factory-->>RS: Return service instance
    
    Note over RS: NEW: Add ContextWithStartupComponent
    RS->>RS: startupOpt = core.ContextOptions(core.ContextWithStartupComponent(svc))
    RS->>RS: opts = append(opts, WrapCoreOptions(startupOpt)...)
    
    Note over RS: Collect service-specific options
    alt svcOpts != nil
        RS->>RS: opts = append(opts, WrapCoreOptions(svcOpts)...)
    end
    
    RS->>Ctx: tctx.RegisterService(svcInfo.ID, svc)
    
    Note over Startup: Later during context startup...
    Startup->>Svc: Initialize BaseComponent
    Startup->>Svc: SetDB(ctx.DB())
    Startup->>Svc: SetConfig(ctx.Config())
    Startup->>Svc: SetLogger(ctx.ServiceLogger(svc))
    Startup->>Svc: SetContext(tracedCtx)
    
    RS-->>Test: Return opts
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->