### PR TITLE
feat(core): add workflow configuration helpers for DRY plugin development

### DIFF
--- a/core/workflow.go
+++ b/core/workflow.go
@@ -16,6 +16,13 @@ import (
 
 const WORKFLOW_SERVICE = "workflow"
 
+// Workflow name constants for common workflows
+const (
+	PinWorkflowName       = "pin"
+	UploadWorkflowName    = "upload"
+	TUSUploadWorkflowName = "tus_upload"
+)
+
 // Predefined errors
 var (
 	ErrWorkflowHasNoSteps = errors.New("workflow has no steps")
@@ -415,4 +422,88 @@ type WorkflowStatus struct {
 	StartedAt     time.Time
 	UpdatedAt     time.Time
 	Message       string
+}
+
+// NewRetryStep creates an OperationStep with RetryStep failure behavior.
+// This is the most common failure behavior for operations that may transiently fail
+// and should be retried with backoff.
+func NewRetryStep(operation string) OperationStep {
+	return OperationStep{
+		Operation:       operation,
+		FailureBehavior: RetryStep,
+		ID:              operation,
+	}
+}
+
+// NewContinueStep creates an OperationStep with ContinueWorkflow failure behavior.
+// Use this for optional operations where failure should not block the workflow.
+func NewContinueStep(operation string) OperationStep {
+	return OperationStep{
+		Operation:       operation,
+		FailureBehavior: ContinueWorkflow,
+		ID:              operation,
+	}
+}
+
+// NewFailStep creates an OperationStep with FailWorkflow failure behavior.
+// Use this for critical operations where any failure should halt the entire workflow.
+func NewFailStep(operation string) OperationStep {
+	return OperationStep{
+		Operation:       operation,
+		FailureBehavior: FailWorkflow,
+		ID:              operation,
+	}
+}
+
+// NewWorkflowDefinition creates a WorkflowDefinition with the given parameters.
+// This is a convenience function for creating workflow definitions.
+func NewWorkflowDefinition(name string, autoTriggerFirstStep bool, steps []OperationStep) WorkflowDefinition {
+	return WorkflowDefinition{
+		Name:                 name,
+		Steps:                steps,
+		AutoTriggerFirstStep: autoTriggerFirstStep,
+	}
+}
+
+// NewPinWorkflow creates a standard pin workflow definition for a protocol.
+// The workflow includes: retrieve, scan, store, and optionally publish steps.
+// Additional steps can be appended by the plugin as needed.
+func NewPinWorkflow(protocol string, includePublish bool) WorkflowDefinition {
+	steps := []OperationStep{
+		NewRetryStep(RetrieveOperationName(protocol)),
+		NewRetryStep(ScanOperationName(protocol)),
+		NewRetryStep(StoreOperationName(protocol)),
+	}
+
+	if includePublish {
+		steps = append(steps, NewContinueStep(PublishOperationName(protocol)))
+	}
+
+	return NewWorkflowDefinition(PinWorkflowName, true, steps)
+}
+
+// NewUploadWorkflow creates a standard upload workflow definition for a protocol.
+// The workflow includes: post-upload step.
+// Additional steps can be appended by the plugin as needed.
+func NewUploadWorkflow(protocol string) WorkflowDefinition {
+	return NewWorkflowDefinition(
+		UploadWorkflowName,
+		true,
+		[]OperationStep{
+			NewRetryStep(PostUploadOperationName(protocol)),
+		},
+	)
+}
+
+// NewTUSUploadWorkflow creates a standard TUS upload workflow definition for a protocol.
+// The workflow includes: TUS upload step.
+// Additional steps can be appended by the plugin as needed.
+func NewTUSUploadWorkflow(protocol string) WorkflowDefinition {
+	return NewWorkflowDefinition(
+		TUSUploadWorkflowName,
+		true,
+		[]OperationStep{
+			NewRetryStep(TUSUploadOperationName(protocol)),
+		},
+	)
 }


### PR DESCRIPTION
- Add step creation helpers: NewRetryStep, NewContinueStep, NewFailStep
- Add workflow definition helper: NewWorkflowDefinition
- Add standard workflow templates: NewPinWorkflow, NewUploadWorkflow, NewTUSUploadWorkflow
- Add workflow name constants: PinWorkflowName, UploadWorkflowName, TUSUploadWorkflowName


---

<!-- kody-pr-summary:start -->
This pull request introduces a set of helper functions and constants to streamline workflow configuration and promote DRY (Don't Repeat Yourself) plugin development.

Key changes include:

*   **Workflow Name Constants**: Added constants (`PinWorkflowName`, `UploadWorkflowName`, `TUSUploadWorkflowName`) for standard workflow names to ensure consistency.
*   **Operation Step Helpers**: Introduced `NewRetryStep`, `NewContinueStep`, and `NewFailStep` functions to simplify the creation of `OperationStep` objects with predefined failure behaviors (retry on transient failure, continue on optional failure, or fail workflow on critical failure).
*   **Workflow Definition Helper**: Added `NewWorkflowDefinition` as a general utility for creating workflow definitions.
*   **Standard Workflow Definitions**: Provided helper functions (`NewPinWorkflow`, `NewUploadWorkflow`, `NewTUSUploadWorkflow`) to generate common workflow definitions with pre-configured steps and failure behaviors, reducing boilerplate for plugins implementing these standard processes.
<!-- kody-pr-summary:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added workflow configuration helpers to reduce boilerplate in plugin development.

- **New constants**: Added `PinWorkflowName`, `UploadWorkflowName`, `TUSUploadWorkflowName` for standardized workflow naming
- **Step creation helpers**: `NewRetryStep`, `NewContinueStep`, `NewFailStep` simplify creating operation steps with different failure behaviors
- **Workflow definition helper**: `NewWorkflowDefinition` provides a cleaner way to construct workflow definitions
- **Standard workflow templates**: `NewPinWorkflow`, `NewUploadWorkflow`, `NewTUSUploadWorkflow` provide ready-to-use workflow patterns for common plugin operations

These helpers follow established patterns in the codebase, correctly utilize existing operation name functions (`RetrieveOperationName`, `ScanOperationName`, etc.), and maintain consistency with the `WorkflowDefinition` struct. The implementation reduces repetitive code that plugins would otherwise need to write when defining workflows.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - pure helper functions with no breaking changes
- The PR adds convenience helpers that are entirely additive with zero risk. All helpers correctly use existing, tested operation name functions and follow established patterns. No existing code is modified, no breaking changes introduced, and the helpers are well-documented with clear use cases
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/workflow.go | Added workflow helper functions and constants for DRY plugin development - all helpers correctly use existing operation name functions and follow established patterns |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Plugin as Plugin/Protocol
    participant Helpers as Workflow Helpers
    participant OpNames as Operation Name Functions
    participant Workflow as Workflow Service
    
    Note over Plugin,Workflow: Plugin Development Flow
    
    Plugin->>Helpers: NewPinWorkflow(protocol, includePublish)
    Helpers->>OpNames: RetrieveOperationName(protocol)
    OpNames-->>Helpers: "protocol.retrieve"
    Helpers->>Helpers: NewRetryStep("protocol.retrieve")
    Helpers->>OpNames: ScanOperationName(protocol)
    OpNames-->>Helpers: "protocol.scan"
    Helpers->>Helpers: NewRetryStep("protocol.scan")
    Helpers->>OpNames: StoreOperationName(protocol)
    OpNames-->>Helpers: "protocol.store"
    Helpers->>Helpers: NewRetryStep("protocol.store")
    
    alt includePublish is true
        Helpers->>OpNames: PublishOperationName(protocol)
        OpNames-->>Helpers: "protocol.publish"
        Helpers->>Helpers: NewContinueStep("protocol.publish")
    end
    
    Helpers->>Helpers: NewWorkflowDefinition(PinWorkflowName, true, steps)
    Helpers-->>Plugin: WorkflowDefinition
    
    Plugin->>Workflow: RegisterWorkflow(wf.Name, wf.Steps, wf.AutoTriggerFirstStep)
    Workflow-->>Plugin: Success
    
    Note over Plugin,Workflow: Alternative: Direct Helper Usage
    
    Plugin->>Helpers: NewUploadWorkflow(protocol)
    Helpers->>OpNames: PostUploadOperationName(protocol)
    OpNames-->>Helpers: "protocol.post_upload"
    Helpers->>Helpers: NewRetryStep("protocol.post_upload")
    Helpers-->>Plugin: WorkflowDefinition
    
    Plugin->>Helpers: NewTUSUploadWorkflow(protocol)
    Helpers->>OpNames: TUSUploadOperationName(protocol)
    OpNames-->>Helpers: "protocol.tus_upload"
    Helpers->>Helpers: NewRetryStep("protocol.tus_upload")
    Helpers-->>Plugin: WorkflowDefinition
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->