### PR TITLE
fix(cli): disable config validation for config-env command

### DIFF
--- a/cmd/internal/cli/commands.go
+++ b/cmd/internal/cli/commands.go
@@ -98,10 +98,15 @@ var configEnvAction cli.ActionFunc = func(ctx context.Context, cmd *cli.Command)
 	// Register services from plugins (this just registers them, doesn't start them)
 	core.RegisterServicesFromPlugins()
 
+	// Disable validation for config-env command since we may not have all required values
+	manager.DisableValidation()
+
 	// Initialize just the config manager to process configs
-	if err := manager.Init(); err != nil {
-		return fmt.Errorf("failed to initialize config manager: %w", err)
-	}
+	// We ignore validation errors here since we just want to display the config
+	_ = manager.Init()
+
+	// Re-enable validation
+	manager.EnableValidation()
 
 	// Register service configs
 	for _, svcInfo := range core.GetServices() {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the code changes, this pull request fixes an issue with the `config-env` command by disabling configuration validation during its execution. The modification ensures that the command can display configuration values even when not all required configuration values are present. The change temporarily disables validation before initializing the config manager, ignores any initialization errors, and then re-enables validation afterward. This allows the `config-env` command to function without requiring a complete configuration set.
<!-- kody-pr-summary:end -->