### PR TITLE
fix(testing): fix missing dot separator in ApplyConfig full key generation

### DIFF
--- a/core/testing/config.go
+++ b/core/testing/config.go
@@ -273,7 +273,10 @@ func ApplyConfig(ctx TestContext, prefix string, cfg config.Defaults) error {
 	})
 
 	for key, value := range flatConfig {
-		fullKey := strings.TrimSuffix(prefix, configKeySeparator) + configKeySeparator + key
+		fullKey := key
+		if prefix != "" {
+			fullKey = strings.TrimSuffix(prefix, configKeySeparator) + configKeySeparator + key
+		}
 		if err := setConfigValue(ctx, fullKey, value); err != nil {
 			return err
 		}

--- a/core/testing/config.go
+++ b/core/testing/config.go
@@ -17,6 +17,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// configKeySeparator is the separator used between config key parts
+	configKeySeparator = "."
+)
+
 // ConfigBuilder is a generic builder for any config type that implements
 // the Defaults pattern (map[string]any)
 type ConfigBuilder struct {
@@ -268,7 +273,7 @@ func ApplyConfig(ctx TestContext, prefix string, cfg config.Defaults) error {
 	})
 
 	for key, value := range flatConfig {
-		fullKey := prefix + key
+		fullKey := strings.TrimSuffix(prefix, configKeySeparator) + configKeySeparator + key
 		if err := setConfigValue(ctx, fullKey, value); err != nil {
 			return err
 		}


### PR DESCRIPTION
- Add `configKeySeparator` constant for config key parts
- Use `strings.TrimSuffix` to defensively trim trailing dots from prefix
- Ensures full keys like `plugin.template-plugin.protocol.storage_path` are generated correctly instead of `plugin.template-plugin.protocolstorage_path`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a critical bug in the `ApplyConfig` function where configuration keys were being generated incorrectly. The issue occurred because the function was concatenating prefix strings directly with keys without a separator, resulting in malformed keys like `plugin.template-plugin.protocolstorage_path` instead of `plugin.template-plugin.protocol.storage_path`.

The fix introduces two changes:
- Adds a `configKeySeparator` constant (`.`) for consistent key part separation
- Uses `strings.TrimSuffix` to defensively remove any trailing dots from the prefix before adding the separator

This ensures correct key generation across all config types (API, Protocol, and Service configurations). The change is backward compatible since the specifiers in `config/constants.go` don't include trailing dots.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is straightforward, addresses a clear bug in key generation, and uses defensive programming with TrimSuffix. The added import is necessary for test helpers. No logic errors or security concerns identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/testing/api_extension.go | Added missing testify mock import for EXPECT() pattern support |
| core/testing/config.go | Fixed config key generation by adding dot separator constant and TrimSuffix logic |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Test Code
    participant Helper as Config Helper<br/>(WithAPIConfig/WithProtocolConfig)
    participant Apply as ApplyConfig
    participant Config as Config Manager
    
    Caller->>Helper: WithProtocolConfig("template-plugin", cfg)
    Helper->>Helper: Generate prefix<br/>fmt.Sprintf("plugin.%s.protocol", "template-plugin")
    Note over Helper: Prefix = "plugin.template-plugin.protocol"
    Helper->>Apply: ApplyConfig(ctx, prefix, cfg)
    Apply->>Apply: Flatten config to keys<br/>e.g., "storage_path"
    Apply->>Apply: TrimSuffix(prefix, ".")<br/>Then add "." + key
    Note over Apply: OLD BUG: "plugin.template-plugin.protocol" + "storage_path"<br/>= "plugin.template-plugin.protocolstorage_path" ❌<br/><br/>NEW FIX: "plugin.template-plugin.protocol" + "." + "storage_path"<br/>= "plugin.template-plugin.protocol.storage_path" ✅
    Apply->>Config: Set(ctx, "plugin.template-plugin.protocol.storage_path", value)
    Config-->>Apply: Success
    Apply-->>Helper: Success
    Helper-->>Caller: Success
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

<!-- kody-pr-summary:start -->
Fixes an issue in the testing framework where the full configuration key generated by the `ApplyConfig` function could be missing a dot separator between the prefix and the key.

The change introduces a `configKeySeparator` constant and modifies the key generation logic to explicitly ensure a single dot separator is always present. This prevents both missing and duplicate separators, ensuring configuration values are applied correctly during tests.
<!-- kody-pr-summary:end -->