### PR TITLE
feat(tus): add real-time progress tracking for upload hashing operations

### DIFF
--- a/core/tus.go
+++ b/core/tus.go
@@ -68,7 +68,8 @@ type TUSUploadCreatedVerifyFunc func(hook handler.HookEvent, uploaderId uint) (S
 type TUSUploadCreatedAfterFunc func(requestId uint) error
 
 // TUSUploadCompletedHashFunc defines a callback that computes and returns the multihash for a completed upload
-type TUSUploadCompletedHashFunc func(handlr TusHandler, hook handler.HookEvent) (StorageHash, error)
+// The reader parameter is provided for the callback to read data from. The callback should not create its own reader.
+type TUSUploadCompletedHashFunc func(handlr TusHandler, hook handler.HookEvent, reader io.Reader) (StorageHash, error)
 
 // TUSPreFinishResponseCallback defines a callback that runs before finishing an upload
 // Can modify the HTTP response before it's sent to the client

--- a/service/internal/tus/hash_progress_reader.go
+++ b/service/internal/tus/hash_progress_reader.go
@@ -1,0 +1,159 @@
+package tus
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultUpdateChunkSize is the default chunk size (in bytes) for updating workflow data
+	DefaultUpdateChunkSize = 1024 * 1024 // 1MB
+)
+
+// HashProgressReader wraps an io.Reader to track progress during hashing operations
+// and updates workflow data at chunk boundaries to avoid excessive database writes.
+type HashProgressReader struct {
+	reader         io.Reader
+	totalBytes     int64
+	bytesRead      int64
+	updateChunk    int64
+	lastUpdateSize int64
+	requestID      uint
+	workflowSvc    core.WorkflowService
+	logger         *core.Logger
+	mu             sync.Mutex
+}
+
+// NewHashProgressReader creates a new HashProgressReader that wraps the provided reader.
+//
+// Parameters:
+//   - reader: The underlying reader to read from
+//   - totalBytes: Total size of the data being hashed
+//   - requestID: The request ID for updating workflow data
+//   - workflowSvc: Workflow service for updating progress
+//   - logger: Logger for debugging
+//   - updateChunk: Chunk size (in bytes) for workflow data updates. If 0, uses DefaultUpdateChunkSize.
+func NewHashProgressReader(
+	reader io.Reader,
+	totalBytes int64,
+	requestID uint,
+	workflowSvc core.WorkflowService,
+	logger *core.Logger,
+	updateChunk int64,
+) *HashProgressReader {
+	if updateChunk <= 0 {
+		updateChunk = DefaultUpdateChunkSize
+	}
+
+	return &HashProgressReader{
+		reader:       reader,
+		totalBytes:   totalBytes,
+		bytesRead:    0,
+		updateChunk:  updateChunk,
+		requestID:    requestID,
+		workflowSvc:  workflowSvc,
+		logger:       logger,
+	}
+}
+
+// Read implements io.Reader. It reads from the underlying reader and updates
+// workflow data at chunk boundaries.
+func (h *HashProgressReader) Read(p []byte) (n int, err error) {
+	n, err = h.reader.Read(p)
+	if n > 0 {
+		h.mu.Lock()
+		h.bytesRead += int64(n)
+
+		// Update workflow data if we've crossed a chunk boundary
+		if h.bytesRead-h.lastUpdateSize >= h.updateChunk {
+			h.updateProgress(context.Background())
+			h.lastUpdateSize = h.bytesRead
+		}
+
+		h.mu.Unlock()
+	}
+
+	return n, err
+}
+
+// updateProgress updates the workflow data with the current hashing progress.
+// This is called at chunk boundaries to avoid excessive database writes.
+func (h *HashProgressReader) updateProgress(ctx context.Context) {
+	if h.workflowSvc == nil || h.requestID == 0 {
+		return
+	}
+
+	progressPercent := float64(0)
+	if h.totalBytes > 0 {
+		progressPercent = float64(h.bytesRead) / float64(h.totalBytes) * 100
+	}
+
+	data := map[string]any{
+		"hash_progress_bytes": h.bytesRead,
+		"hash_progress_total": h.totalBytes,
+	}
+
+	err := h.workflowSvc.UpdateWorkflowData(ctx, h.requestID, data)
+	if err != nil {
+		if h.logger != nil {
+			h.logger.Warn("Failed to update hashing progress in workflow data",
+				zap.Error(err),
+				zap.Uint("requestID", h.requestID),
+				zap.Int64("bytesRead", h.bytesRead),
+				zap.Int64("totalBytes", h.totalBytes),
+			)
+		}
+	}
+}
+
+// Finalize updates workflow data with the final progress (100% complete).
+// This should be called after hashing completes successfully.
+func (h *HashProgressReader) Finalize(ctx context.Context) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.bytesRead = h.totalBytes
+	data := map[string]any{
+		"hash_progress_bytes":    h.bytesRead,
+		"hash_progress_total":    h.totalBytes,
+		"hash_progress_complete": true,
+	}
+
+	if h.workflowSvc != nil && h.requestID != 0 {
+		err := h.workflowSvc.UpdateWorkflowData(ctx, h.requestID, data)
+		if err != nil && h.logger != nil {
+			h.logger.Warn("Failed to finalize hashing progress in workflow data",
+				zap.Error(err),
+				zap.Uint("requestID", h.requestID),
+			)
+		}
+	}
+}
+
+// BytesRead returns the number of bytes read so far.
+func (h *HashProgressReader) BytesRead() int64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.bytesRead
+}
+
+// TotalBytes returns the total bytes expected.
+func (h *HashProgressReader) TotalBytes() int64 {
+	return h.totalBytes
+}
+
+// ProgressPercent returns the current progress as a percentage (0-100).
+func (h *HashProgressReader) ProgressPercent() float64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.totalBytes == 0 {
+		return 0
+	}
+	return float64(h.bytesRead) / float64(h.totalBytes) * 100
+}

