### PR TITLE
refactor: centralize progress percentage rounding to API boundary

### DIFF
--- a/service/request.go
+++ b/service/request.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 	"time"
@@ -807,7 +808,8 @@ func (r *RequestServiceDefault) GetRequestStatus(ctx context.Context, id uint, w
 		computedStatus, err = r.ComputeRequestStatus(ctx, id, true)
 	}
 	if err == nil {
-		status.ProgressPercent = computedStatus.ProgressPercent
+		// Normalize to 2 decimal places to ensure consistent JSON output for UI clients
+		status.ProgressPercent = math.Round(computedStatus.ProgressPercent*100) / 100
 		// Use message from handler if provided, otherwise fall back to request status message
 		if computedStatus.Message != "" {
 			status.Message = computedStatus.Message

--- a/service/tus.go
+++ b/service/tus.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"time"
 
@@ -491,8 +490,7 @@ func (h *TUSOperationHandler) GetStatus(ctx context.Context, req *models.Request
 				if progress > 100 {
 					progress = 100
 				}
-				// Round to 2 decimal places
-				status.ProgressPercent = math.Round(progress*100) / 100
+				status.ProgressPercent = progress
 
 				// Use custom status message for hashing stage
 				status.Message = "Hashing upload..."

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -704,6 +705,8 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStatus(ctx context.Context, requ
 
 			// Calculate progress using centralized helper
 			status.Progress = workflowPkg.CalculateWorkflowStatusProgress(status, reqStatus)
+			// Normalize to 2 decimal places to ensure consistent JSON output for UI clients
+			status.Progress = math.Round(status.Progress*100) / 100
 			currentStepProgress := reqStatus.ProgressPercent / 100.0
 			w.Logger().Debug("Calculated workflow progress",
 				zap.String("workflow", status.WorkflowName),


### PR DESCRIPTION
- Move rounding logic from internal handlers to API response methods
- Apply 2-decimal normalization in GetRequestStatus and GetWorkflowStatus
- Remove duplicate rounding from TUSOperationHandler.GetStatus
- Ensures consistent JSON output for UI clients while maintaining full precision internally


---

<!-- kody-pr-summary:start -->
This pull request centralizes the rounding logic for progress percentages to the API boundary layer. It removes the 2-decimal place normalization from the TUS operation handler and applies it within the Request and Workflow status services. This ensures that progress data returned to UI clients is consistently formatted with two decimal places.
<!-- kody-pr-summary:end -->