### PR TITLE
fix(tus): remove unused import and variable in HashProgressReader

### DIFF
--- a/service/internal/tus/hash_progress_reader.go
+++ b/service/internal/tus/hash_progress_reader.go
@@ -2,7 +2,6 @@ package tus
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"sync"
 
@@ -86,11 +85,6 @@ func (h *HashProgressReader) Read(p []byte) (n int, err error) {
 func (h *HashProgressReader) updateProgress(ctx context.Context) {
 	if h.workflowSvc == nil || h.requestID == 0 {
 		return
-	}
-
-	progressPercent := float64(0)
-	if h.totalBytes > 0 {
-		progressPercent = float64(h.bytesRead) / float64(h.totalBytes) * 100
 	}
 
 	data := map[string]any{


### PR DESCRIPTION
- Remove unused fmt import
- Remove unused progressPercent variable calculation


---

<!-- kody-pr-summary:start -->
This pull request cleans up the `HashProgressReader` implementation by removing an unused `fmt` import and eliminating the calculation of an unused `progressPercent` variable within the `updateProgress` function.
<!-- kody-pr-summary:end -->