### PR TITLE
fix(tus): use service context instead of canceled hook context and round progress percentage

### DIFF
--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -624,7 +624,10 @@ func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUplo
 			}
 
 			// Get the upload reader
-			reader, err := handlr.UploadReader(hook.Context, hook.Upload.ID, protocol, 0)
+			// IMPORTANT: Use the service context (ctx) instead of hook.Context
+			// because hook.Context is the HTTP request context which is canceled after
+			// the upload completes, and this handler runs in a goroutine after completion.
+			reader, err := handlr.UploadReader(ctx, hook.Upload.ID, protocol, 0)
 			if err != nil {
 				errMessage := fmt.Sprintf("failed to get upload reader for %s: %v", hook.Upload.ID, err)
 				ctx.Logger().Error(errMessage)
@@ -642,7 +645,7 @@ func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUplo
 				if err := reader.Close(); err != nil {
 					ctx.Logger().Error("failed to close upload reader", zap.Error(err))
 				}
-				progressReader.Finalize(hook.Context)
+				progressReader.Finalize(ctx)
 			}()
 
 			// Call hashCallback with the progress reader

--- a/service/tus.go
+++ b/service/tus.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"time"
 
@@ -490,7 +491,8 @@ func (h *TUSOperationHandler) GetStatus(ctx context.Context, req *models.Request
 				if progress > 100 {
 					progress = 100
 				}
-				status.ProgressPercent = progress
+				// Round to 2 decimal places
+				status.ProgressPercent = math.Round(progress*100) / 100
 
 				// Use custom status message for hashing stage
 				status.Message = "Hashing upload..."


### PR DESCRIPTION
- Replace hook.Context with service context in DefaultUploadCompletedHandler to avoid using canceled HTTP request context in post-completion goroutine
- Round progress percentage to 2 decimal places using math.Round for cleaner display


---

<!-- kody-pr-summary:start -->
This pull request implements fixes for the TUS upload service to ensure reliable post-upload processing and improve status reporting precision.

*   **Fix Context Cancellation:** Updates the `DefaultUploadCompletedHandler` to use the persistent service context instead of the HTTP request hook context. This prevents operations running in background goroutines (such as reading the upload file) from failing due to the request context being canceled after the upload completes.
*   **Round Progress Percentage:** Modifies the `GetStatus` method to round the upload progress percentage to two decimal places, ensuring cleaner and more precise status updates.
<!-- kody-pr-summary:end -->