### PR TITLE
refactor(tus): distinguish hashing phase from workflow execution in status reporting

### DIFF
--- a/service/tus.go
+++ b/service/tus.go
@@ -26,8 +26,9 @@ var _ core.TUSService = (*TUSServiceDefault)(nil)
 
 // TUSHashProgressData represents the hashing progress data stored in workflow metadata
 type TUSHashProgressData struct {
-	BytesHashed int64 `json:"hash_progress_bytes"`
-	TotalBytes  int64 `json:"hash_progress_total"`
+	BytesHashed          int64 `json:"hash_progress_bytes"`
+	TotalBytes           int64 `json:"hash_progress_total"`
+	HashProgressComplete bool  `json:"hash_progress_complete"`
 }
 
 func init() {
@@ -494,8 +495,9 @@ func (h *TUSOperationHandler) GetStatus(ctx context.Context, req *models.Request
 				// Round to 2 decimal places
 				status.ProgressPercent = math.Round(progress*100) / 100
 
-				// Use custom status message for hashing stage
-				status.Message = "Hashing upload..."
+				if !progressData.HashProgressComplete {
+					status.Message = "Hashing upload..."
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Add HashProgressComplete field to TUSHashProgressData
- Only show "Hashing upload..." message when hashing is in progress
- Allow framework to set status message after hashing completes


---

<!-- kody-pr-summary:start -->
This pull request refines the status reporting for TUS uploads by distinguishing between the hashing phase and the workflow execution phase. It introduces a completion flag for the hashing process, ensuring that the "Hashing upload..." status message is only displayed while hashing is actively in progress and is cleared once the hashing stage is finished.
<!-- kody-pr-summary:end -->