### PR TITLE
fix(core): add nil check before incrementing error counter in MetricTrackResult

### DIFF
--- a/core/metrics.go
+++ b/core/metrics.go
@@ -250,7 +250,7 @@ func MetricTrackResult[T any](observer prometheus.Observer, errors prometheus.Co
 
 	result, err := f()
 
-	if err != nil {
+	if err != nil && errors != nil {
 		errors.Inc()
 	}
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the `MetricTrackResult` function in `core/metrics.go` to prevent a runtime panic. It adds a check to ensure the error counter is not nil before attempting to increment it. This change allows the function to operate safely even when an error counter is not provided.
<!-- kody-pr-summary:end -->