--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -594,7 +594,59 @@ func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUplo
 		// Compute hash if callback is provided (now the request is visible in operations and in a workflow)
 		var computedHash core.StorageHash
 		if hashCallback != nil {
-			computedHash, err = hashCallback(handlr, hook)
+			// Get the upload reader and size for progress tracking
+			protocol, err := handlr.StorageProtocol()
+			if err != nil {
+				errMessage := "Failed to get storage protocol"
+				ctx.Logger().Error(errMessage, zap.Error(err))
+				if failErr := handlr.FailUploadById(ctx, sp, hook.Upload.ID); failErr != nil {
+					ctx.Logger().Error("Failed to fail upload",
+						zap.Error(failErr),
+						zap.String("uploadID", hook.Upload.ID))
+				}
+				return
+			}
+
+			// Resolve effective size and validate
+			size := hook.Upload.Size
+			if size < 0 {
+				size = hook.Upload.Offset
+			}
+			if size < 0 {
+				errMessage := fmt.Sprintf("invalid/unknown upload size for %s: size=%d offset=%d", hook.Upload.ID, hook.Upload.Size, hook.Upload.Offset)
+				ctx.Logger().Error(errMessage)
+				if failErr := handlr.FailUploadById(ctx, sp, hook.Upload.ID); failErr != nil {
+					ctx.Logger().Error("Failed to fail upload",
+						zap.Error(failErr),
+						zap.String("uploadID", hook.Upload.ID))
+				}
+				return
+			}
+
+			// Get the upload reader
+			reader, err := handlr.UploadReader(hook.Context, hook.Upload.ID, protocol, 0)
+			if err != nil {
+				errMessage := fmt.Sprintf("failed to get upload reader for %s: %v", hook.Upload.ID, err)
+				ctx.Logger().Error(errMessage)
+				if failErr := handlr.FailUploadById(ctx, sp, hook.Upload.ID); failErr != nil {
+					ctx.Logger().Error("Failed to fail upload",
+						zap.Error(failErr),
+						zap.String("uploadID", hook.Upload.ID))
+				}
+				return
+			}
+
+			// Wrap reader with progress tracking
+			progressReader := NewHashProgressReader(reader, size, tusReq.RequestID, workflowSvc, ctx.Logger(), 0)
+			defer func() {
+				if err := reader.Close(); err != nil {
+					ctx.Logger().Error("failed to close upload reader", zap.Error(err))
+				}
+				progressReader.Finalize(hook.Context)
+			}()
+
+			// Call hashCallback with the progress reader
+			computedHash, err = hashCallback(handlr, hook, progressReader)
 			if err != nil {
 				errMessage := "Failed to compute hash"
 				ctx.Logger().Error(errMessage, zap.Error(err))

--- a/service/tus.go
+++ b/service/tus.go
@@ -23,6 +23,12 @@ import (
 
 var _ core.TUSService = (*TUSServiceDefault)(nil)
 
+// TUSHashProgressData represents the hashing progress data stored in workflow metadata
+type TUSHashProgressData struct {
+	BytesHashed int64 `json:"hash_progress_bytes"`
+	TotalBytes  int64 `json:"hash_progress_total"`
+}
+
 func init() {
 	core.RegisterService(core.ServiceInfo{
 		ID:      core.TUS_SERVICE,
@@ -475,8 +481,21 @@ func (h *TUSOperationHandler) GetStatus(ctx context.Context, req *models.Request
 	if req.Status == models.RequestStatusCompleted || tusReq.Completed {
 		status.ProgressPercent = 100
 	} else if req.Status == models.RequestStatusProcessing {
-		// For processing, we don't have detailed progress info from TUS
-		status.ProgressPercent = 50
+		// Try to get progress from workflow data
+		var progressData TUSHashProgressData
+		if err := h.StructuredWorkflowData(req.ID, &progressData); err == nil {
+			// Calculate progress from bytes/total
+			if progressData.TotalBytes > 0 && progressData.BytesHashed > 0 {
+				progress := float64(progressData.BytesHashed) / float64(progressData.TotalBytes) * 100
+				if progress > 100 {
+					progress = 100
+				}
+				status.ProgressPercent = progress
+
+				// Use custom status message for hashing stage
+				status.Message = "Hashing upload..."
+			}
+		}
 	}
 
 	return &status, nil


### PR DESCRIPTION
- Update TUSUploadCompletedHashFunc callback signature to accept io.Reader parameter
- Add HashProgressReader wrapper to track bytes hashed during hash computation
- Update workflow data with hash progress at 1MB chunk boundaries to avoid excessive DB writes
- Update TUSOperationHandler.GetStatus to read hashing progress from workflow data
- Remove misleading 50% default progress during processing state
- Add TUSHashProgressData struct for structured workflow data access
- Set custom status message "Hashing upload..." during processing stage


---

<!-- kody-pr-summary:start -->
This pull request introduces real-time progress tracking for the hashing phase of TUS uploads.

**Key changes:**

*   **Progress Tracking Implementation:** Added a `HashProgressReader` that wraps the upload data stream. This component monitors the number of bytes processed during hashing and periodically updates workflow metadata (bytes hashed vs. total bytes) to avoid excessive database writes.
*   **Interface Update:** Modified the `TUSUploadCompletedHashFunc` callback signature to accept an `io.Reader` parameter. This allows the system to inject the progress-tracking wrapper directly into the hashing computation logic.
*   **Handler Integration:** Updated the default upload completion handler to retrieve the upload reader, wrap it with the `HashProgressReader`, and pass it to the hashing callback. It also ensures the progress is finalized once hashing completes.
*   **Status Reporting:** Enhanced the status retrieval logic to read the hashing progress from workflow metadata. Instead of displaying a static progress value during processing, the system now calculates the actual percentage based on bytes hashed and updates the status message to "Hashing upload...".
<!-- kody-pr-summary:end -->