### PR TITLE
refactor(testing): add ResetMetrics function for test isolation

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -652,6 +652,7 @@ func ResetState() {
 	ResetServices()
 	ResetHashAlgorithms()
 	ResetErrorRegistry()
+	ResetMetrics()
 
 	// Reset plugins
 	pluginsMu.Lock()

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -42,6 +42,16 @@ func PluginMetricsRegistry(pluginID string) *prometheus.Registry {
 	return pluginRegistries[pluginID]
 }
 
+// ResetMetrics resets all metrics registries for testing purposes
+// This should be called between tests to prevent duplicate registration errors
+func ResetMetrics() {
+	metricsMu.Lock()
+	defer metricsMu.Unlock()
+
+	coreRegistry = prometheus.NewRegistry()
+	pluginRegistries = make(map[string]*prometheus.Registry)
+}
+
 // RegisterCoreCollector registers a collector with the core registry
 func RegisterCoreCollector(collector prometheus.Collector) error {
 	return CoreMetricsRegistry().Register(collector)


### PR DESCRIPTION
- Add ResetMetrics() function to reset all metrics registries
- Call ResetMetrics() in ResetState() to prevent duplicate registration errors between tests


---

<!-- kody-pr-summary:start -->
This pull request introduces a `ResetMetrics` function to reset the core and plugin metrics registries to their initial states. This function is integrated into the existing `ResetState` workflow to ensure metrics are cleared during global state resets. The change is intended to improve test isolation by preventing errors related to duplicate metric registrations.
<!-- kody-pr-summary:end -->