### PR TITLE
fix: create temporary logger for config errors

### DIFF
--- a/cmd/internal/portal/server.go
+++ b/cmd/internal/portal/server.go
@@ -12,11 +12,13 @@ import (
 func StartServer(cmd *cli.Command) error {
 	// Continue with normal portal initialization
 	cfg, err := config.NewManager()
-	logger := core.NewLogger(cfg)
 	if err != nil {
+		// Create a basic logger for fatal error since we can't use core.NewLogger without config
+		logger, _ := zap.NewDevelopment()
 		logger.Fatal("Failed to load config", zap.Error(err))
 		return err
 	}
+	logger := core.NewLogger(cfg)
 
 	ctx, err := core.NewContext(cfg, logger)
 	if err != nil {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes an issue with error handling during server initialization when the configuration fails to load. The changes ensure that a temporary logger is created to properly log fatal configuration errors before the main logger can be initialized. This prevents potential crashes or unlogged errors when the configuration loading fails at startup.
<!-- kody-pr-summary:end -->