### PR TITLE
fix(core): improve status reporting for active operations

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -591,6 +591,11 @@ func (h *OperationHelperDefault) GetStatusFromWorkflowData(requestID uint, req *
 			// Fall back to operation-aware message
 			status.Message = h.getOperationAwareMessage(req.Status, req.Operation)
 		}
+
+		// If progress is > 0, the operation is definitely processing regardless of req.Status
+		if progress.ProgressPercent > 0 {
+			status.State = models.RequestStatusProcessing
+		}
 	} else {
 		// Fall back to operation-aware status messages
 		status.Message = h.getOperationAwareMessage(req.Status, req.Operation)

--- a/core/operation.go
+++ b/core/operation.go
@@ -592,8 +592,9 @@ func (h *OperationHelperDefault) GetStatusFromWorkflowData(requestID uint, req *
 			status.Message = h.getOperationAwareMessage(req.Status, req.Operation)
 		}
 
-		// If progress is > 0, the operation is definitely processing regardless of req.Status
-		if progress.ProgressPercent > 0 {
+		// If progress is > 0, the operation is definitely processing
+		// Preserve terminal states (Failed/Completed) regardless of progress
+		if progress.ProgressPercent > 0 && status.State != models.RequestStatusCompleted && status.State != models.RequestStatusFailed {
 			status.State = models.RequestStatusProcessing
 		}
 	} else {

--- a/core/progress.go
+++ b/core/progress.go
@@ -268,7 +268,8 @@ func (t *ProgressTracker) CompleteWorkUnit(unitIndex int) error {
 	
 	// Calculate progress
 	t.currentProgress = float64(t.completedUnits) / float64(t.config.TotalWorkUnits) * 100
-	t.currentStep = t.workUnits[unitIndex].Name
+	// Don't set currentStep to work unit name - use overall message instead
+	// This prevents "unit_X" from appearing in status messages
 	t.stepProgress = 100
 	
 	return t.persistProgress()
@@ -442,18 +443,24 @@ func (t *ProgressTracker) getStepDescription(stepName string) string {
 
 // persistProgress saves the progress to workflow data and notifies callbacks
 func (t *ProgressTracker) persistProgress() error {
+	// In WorkUnits mode, don't use step-specific messages to avoid "unit_X" in status
+	stepName := t.currentStep
+	if t.config.Mode == ProgressModeWorkUnits {
+		stepName = ""
+	}
+
 	// Create progress update
 	update := ProgressUpdate{
 		ProgressPercent: t.currentProgress,
-		StepName:        t.currentStep,
+		StepName:        stepName,
 		StepProgress:    t.stepProgress,
 		UpdatedAt:       time.Now(),
 	}
 	
 	// Generate messages
-	if t.currentStep != "" {
+	if stepName != "" {
 		// Try to get step description for better messaging
-		stepDescription := t.getStepDescription(t.currentStep)
+		stepDescription := t.getStepDescription(stepName)
 		update.Message = t.config.MessageProvider.GetStepMessage(stepDescription, t.stepProgress)
 	} else {
 		update.Message = t.config.MessageProvider.GetOverallMessage(t.currentProgress)
@@ -462,7 +469,7 @@ func (t *ProgressTracker) persistProgress() error {
 	// Persist to workflow data
 	progressData := map[string]any{
 		"progress_percent": t.currentProgress,
-		"step_name":        t.currentStep,
+		"step_name":        stepName,
 		"step_progress":    t.stepProgress,
 		"message":          update.Message,
 		"updated_at":       update.UpdatedAt,

--- a/service/request.go
+++ b/service/request.go
@@ -811,7 +811,10 @@ func (r *RequestServiceDefault) GetRequestStatus(ctx context.Context, id uint, w
 		// Normalize to 2 decimal places to ensure consistent JSON output for UI clients
 		status.ProgressPercent = math.Round(computedStatus.ProgressPercent*100) / 100
 		// Use state from handler if provided (may be different from req.Status due to progress tracking)
-		status.State = computedStatus.State
+		// Only apply handler-provided state if it's non-empty to preserve terminal states
+		if computedStatus.State != "" {
+			status.State = computedStatus.State
+		}
 		// Use message from handler if provided, otherwise fall back to request status message
 		if computedStatus.Message != "" {
 			status.Message = computedStatus.Message

--- a/service/request.go
+++ b/service/request.go
@@ -810,6 +810,8 @@ func (r *RequestServiceDefault) GetRequestStatus(ctx context.Context, id uint, w
 	if err == nil {
 		// Normalize to 2 decimal places to ensure consistent JSON output for UI clients
 		status.ProgressPercent = math.Round(computedStatus.ProgressPercent*100) / 100
+		// Use state from handler if provided (may be different from req.Status due to progress tracking)
+		status.State = computedStatus.State
 		// Use message from handler if provided, otherwise fall back to request status message
 		if computedStatus.Message != "" {
 			status.Message = computedStatus.Message


### PR DESCRIPTION
- Prevent internal work unit names from appearing in user-facing status messages
- Set status state to Processing when progress > 0 regardless of stored request status
- Use computed status state from handlers which may reflect actual operation progress
- Skip step-specific messages in WorkUnits mode to avoid exposing internal identifiers


---

<!-- kody-pr-summary:start -->
This pull request improves status reporting for active operations by ensuring that operations with progress are correctly identified as processing and by refining progress messaging to avoid displaying technical unit names.

Key changes:
- Modified status determination logic to set operations to "processing" state when progress is greater than 0, regardless of the request status
- Updated progress tracking to prevent work unit names (like "unit_X") from appearing in status messages, providing cleaner user-facing messages
- Ensured that the computed state from the operation handler is properly used in the final status response

These changes provide more accurate status reporting for operations in progress and improve the clarity of status messages presented to users.
<!-- kody-pr-summary:end -->