### PR TITLE
refactor(testing): migrate from .On() to .EXPECT() mock pattern and improve test utilities

### DIFF
--- a/core/testing/api.go
+++ b/core/testing/api.go
@@ -85,28 +85,28 @@ func NewMockAPI(t testing.TB, name string) *MockAPI {
 // WithConfig sets the config for the mock API
 func (m *MockAPI) WithConfig(cfg config.APIConfig) *MockAPI {
 	m.configValue = cfg
-	m.MockAPI.On("GetConfig").Return(cfg).Maybe()
+	m.MockAPI.EXPECT().GetConfig().Return(cfg).Maybe()
 	return m
 }
 
 // WithSubdomain sets the subdomain for the mock API
 func (m *MockAPI) WithSubdomain(subdomain string) *MockAPI {
 	m.subdomainValue = subdomain
-	m.MockAPI.On("Subdomain").Return(subdomain).Maybe()
+	m.MockAPI.EXPECT().Subdomain().Return(subdomain).Maybe()
 	return m
 }
 
 // WithAuthTokenName sets the auth token name for the mock API
 func (m *MockAPI) WithAuthTokenName(authTokenName string) *MockAPI {
 	m.authTokenNameValue = authTokenName
-	m.MockAPI.On("AuthTokenName").Return(authTokenName).Maybe()
+	m.MockAPI.EXPECT().AuthTokenName().Return(authTokenName).Maybe()
 	return m
 }
 
 // WithOpenAPIInfo sets the OpenAPI info for the mock API
 func (m *MockAPI) WithOpenAPIInfo(openAPIInfo router.APIInfoDefinition) *MockAPI {
 	m.openAPIInfoValue = openAPIInfo
-	m.MockAPI.On("OpenAPIInfo").Return(openAPIInfo).Maybe()
+	m.MockAPI.EXPECT().OpenAPIInfo().Return(openAPIInfo).Maybe()
 	return m
 }
 

--- a/core/testing/api_extension.go
+++ b/core/testing/api_extension.go
@@ -34,8 +34,8 @@ func NewMockAPIExtension(t TB, targetAPI string) *MockAPIExtension {
 	}
 
 	// Setup default expectations
-	mockAPIExtension.MockAPIExtension.On("TargetAPI").Return(targetAPI).Maybe()
-	mockAPIExtension.MockAPIExtension.On("Configure", new(router.Router), new(core.AccessService)).Return(nil).Maybe()
+	mockAPIExtension.MockAPIExtension.EXPECT().TargetAPI().Return(targetAPI).Maybe()
+	mockAPIExtension.MockAPIExtension.EXPECT().Configure(new(router.Router), new(core.AccessService)).Return(nil).Maybe()
 
 	return mockAPIExtension
 }

--- a/core/testing/api_extension.go
+++ b/core/testing/api_extension.go
@@ -35,7 +35,7 @@ func NewMockAPIExtension(t TB, targetAPI string) *MockAPIExtension {
 
 	// Setup default expectations
 	mockAPIExtension.MockAPIExtension.EXPECT().TargetAPI().Return(targetAPI).Maybe()
-	mockAPIExtension.MockAPIExtension.EXPECT().Configure(new(router.Router), new(core.AccessService)).Return(nil).Maybe()
+	mockAPIExtension.MockAPIExtension.EXPECT().Configure(mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	return mockAPIExtension
 }

--- a/core/testing/example_api/example_test.go
+++ b/core/testing/example_api/example_test.go
@@ -25,7 +25,7 @@ func TestAPIEndpoints(t *testing.T) {
 	// The API registration option is passed as a variadic option after the test function.
 	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		// The API is now registered and configured within this test context
-		// because NewAPIRegistrationOption was passed as an option to RunTestCaseWithDB.
+		// because WithAPI was passed as an option to RunTestCase.
 
 		t.Run("public hello endpoint", func(t *testing.T) {
 			//t.Parallel() // Subtests can run in parallel
@@ -73,12 +73,13 @@ func TestAPIEndpoints(t *testing.T) {
 		})
 	},
 		// Pass the API registration option here as a variadic argument
-		coreTesting.NewAPIRegistrationOption("test", NewTestAPI),
+		coreTesting.WithAPI("test", NewTestAPI),
 	)
 }
 
 // TestAPI implements a simple API for testing
 type TestAPI struct {
+	*core.BaseComponent
 	ctx    core.Context
 	logger *core.Logger
 }
