### PR TITLE
fix(testing): change GetMockWorkflowService to return high-level wrapper type

### DIFF
--- a/core/testing/service.go
+++ b/core/testing/service.go
@@ -438,8 +438,8 @@ func GetMockUserService(ctx core.Context) *MockUserService {
 
 // GetMockWorkflowService returns the mock workflow service from the context for testing
 // Panics if the workflow service is not a mock
-func GetMockWorkflowService(ctx core.Context) *mocks.MockWorkflowService {
-	return getMock[mocks.MockWorkflowService](ctx, core.WORKFLOW_SERVICE)
+func GetMockWorkflowService(ctx core.Context) *MockWorkflowService {
+	return getMock[MockWorkflowService](ctx, core.WORKFLOW_SERVICE)
 }
 
 // registerServiceInstance registers a service instance both locally in the test context


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactored the `GetMockWorkflowService` function in the testing utilities to return a `*MockWorkflowService` type instead of `*mocks.MockWorkflowService`. This change ensures that tests retrieve a high-level wrapper type for the mock workflow service, standardizing its usage within the testing framework.
<!-- kody-pr-summary:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Changed `GetMockWorkflowService` to return the high-level `*MockWorkflowService` wrapper type instead of the low-level `*mocks.MockWorkflowService` type.

This change brings consistency with other similar getter functions in the testing package (`GetMockAccessService`, `GetMockAuthService`, `GetMockHTTPService`, `GetMockOTPService`, `GetMockStorageService`, `GetMockUserService`) which all return wrapper types from the `testing` package rather than the underlying mock types from `testing/mocks`.

The wrapper type provides high-level helper methods like `ExpectStartWorkflow`, `SetupSimpleWorkflow`, and `CreateTestRequest` that simplify workflow testing.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a simple, well-motivated type change that improves consistency across the testing utilities. The change aligns GetMockWorkflowService with the pattern used by all other similar getter functions. Since no existing code uses this function, there is zero risk of breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/testing/service.go | Changed GetMockWorkflowService return type from mocks.MockWorkflowService to MockWorkflowService wrapper for consistency with other mock service getters |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Code
    participant Getter as GetMockWorkflowService()
    participant Context as core.Context
    participant Wrapper as MockWorkflowService
    participant Mock as mocks.MockWorkflowService

    Test->>Getter: Call GetMockWorkflowService(ctx)
    Getter->>Context: ctx.Service(WORKFLOW_SERVICE)
    Context-->>Getter: service instance
    Getter->>Getter: Type assert to *MockWorkflowService
    Note over Getter: Changed from *mocks.MockWorkflowService<br/>to *MockWorkflowService
    Getter-->>Test: Return *MockWorkflowService
    
    Note over Test,Wrapper: Test can now use high-level helpers
    Test->>Wrapper: ExpectStartWorkflow(...)
    Wrapper->>Mock: EXPECT().StartWorkflow(...)
    Mock-->>Wrapper: Return mock call
    Wrapper-->>Test: Return configured expectation
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->