### PR TITLE
fix(request): initialize OperationFinder during startup

### DIFF
--- a/service/request.go
+++ b/service/request.go
@@ -109,7 +109,12 @@ func NewRequestService() (core.Service, []core.ContextBuilderOption, error) {
 		models: make(map[string]data_models.RequestDataModel),
 	}
 
-	return req, nil, nil
+	return req, core.ContextOptions(
+		core.ContextWithStartupFunc(func(ctx core.Context) error {
+			req.ops = NewOperationFinder(ctx)
+			return nil
+		}),
+	), nil
 }
 
 func (r *RequestServiceDefault) ID() string {


### PR DESCRIPTION
- Initialize req.ops field via ContextWithStartupFunc instead of immediate initialization
- Fixes missing OperationFinder entity by deferring initialization until context is fully available


---

<!-- kody-pr-summary:start -->
This pull request updates the `RequestService` to ensure the `OperationFinder` is initialized during the application startup phase. By adding a startup function to the service context options, the `OperationFinder` is now created and assigned when the service context starts, rather than during the initial service construction.
<!-- kody-pr-summary:end -->