@@ -98,6 +99,7 @@ func NewTestAPI() (core.API, []core.ContextBuilderOption, error) {
 }
 
 func (a *TestAPI) Name() string          { return "test" }
+func (a *TestAPI) ID() string            { return "test" }
 func (a *TestAPI) Subdomain() string     { return "" }
 func (a *TestAPI) AuthTokenName() string { return "test-token" }
 
@@ -108,7 +110,7 @@ func (a *TestAPI) OpenAPIInfo() router.APIInfoDefinition {
 		Version("1.0.0")
 }
 
-func (a *TestAPI) Config() config.APIConfig {
+func (a *TestAPI) GetConfig() config.APIConfig {
 	return &TestAPIConfig{}
 }
 
@@ -139,7 +141,7 @@ func (a *TestAPI) Configure(r router.Router, access core.AccessService) error {
 			),
 			router.WithMiddlewares(middleware.AuthMiddleware(
 				a.ctx,
-				jwt.PurposeLogin,
+				middleware.WithAuthPurpose(jwt.PurposeLogin),
 			)),
 		),
 	)

--- a/core/testing/example_service/example_service_test.go
+++ b/core/testing/example_service/example_service_test.go
@@ -3,7 +3,6 @@ package example_service_test
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,209 +14,138 @@ import (
 	"gorm.io/gorm"
 )
 
-// TestMain is the entry point for running tests in this package.
-// It sets up and tears down the test environment, including the database.
-func TestMain(m *testing.M) {
-	// Run tests with an in-memory SQLite database enabled by default.
-	// Migrations are also enabled by default.
-	// We also register the real UserService here so all tests use it.
-	os.Exit(coreTesting.WithDBAndOptions(m,
-		WithRealUserService(),
-	))
-}
-
-// WithRealUserService configures the test context to use the real UserService implementation
-func WithRealUserService() coreTesting.TestContextBuilderOption {
-	return func(ctx coreTesting.TestContext) (coreTesting.TestContext, error) {
-		// Create and register the real service
-		userSvc, opts, err := service.NewUserService()
-		if err != nil {
-			return ctx, err
-		}
-
-		// Apply any context options from the service
-		ctx, err = coreTesting.ProcessCtxOptions(ctx, coreTesting.WrapCoreOptions(opts)...)
-		if err != nil {
-			return ctx, err
-		}
-
-		// Register the real service
-		ctx.RegisterService(core.USER_SERVICE, userSvc)
-		return ctx, nil
-	}
-}
-
-// TestUserService demonstrates a complete service test with database integration
-func TestUserService(t *testing.T) {
-	t.Parallel()
-
-	// SetupTest retrieves the TestContext configured by TestMain.
-	// It also registers cleanup for this specific test.
-	ctx := coreTesting.SetupTest(t)
-
-	// Boot the environment after the context is set up.
-	// This applies the global options (like WithRealUserService) and runs startup funcs.
-	err := coreTesting.BootEnvironment(t, ctx)
-	require.NoError(t, err, "Failed to boot test environment")
-
-	// Get the real database instance
-	db := ctx.DB()
-
-	// Get the real user service
-	userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
-	require.NotNil(t, userSvc, "User service not found in context after booting environment")
-
-	t.Run("create and get user", func(t *testing.T) {
-		//	t.Parallel()
+// TestUserService_CreateAndGet tests creating and retrieving a user
+func TestUserService_CreateAndGet(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userSvc)
 
 		email := "test@example.com"
 		password := "password123"
 
-		// Test create user account using the real service
 		createdUser, err := userSvc.CreateAccount(context.Background(), email, password, false)
 		require.NoError(t, err)
 		assert.Equal(t, email, createdUser.Email)
 		assert.NotZero(t, createdUser.ID)
 
-		// Verify user exists in the database
 		var userInDB models.User
-		result := db.Where("email = ?", email).First(&userInDB)
+		result := ctx.DB().Where("email = ?", email).First(&userInDB)
 		require.NoError(t, result.Error)
 		assert.Equal(t, createdUser.ID, userInDB.ID)
-		assert.Equal(t, createdUser.Email, userInDB.Email)
 
-		// Test check if email exists using the real service
 		exists, foundUser, err := userSvc.EmailExists(context.Background(), email)
 		require.NoError(t, err)
 		assert.True(t, exists)
 		assert.Equal(t, createdUser.ID, foundUser.ID)
-		assert.Equal(t, createdUser.Email, foundUser.Email)
-	})
+	},
+		coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService),
+	)
+}
 
