### PR TITLE
feat(db): add JSONSchema method to BinaryUUID for swagger generation

### DIFF
--- a/db/types/binary_uuid.go
+++ b/db/types/binary_uuid.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 
+	jsonschema "github.com/invopop/jsonschema"
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
 )
@@ -65,4 +66,14 @@ func (u BinaryUUID) Equals(other BinaryUUID) bool {
 
 func (u BinaryUUID) Empty() bool {
 	return u.Equals(EmptyUUID)
+}
+
+// JSONSchema returns the JSON Schema definition for BinaryUUID.
+// This ensures swagger generation treats BinaryUUID as a string UUID format
+// rather than the default object structure.
+func (b BinaryUUID) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:   "string",
+		Format: "uuid",
+	}
 }

--- a/db/types/binary_uuid_test.go
+++ b/db/types/binary_uuid_test.go
@@ -84,3 +84,12 @@ func TestNewBinUUID(t *testing.T) {
 	assert.Equal(t, byte('4'), uuid1.String()[14])
 	assert.Equal(t, byte('4'), uuid2.String()[14])
 }
+
+func TestBinaryUUID_JSONSchema(t *testing.T) {
+	uuid := BinaryUUID{}
+	schema := uuid.JSONSchema()
+
+	assert.NotNil(t, schema)
+	assert.Equal(t, "string", schema.Type)
+	assert.Equal(t, "uuid", schema.Format)
+}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the code changes provided, here's a precise description for this pull request:

**feat(db): add JSONSchema method to BinaryUUID for swagger generation**

This pull request adds a JSONSchema method to the BinaryUUID type to ensure proper Swagger/OpenAPI documentation generation. The new method configures BinaryUUID to be represented as a string with UUID format in API documentation, rather than the default object structure. This change improves API documentation accuracy by correctly representing UUID fields in generated Swagger specifications.

The implementation includes:
- Added JSONSchema() method to BinaryUUID type that returns a schema with type "string" and format "uuid"
- Added corresponding unit test to verify the schema configuration

This change specifically targets API documentation generation without modifying the underlying BinaryUUID functionality or database storage behavior.
<!-- kody-pr-summary:end -->