### PR TITLE
feat(core): add DetachContext for long-running workflows

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -662,3 +662,11 @@ func ResetState() {
 	pluginsOrderedMu.Unlock()
 	pluginsMu.Unlock()
 }
+
+// DetachContext creates a new context that inherits the trace context from the input
+// but is not canceled when the input context is canceled.
+// This is useful for starting long-running workflows that should outlive HTTP requests
+// or other short-lived contexts while preserving OpenTelemetry tracing.
+func DetachContext(ctx context.Context) context.Context {
+	return context.WithoutCancel(ctx)
+}


### PR DESCRIPTION
Adds a new DetachContext function that creates a context inheriting trace context
from the input but without cancellation propagation. This enables starting
long-running workflows that outlive HTTP requests while preserving OpenTelemetry
tracing.


---

<!-- kody-pr-summary:start -->
This pull request introduces a new `DetachContext` utility function to the core package. This function creates a new context that inherits the trace context from the input but remains active even if the input context is canceled. This change enables long-running workflows to outlive short-lived operations (such as HTTP requests) while preserving OpenTelemetry tracing information.
<!-- kody-pr-summary:end -->