-	t.Run("user not found", func(t *testing.T) {
-		//	t.Parallel()
+// TestUserService_NotFound tests email exists for non-existent user
+func TestUserService_NotFound(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userSvc)
 
-		// Test check if non-existent email exists using the real service
 		exists, _, err := userSvc.EmailExists(context.Background(), "nonexistent@example.com")
-		assert.NoError(t, err) // EmailExists should return false, nil, nil for not found
+		assert.NoError(t, err)
 		assert.False(t, exists)
-	})
+	},
+		coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService),
+	)
+}
 
-	t.Run("update user", func(t *testing.T) {
-		//	t.Parallel()
+// TestUserService_Update tests updating a user
+func TestUserService_Update(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userSvc)
 
-		// Create test user first using the real service
 		testUser, err := userSvc.CreateAccount(context.Background(), "update@example.com", "password123", false)
 		require.NoError(t, err)
 
-		// Test update account info using the real service
 		updatedEmail := "updated@example.com"
 		err = userSvc.UpdateAccountInfo(context.Background(), testUser.ID, map[string]any{
 			"email": updatedEmail,
 		})
 		require.NoError(t, err)
 
-		// Verify update in the database
 		var updatedUser models.User
-		require.NoError(t, db.First(&updatedUser, testUser.ID).Error)
+		require.NoError(t, ctx.DB().First(&updatedUser, testUser.ID).Error)
 		assert.Equal(t, updatedEmail, updatedUser.Email)
-	})
+	},
+		coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService),
+	)
+}
 
-	t.Run("delete user", func(t *testing.T) {
-		//	t.Parallel()
+// TestUserService_Delete tests deleting a user
+func TestUserService_Delete(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userSvc)
 
-		// Create test user first using the real service
 		testUser, err := userSvc.CreateAccount(context.Background(), "delete@example.com", "password123", false)
 		require.NoError(t, err)
 
-		// Test delete account using the real service
 		err = userSvc.DeleteAccount(context.Background(), testUser.ID)
 		require.NoError(t, err)
 
-		// Verify deletion in the database
 		var deletedUser models.User
-		err = db.First(&deletedUser, testUser.ID).Error
+		err = ctx.DB().First(&deletedUser, testUser.ID).Error
 		assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
-	})
+	},
+		coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService),
+	)
+}
 
-	t.Run("list users", func(t *testing.T) {
-		//	t.Parallel()
+// TestUserService_List tests listing users pending deletion
+func TestUserService_List(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userSvc)
 
-		// Create test data using the real service
 		usersToCreate := []string{"list1@example.com", "list2@example.com", "list3@example.com"}
 		for _, email := range usersToCreate {
 			_, err := userSvc.CreateAccount(context.Background(), email, "password123", false)
 			require.NoError(t, err)
 		}
 
-		// Test get accounts pending deletion (using a real method from the interface)
-		// This method is not implemented in the mock, but should work with the real service
-		// if it queries the database correctly.
 		pendingUsers, err := userSvc.GetAccountsPendingDeletion(context.Background())
 		require.NoError(t, err)
-		// Since we just created test users, none should be pending deletion
 		assert.Len(t, pendingUsers, 0)
-
-		// Note: Testing pagination/listing requires calling the actual List method
-		// on the real service, which is not part of the current UserService interface
-		// summary provided. If a List method exists on the real service, you would
-		// call it here and assert on the results from the database.
-		// Example (assuming a List method exists):
-		// listedUsers, err := userSvc.List(context.Background(), 2, 1) // limit 2, offset 1
-		// require.NoError(t, err)
-		// assert.Len(t, listedUsers, 2)
-		// assert.Equal(t, "list2@example.com", listedUsers[0].Email) // Assuming default order by creation
-	})
+	},
+		coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService),
+	)
 }
 
