### PR TITLE
refactor(request): prioritize handler-provided status message over request status message

### DIFF
--- a/service/request.go
+++ b/service/request.go
@@ -799,14 +799,7 @@ func (r *RequestServiceDefault) GetRequestStatus(ctx context.Context, id uint, w
 		UpdatedAt: req.UpdatedAt,
 	}
 
-	// Set default message based on status if not provided
-	if req.StatusMessage == "" {
-		status.Message = core.GetDefaultStatusMessage(req.Status)
-	} else {
-		status.Message = req.StatusMessage
-	}
-
-	// Get progress percentage
+	// Get progress percentage and detailed status from handler
 	var computedStatus *core.RequestStatus
 	if withDeleted {
 		computedStatus, err = r.ComputeRequestStatusWithDeleted(ctx, id, true)
@@ -815,6 +808,19 @@ func (r *RequestServiceDefault) GetRequestStatus(ctx context.Context, id uint, w
 	}
 	if err == nil {
 		status.ProgressPercent = computedStatus.ProgressPercent
+		// Use message from handler if provided, otherwise fall back to request status message
+		if computedStatus.Message != "" {
+			status.Message = computedStatus.Message
+		}
+	}
+
+	// Set default message based on status if not yet set
+	if status.Message == "" {
+		if req.StatusMessage == "" {
+			status.Message = core.GetDefaultStatusMessage(req.Status)
+		} else {
+			status.Message = req.StatusMessage
+		}
 	}
 
 	return status, nil


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the `GetRequestStatus` method in `service/request.go` to modify the priority hierarchy for status messages.

Previously, the status message was determined solely by the request's stored `StatusMessage` or a default message based on the status code. With this change, the method now prioritizes messages provided by the request handler (via the computed status). If the handler provides a specific message, it will be used; otherwise, the system falls back to the request's stored message or the default message.
<!-- kody-pr-summary:end -->