### PR TITLE
fix(testing): add testify mock import to API extension test helper

### DIFF
--- a/core/testing/api_extension.go
+++ b/core/testing/api_extension.go
@@ -1,6 +1,7 @@
 package testing
 
 import (
+	"github.com/stretchr/testify/mock"
 	router "go.lumeweb.com/portal-router"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/core/testing/mocks"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fixes a testing issue by adding the `github.com/stretchr/testify/mock` import to the `core/testing/api_extension.go` file. This ensures that the `testify/mock` package is available for use within the API extension test helper.
<!-- kody-pr-summary:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added missing import for `github.com/stretchr/testify/mock` package to resolve compilation error in the API extension test helper.

- The `NewMockAPIExtension` function uses `mock.Anything` on line 39 when setting up default expectations for the `Configure` method
- This import was missing after the recent refactoring from `.On()` to `.EXPECT()` mock pattern (commit c620874)
- The fix enables proper compilation of the test utilities

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- Single-line import addition that fixes a compilation error - no logic changes, no security implications, and follows standard Go import practices
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/testing/api_extension.go | Added missing testify mock import for mock.Anything usage on line 39 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Code
    participant Helper as NewMockAPIExtension
    participant MockExt as MockAPIExtension
    participant Testify as testify/mock

    Test->>Helper: NewMockAPIExtension(t, "api-name")
    Helper->>MockExt: Create wrapper instance
    Helper->>Testify: EXPECT().TargetAPI().Return("api-name").Maybe()
    Helper->>Testify: EXPECT().Configure(mock.Anything, mock.Anything).Return(nil).Maybe()
    Note over Helper,Testify: mock.Anything now properly imported
    Helper-->>Test: Return configured mock
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->