-// BenchmarkUserService demonstrates benchmarking the real UserService with database operations
+// BenchmarkUserService benchmarks the real UserService with database operations
 func BenchmarkUserService(b *testing.B) {
-	// SetupTestWithDB creates a test context with DB support.
-	// Since TestMain already configured the environment with the real service,
-	// this will use the real service and the in-memory DB.
-	ctx := coreTesting.SetupTestWithDB(b)
-	defer ctx.Teardown() // Ensure cleanup after benchmark
+	// For benchmarks, we use SetupTestWithDB directly since RunTestCaseWithDB
+	// expects a function with TB interface which doesn't have benchmark methods
+	ctx, err := coreTesting.SetupTestWithDB(b)
+	require.NoError(b, err)
 
-	// Boot the environment after the context is set up.
-	// This applies the global options (like WithRealUserService) and runs startup funcs.
-	err := coreTesting.BootEnvironment(b, ctx)
-	require.NoError(b, err, "Failed to boot test environment")
+	realUserSvc, opts, err := service.NewUserService()
+	require.NoError(b, err)
 
-	// Get the real user service
+	ctx, err = coreTesting.ProcessCtxOptions(ctx, coreTesting.WrapCoreOptions(opts)...)
+	require.NoError(b, err)
+
+	err = coreTesting.BootEnvironment(b, ctx)
+	require.NoError(b, err)
+
 	userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
-	require.NotNil(b, userSvc, "User service not found in context after booting environment")
+	require.NotNil(b, userSvc)
+	_ = realUserSvc // unused but kept for clarity
 
-	// Reset the timer before the loop to exclude setup time
 	b.ResetTimer()
 
-	b.Run("create user", func(b *testing.B) {
-		// SetupTestWithDB provides a clean DB for each benchmark run (due to t.Cleanup).
-		// No need to manually delete users.
-		for i := 0; i < b.N; i++ {
-			email := fmt.Sprintf("user%d@example.com", i)
-			_, err := userSvc.CreateAccount(context.Background(), email, "password123", false)
-			if err != nil {
-				b.Fatalf("Failed to create user: %v", err)
-			}
-		}
-	})
-
-	b.Run("check email exists", func(b *testing.B) {
-		// SetupTestWithDB provides a clean DB for each benchmark run.
-		// Create test data within the benchmark setup.
-		email := "benchmark@example.com"
+	for i := 0; i < b.N; i++ {
+		email := fmt.Sprintf("user%d@example.com", i)
 		_, err := userSvc.CreateAccount(context.Background(), email, "password123", false)
 		if err != nil {
-			b.Fatalf("Failed to create test user: %v", err)
+			b.Fatalf("Failed to create user: %v", err)
 		}
-
-		b.ResetTimer() // Reset timer after setup
-
-		for i := 0; i < b.N; i++ {
-			_, _, err := userSvc.EmailExists(context.Background(), email)
-			if err != nil {
-				b.Fatalf("Failed to check email: %v", err)
-			}
-		}
-	})
+	}
 }

--- a/core/testing/example_service/example_service_test.go
+++ b/core/testing/example_service/example_service_test.go
@@ -14,6 +14,8 @@ import (
 	"gorm.io/gorm"
 )
 
