### PR TITLE
fix(testing): prepend ContextWithStartupComponent in RegisterService for proper wiring

### DIFF
--- a/core/testing/plugin.go
+++ b/core/testing/plugin.go
@@ -381,7 +381,12 @@ func RegisterService(ctx TestContext, id string, factory core.ServiceFactory, pl
 		return nil, fmt.Errorf("failed to register service: %w", err)
 	}
 
-	return WrapCoreOptions(opts), nil
+	// Prepend ContextWithStartupComponent to ensure proper wiring
+	startupOpts := WrapCoreOptions(core.ContextOptions(core.ContextWithStartupComponent(service)))
+	wrappedOpts := WrapCoreOptions(opts)
+	allOpts := append(startupOpts, wrappedOpts...)
+
+	return allOpts, nil
 }
 
 // configureService handles the configuration of a single service, including:


### PR DESCRIPTION
- Ensures services are properly wired with context, logger, DB, and config
- Prevents potential initialization issues in test contexts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes the `RegisterService` function to prepend `ContextWithStartupComponent` for proper service initialization in test contexts. Previously, services registered via `RegisterService` were missing the startup component wiring, which could lead to uninitialized `BaseComponent` fields and missing logger, DB, config, and context dependencies.

**Key changes:**
- Added `ContextWithStartupComponent(service)` to ensure services are properly wired during context startup
- Prepends startup options before factory-provided options to maintain correct initialization order
- Aligns `RegisterService` with the existing patterns used in `registerAPIInstance` (line 178) and `registerProtocolInstance` (line 299)

**Why this matters:**
Without this change, services might fail to initialize properly in tests because their `BaseComponent` field wouldn't be populated with essential dependencies (logger, DB, config, context) during the startup phase. This fix ensures consistency across all component types (Services, APIs, Protocols) in the testing framework.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it's a straightforward bug fix that aligns with established patterns
- The change is well-scoped, follows existing patterns in the codebase (identical to `registerAPIInstance` and `registerProtocolInstance`), and addresses a real initialization issue. The modification is minimal, adding only the necessary wiring logic without introducing new complexity or side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/testing/plugin.go | Added `ContextWithStartupComponent` for services to ensure proper wiring with context, logger, DB, and config - consistent with API and Protocol registration patterns |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Code
    participant RS as RegisterService
    participant Factory as ServiceFactory
    participant Core as core.RegisterService
    participant Wrap as WrapCoreOptions
    
    Test->>RS: RegisterService(ctx, id, factory, plugin)
    RS->>Factory: factory()
    Factory-->>RS: service, opts, err
    
    alt service is nil
        RS-->>Test: error: "service factory returned nil"
    end
    
    RS->>Core: registerServiceInstance(ctx, id, service, plugin)
    Core-->>RS: success/error
    
    Note over RS: NEW: Prepend ContextWithStartupComponent
    RS->>Wrap: WrapCoreOptions(ContextOptions(ContextWithStartupComponent(service)))
    Wrap-->>RS: startupOpts
    
    RS->>Wrap: WrapCoreOptions(opts)
    Wrap-->>RS: wrappedOpts
    
    RS->>RS: allOpts = append(startupOpts, wrappedOpts...)
    RS-->>Test: allOpts, nil
    
    Note over Test: Later during startup
    Test->>startupOpts: Process context options
    startupOpts->>service: Wire BaseComponent, DB, Config, Logger, Context
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

---

<!-- kody-pr-summary:start -->
Fixes an issue in the `RegisterService` function within the testing plugin by ensuring that `ContextWithStartupComponent` is prepended to the core options. This change guarantees proper wiring of services when they are registered in a testing context.
<!-- kody-pr-summary:end -->