### PR TITLE
fix(config): update SetPath calls to use string slice syntax

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -50,28 +50,28 @@ func (d DatabaseConfig) Schema() z.ZogSchema {
 
 		if d.Type == "sqlite" {
 			if d.File == "" {
-				ctx.AddIssue(ctx.Issue().SetPath("File").SetMessage("core.db.file is required for sqlite"))
+				ctx.AddIssue(ctx.Issue().SetPath([]string{"File"}).SetMessage("core.db.file is required for sqlite"))
 				valid = false
 			}
 		} else if d.Type == "mysql" {
 			if d.Host == "" {
-				ctx.AddIssue(ctx.Issue().SetPath("Host").SetMessage("core.db.host is required for mysql"))
+				ctx.AddIssue(ctx.Issue().SetPath([]string{"Host"}).SetMessage("core.db.host is required for mysql"))
 				valid = false
 			}
 			if d.Port <= 0 {
-				ctx.AddIssue(ctx.Issue().SetPath("Port").SetMessage("core.db.port must be greater than 0"))
+				ctx.AddIssue(ctx.Issue().SetPath([]string{"Port"}).SetMessage("core.db.port must be greater than 0"))
 				valid = false
 			}
 			if d.Username == "" {
-				ctx.AddIssue(ctx.Issue().SetPath("Username").SetMessage("core.db.username is required for mysql"))
+				ctx.AddIssue(ctx.Issue().SetPath([]string{"Username"}).SetMessage("core.db.username is required for mysql"))
 				valid = false
 			}
 			if d.Password == "" {
-				ctx.AddIssue(ctx.Issue().SetPath("Password").SetMessage("core.db.password is required for mysql"))
+				ctx.AddIssue(ctx.Issue().SetPath([]string{"Password"}).SetMessage("core.db.password is required for mysql"))
 				valid = false
 			}
 			if d.Name == "" {
-				ctx.AddIssue(ctx.Issue().SetPath("Name").SetMessage("core.db.name is required for mysql"))
+				ctx.AddIssue(ctx.Issue().SetPath([]string{"Name"}).SetMessage("core.db.name is required for mysql"))
 				valid = false
 			}
 		}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated `SetPath` calls within the database configuration validation logic to use string slice syntax, aligning with an API change in how validation issue paths are specified. This change affects validation for SQLite file paths and MySQL host, port, username, password, and database name fields.
<!-- kody-pr-summary:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Updated all `SetPath` calls in `config/database.go` to use string slice syntax (`[]string{"FieldName"}`) instead of plain strings to comply with the zog v0.22.0 API changes. The change affects 6 validation error calls in the database configuration schema's custom validation function, ensuring field-specific error paths are correctly reported when validating SQLite and MySQL configurations.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks
- The changes are mechanical API updates required for compatibility with zog v0.22.0. All 6 SetPath calls follow the identical pattern of wrapping field names in string slices. The logic remains unchanged, only the syntax was updated. No other files in the codebase use SetPath with the old syntax.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| config/database.go | Updated SetPath calls from string to string slice syntax to match zog v0.22.0 API changes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant DC as DatabaseConfig
    participant Zog as Zog Schema Validator
    participant Ctx as Validation Context
    
    App->>DC: Call Schema()
    DC->>Zog: Create validation schema
    DC->>Zog: Add TestFunc for custom validation
    
    App->>Zog: Validate config data
    Zog->>DC: Execute TestFunc with data
    
    alt Database Type is SQLite
        DC->>DC: Check if File is empty
        alt File is empty
            DC->>Ctx: AddIssue(Issue().SetPath([]string{"File"}))
        end
    else Database Type is MySQL
        DC->>DC: Validate Host, Port, Username, Password, Name
        alt Any field is invalid
            DC->>Ctx: AddIssue(Issue().SetPath([]string{"FieldName"}))
        end
    end
    
    DC->>Zog: Return validation result
    Zog->>App: Return validation status with field-specific errors
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->