+const testPassword = "password123"
+
 // TestUserService_CreateAndGet tests creating and retrieving a user
 func TestUserService_CreateAndGet(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
@@ -21,9 +23,8 @@ func TestUserService_CreateAndGet(t *testing.T) {
 		require.NotNil(tb, userSvc)
 
 		email := "test@example.com"
-		password := "password123"
 
-		createdUser, err := userSvc.CreateAccount(context.Background(), email, password, false)
+		createdUser, err := userSvc.CreateAccount(context.Background(), email, testPassword, false)
 		require.NoError(t, err)
 		assert.Equal(t, email, createdUser.Email)
 		assert.NotZero(t, createdUser.ID)
@@ -62,7 +63,7 @@ func TestUserService_Update(t *testing.T) {
 		userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
 		require.NotNil(tb, userSvc)
 
-		testUser, err := userSvc.CreateAccount(context.Background(), "update@example.com", "password123", false)
+		testUser, err := userSvc.CreateAccount(context.Background(), "update@example.com", testPassword, false)
 		require.NoError(t, err)
 
 		updatedEmail := "updated@example.com"
@@ -85,7 +86,7 @@ func TestUserService_Delete(t *testing.T) {
 		userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
 		require.NotNil(tb, userSvc)
 
-		testUser, err := userSvc.CreateAccount(context.Background(), "delete@example.com", "password123", false)
+		testUser, err := userSvc.CreateAccount(context.Background(), "delete@example.com", testPassword, false)
 		require.NoError(t, err)
 
 		err = userSvc.DeleteAccount(context.Background(), testUser.ID)
@@ -107,7 +108,7 @@ func TestUserService_List(t *testing.T) {
 
 		usersToCreate := []string{"list1@example.com", "list2@example.com", "list3@example.com"}
 		for _, email := range usersToCreate {
-			_, err := userSvc.CreateAccount(context.Background(), email, "password123", false)
+			_, err := userSvc.CreateAccount(context.Background(), email, testPassword, false)
 			require.NoError(t, err)
 		}
 
@@ -132,12 +133,13 @@ func BenchmarkUserService(b *testing.B) {
 	ctx, err = coreTesting.ProcessCtxOptions(ctx, coreTesting.WrapCoreOptions(opts)...)
 	require.NoError(b, err)
 
+	ctx.RegisterService(core.USER_SERVICE, realUserSvc)
+
 	err = coreTesting.BootEnvironment(b, ctx)
 	require.NoError(b, err)
 
 	userSvc := core.GetService[core.UserService](ctx, core.USER_SERVICE)
 	require.NotNil(b, userSvc)
-	_ = realUserSvc // unused but kept for clarity
 
 	b.ResetTimer()
 

--- a/core/testing/mock_access.go
+++ b/core/testing/mock_access.go
@@ -27,15 +27,15 @@ func NewMockAccessService(t TB) *MockAccessService {
 	}
 
 	// Set up default expectations
-	mockAccess.On("RegisterRoute", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+	mockAccess.EXPECT().RegisterRoute(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Maybe().
 		Return(nil)
 
-	mockAccess.On("AssignRoleToUser", mock.AnythingOfType("uint"), mock.AnythingOfType("string")).
+	mockAccess.EXPECT().AssignRoleToUser(mock.Anything, mock.Anything, mock.Anything).
 		Maybe().
 		Return(nil)
 
-	mockAccess.On("CheckAccess", mock.AnythingOfType("uint"), mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+	mockAccess.EXPECT().CheckAccess(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Maybe().
 		Return(true, nil)
 
@@ -46,7 +46,7 @@ func NewMockAccessService(t TB) *MockAccessService {
 func (m *MockAccessService) CheckAccess(ctx context.Context, userId uint, fqdn, path, method string) (bool, error) {
 	// Set up expectation if not already set
 	if !WasMethodCalled(&m.MockAccessService.Mock, "CheckAccess", userId, fqdn, path, method) {
-		m.On("CheckAccess", userId, fqdn, path, method).Return(true, nil)
+		m.EXPECT().CheckAccess(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 	}
 
 	return m.MockAccessService.CheckAccess(nil, userId, fqdn, path, method)
@@ -56,7 +56,7 @@ func (m *MockAccessService) CheckAccess(ctx context.Context, userId uint, fqdn, 
 func (m *MockAccessService) AssignRoleToUser(ctx context.Context, userId uint, role string) error {
 	// Set up expectation if not already set
 	if !WasMethodCalled(&m.MockAccessService.Mock, "AssignRoleToUser", userId, role) {
-		m.On("AssignRoleToUser", userId, role).Return(nil)
+		m.EXPECT().AssignRoleToUser(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	}
 
 	return m.MockAccessService.AssignRoleToUser(nil, userId, role)

--- a/core/testing/mock_access.go
+++ b/core/testing/mock_access.go
@@ -26,40 +26,30 @@ func NewMockAccessService(t TB) *MockAccessService {
 		MockAccessService: mockAccess,
 	}
 
-	// Set up default expectations
+	// Set up default expectations using EXPECT() with Maybe() for optional calls
 	mockAccess.EXPECT().RegisterRoute(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Maybe().
-		Return(nil)
+		Return(nil).
+		Maybe()
 
 	mockAccess.EXPECT().AssignRoleToUser(mock.Anything, mock.Anything, mock.Anything).
-		Maybe().
-		Return(nil)
+		Return(nil).
+		Maybe()
 
 	mockAccess.EXPECT().CheckAccess(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Maybe().
-		Return(true, nil)
+		Return(true, nil).
+		Maybe()
 
 	return access
 }
 
 // CheckAccess implements core.AccessService with automatic mock setup
 func (m *MockAccessService) CheckAccess(ctx context.Context, userId uint, fqdn, path, method string) (bool, error) {
-	// Set up expectation if not already set
-	if !WasMethodCalled(&m.MockAccessService.Mock, "CheckAccess", userId, fqdn, path, method) {
-		m.EXPECT().CheckAccess(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
-	}
-
-	return m.MockAccessService.CheckAccess(nil, userId, fqdn, path, method)
+	return m.MockAccessService.CheckAccess(ctx, userId, fqdn, path, method)
 }
 
 // AssignRoleToUser implements core.AccessService with automatic mock setup
 func (m *MockAccessService) AssignRoleToUser(ctx context.Context, userId uint, role string) error {
-	// Set up expectation if not already set
-	if !WasMethodCalled(&m.MockAccessService.Mock, "AssignRoleToUser", userId, role) {
-		m.EXPECT().AssignRoleToUser(mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	}
-
-	return m.MockAccessService.AssignRoleToUser(nil, userId, role)
+	return m.MockAccessService.AssignRoleToUser(ctx, userId, role)
 }
 
 // Config implements core.Component

--- a/core/testing/mock_http.go
+++ b/core/testing/mock_http.go
@@ -29,25 +29,25 @@ func NewMockHTTPService(t TB) *MockHTTPService {
 	}
 
 	// Set up default expectations
-	mockHTTPService.On("Router").
+	mockHTTPService.EXPECT().Router().
 		Maybe().
 		Return(func() router.Router {
 			return httpService.router
 		})
 
-	mockHTTPService.On("Serve").
+	mockHTTPService.EXPECT().Serve().
 		Maybe().
 		Return(nil)
 
-	mockHTTPService.On("Init").
+	mockHTTPService.EXPECT().Init().
 		Maybe().
 		Return(nil)
 
-	mockHTTPService.On("RegisterGlobalPath", mock.AnythingOfType("string")).
+	mockHTTPService.EXPECT().RegisterGlobalPath(mock.AnythingOfType("string")).
 		Maybe().
 		Return(nil)
 
-	mockHTTPService.On("APISubdomain", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).
+	mockHTTPService.EXPECT().APISubdomain(mock.AnythingOfType("string"), mock.AnythingOfType("bool")).
 		Maybe().
 		Return(httpService.apiSubdomainFunc("", false))
 
@@ -58,7 +58,7 @@ func NewMockHTTPService(t TB) *MockHTTPService {
 func (m *MockHTTPService) APISubdomain(id string, proto bool) string {
 	// Set up expectation if not already set
 	if !WasMethodCalled(&m.MockHTTPService.Mock, "APISubdomain", id, proto) {
-		m.On("APISubdomain", id, proto).Return(m.apiSubdomainFunc(id, proto))
+		m.EXPECT().APISubdomain(id, proto).Return("")
 	}
 
 	return m.MockHTTPService.APISubdomain(id, proto)
@@ -78,7 +78,7 @@ func (m *MockHTTPService) apiSubdomainFunc(id string, proto bool) func(string, b
 func (m *MockHTTPService) Serve() error {
 	// Set up expectation if not already set
 	if !WasMethodCalled(&m.MockHTTPService.Mock, "Serve") {
-		m.On("Serve").Return(nil)
+		m.EXPECT().Serve().Return(nil)
 	}
 
 	return m.MockHTTPService.Serve()
@@ -88,7 +88,7 @@ func (m *MockHTTPService) Serve() error {
 func (m *MockHTTPService) Init() error {
 	// Set up expectation if not already set
 	if !WasMethodCalled(&m.MockHTTPService.Mock, "Init") {
-		m.On("Init").Return(nil)
+		m.EXPECT().Init().Return(nil)
 	}
 
 	return m.MockHTTPService.Init()
@@ -98,7 +98,7 @@ func (m *MockHTTPService) Init() error {
 func (m *MockHTTPService) RegisterGlobalPath(path string) error {
 	// Set up expectation if not already set
 	if !WasMethodCalled(&m.MockHTTPService.Mock, "RegisterGlobalPath", path) {
-		m.On("RegisterGlobalPath", path).Return(nil)
+		m.EXPECT().RegisterGlobalPath(path).Return(nil)
 	}
 
 	return m.MockHTTPService.RegisterGlobalPath(path)

--- a/core/testing/operation.go
+++ b/core/testing/operation.go
@@ -90,9 +90,9 @@ func NewMockOperation(t TB) *MockOperation {
 	}
 
 	// Set up default expectations (optional, but good practice)
-	mockOp.On("Type").Return("").Maybe()
-	mockOp.On("GlobalType").Return(core.OperationType("")).Maybe()
-	mockOp.On("Handler").Return(NewMockOperationHandler(t)).Maybe()
+	mockOp.EXPECT().Type().Return("").Maybe()
+	mockOp.EXPECT().GlobalType().Return(core.OperationType("")).Maybe()
+	mockOp.EXPECT().Handler().Return(NewMockOperationHandler(t)).Maybe()
 
 	return op
 }
@@ -105,10 +105,10 @@ func NewMockOperationHandler(t TB) *MockOperationHandler {
 	}
 
 	// Set up default expectations (optional, but good practice)
-	mockHandler.On("ValidateRequest", mock.Anything, mock.Anything).Return(nil).Maybe()
-	mockHandler.On("Execute", mock.Anything, mock.Anything).Return(nil).Maybe()
-	mockHandler.On("GetStatus", mock.Anything, mock.Anything).Return(&core.RequestStatus{}, nil).Maybe()
-	mockHandler.On("Cleanup", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockHandler.EXPECT().ValidateRequest(mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockHandler.EXPECT().Execute(mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockHandler.EXPECT().GetStatus(mock.Anything, mock.Anything).Return(&core.RequestStatus{}, nil).Maybe()
+	mockHandler.EXPECT().Cleanup(mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	return handler
 }

--- a/core/testing/service.go
+++ b/core/testing/service.go
@@ -114,6 +114,15 @@ func WithServiceFactory(id string, factory core.ServiceFactory) TestContextBuild
 			return nil, fmt.Errorf("failed to create service '%s': %w", id, err)
 		}
 
+		// Ensure the service instance is a pointer so it can be modified by the wiring function.
+		// If the factory returns a value type, we need to take its address so wiring works.
+		servicePtr := reflect.ValueOf(serviceInstance)
+		if servicePtr.Kind() != reflect.Ptr {
+			servicePtr = reflect.New(servicePtr.Type())
+			servicePtr.Elem().Set(reflect.ValueOf(serviceInstance))
+			serviceInstance = servicePtr.Interface().(core.Service)
+		}
+
 		// Wire up the service's BaseComponent with context, logger, DB, and config
 		startupOpt := core.ContextWithStartupComponent(serviceInstance)
 

--- a/core/testing/service.go
+++ b/core/testing/service.go
@@ -114,8 +114,11 @@ func WithServiceFactory(id string, factory core.ServiceFactory) TestContextBuild
 			return nil, fmt.Errorf("failed to create service '%s': %w", id, err)
 		}
 
-		// Register a startup function that will create and register the service later
-		startupOpt := core.ContextWithStartupFunc(func(coreCtx core.Context) error {
+		// Wire up the service's BaseComponent with context, logger, DB, and config
+		startupOpt := core.ContextWithStartupComponent(serviceInstance)
+
+		// Register a startup function that will register the service in the context
+		registerOpt := core.ContextWithStartupFunc(func(coreCtx core.Context) error {
 			tctx, ok := coreCtx.(TestContext)
 			if !ok {
 				return fmt.Errorf("context is not a TestContext, cannot use WithServiceFactory")
@@ -133,12 +136,18 @@ func WithServiceFactory(id string, factory core.ServiceFactory) TestContextBuild
 			return nil
 		})
 
-		options, err := ProcessCtxOptions(ctx, WrapCoreOptions(ctxOpts)...)
+		// Apply wiring first, then registration, then other options
+		options, err := ProcessCtxOptions(ctx, WrapCoreOption(startupOpt))
 		if err != nil {
 			return nil, err
 		}
 
-		options, err = ProcessCtxOptions(options, WrapCoreOption(startupOpt))
+		options, err = ProcessCtxOptions(options, WrapCoreOption(registerOpt))
+		if err != nil {
+			return nil, err
+		}
+
+		options, err = ProcessCtxOptions(options, WrapCoreOptions(ctxOpts)...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Update all mock helpers to use EXPECT() instead of On() for explicit expectations
- Refactor WithServiceFactory to use ContextWithStartupComponent for proper wiring
- Add BaseComponent and ID() to TestAPI example
- Rename Config() to GetConfig() in test API
- Simplify example_service tests with RunTestCaseWithDB and WithServiceFactory

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR modernizes the testing framework by migrating from the older `.On()` mock pattern to the newer `.EXPECT()` pattern across all mock helpers, making expectations more explicit and consistent with modern testify/mock practices.

**Key Changes:**
- Migrated all mock helpers (`MockAPI`, `MockAccessService`, `MockHTTPService`, `MockOperation`, `MockAPIExtension`) from `.On()` to `.EXPECT()` for setting up expectations
- Refactored `WithServiceFactory` to use `ContextWithStartupComponent` for proper component wiring, ensuring services have their `BaseComponent` fields initialized with context, logger, DB, and config before registration
- Added `BaseComponent` embedding and `ID()` method to the `TestAPI` example to demonstrate proper API component structure
- Renamed `Config()` to `GetConfig()` in test API to match interface requirements
- Simplified `example_service_test.go` by removing `TestMain` and using `RunTestCaseWithDB` + `WithServiceFactory` for each test, providing better test isolation

**Issues Found:**
- The benchmark function in `example_service_test.go` has a logic bug where the service is created but not properly registered, likely causing the benchmark to fail or test the wrong implementation

<h3>Confidence Score: 4/5</h3>


- safe to merge with one logic bug fix needed in the benchmark function
- the `.On()` to `.EXPECT()` migration is syntactically correct across all files, and the `WithServiceFactory` refactor properly orders component wiring before registration - however, the benchmark function has a clear bug where the service isn't registered, dropping the score from 5 to 4
- `core/testing/example_service/example_service_test.go` - fix the benchmark service registration bug on line 129

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/testing/example_api/example_test.go | added `BaseComponent`, `ID()`, renamed `Config()` to `GetConfig()`, updated middleware call - minor API update with proper implementation |
| core/testing/example_service/example_service_test.go | major refactor removing `TestMain` in favor of `RunTestCaseWithDB` per test - simplified but benchmark service registration may not work correctly |
| core/testing/service.go | improved `WithServiceFactory` to use `ContextWithStartupComponent` for proper wiring - correctly orders startup, registration, and context options |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Function
    participant Factory as WithServiceFactory
    participant Startup as ContextWithStartupComponent
    participant Register as Registration Startup Func
    participant Service as Service Instance
    participant Context as Test Context

    Test->>Factory: WithServiceFactory(id, factory)
    Factory->>Service: factory() - create service
    Service-->>Factory: service instance + options
    Factory->>Startup: ContextWithStartupComponent(service)
    Note over Startup: Wires BaseComponent<br/>(DB, Config, Logger, Context)
    Factory->>Register: ContextWithStartupFunc
    Note over Register: Registers service in context
    Factory->>Context: ProcessCtxOptions(wiring → registration → other opts)
    Note over Context: Ensures proper ordering:<br/>1. Wire component<br/>2. Register service<br/>3. Apply other options
    Test->>Context: BootEnvironment()
    Context->>Startup: Execute startup funcs
    Startup->>Service: SetDB(), SetConfig(), SetLogger()
    Context->>Register: Execute registration
    Register->>Context: RegisterService(id, instance)
    Test->>Context: GetService(id)
    Context-->>Test: Service instance ready
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

<!-- kody-pr-summary:start -->
This pull request introduces significant refactoring to the testing utilities, focusing on improving mock patterns and streamlining the setup of services and APIs within tests.

Key changes include:

*   **Migration to `EXPECT()` Mock Pattern**: All mock definitions using `testify/mock` have been updated from the older `.On()` method to the more explicit and recommended `.EXPECT()` method. This enhances the clarity and strictness of mock expectations across `MockAPI`, `MockAPIExtension`, `MockAccessService`, `MockHTTPService`, and `MockOperation` implementations.
*   **Enhanced Service Testing Utilities**:
    *   The `example_service_test.go` has been refactored to use `coreTesting.RunTestCaseWithDB` and `coreTesting.WithServiceFactory`, significantly simplifying the setup and teardown of services with database integration. This removes the need for a `TestMain` function and explicit `SetupTest`/`BootEnvironment` calls, making service tests more concise and easier to write.
    *   The `WithServiceFactory` utility now properly wires up `core.BaseComponent` instances using `core.ContextWithStartupComponent` and adjusts the order of context option processing to ensure correct service initialization.
*   **Improved API Testing and Definition**:
    *   The `NewAPIRegistrationOption` has been renamed to `WithAPI` for better readability and consistency in test case options.
    *   The `TestAPI` example now embeds `*core.BaseComponent`, implements an `ID()` method, and renames `Config()` to `GetConfig()`, aligning with updated API interface requirements and best practices.
    *   Middleware configuration in API tests now uses `middleware.WithAuthPurpose` for a more structured approach to setting authentication purposes.
*   **More Generic Mock Arguments**: Default mock expectations for `MockAccessService` now utilize `mock.Anything` instead of `mock.AnythingOfType` for arguments, providing greater flexibility in matching calls.
<!-- kody-pr-summary:end -->