### PR TITLE
fix(config): validate CONFIG_PATHS as directories and update defaults

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -4,6 +4,8 @@ const (
 	//
 	ENV_PREFIX    = "PORTAL__"
 	ENV_SEPARATOR = "__"
+	// Environment variable names
+	ENV_CONFIG_PATHS = ENV_PREFIX + "CONFIG_PATHS"
 	// File extensions and names
 	CONFIG_EXTENSION  = ".yaml"
 	CoreConfigFile    = "core" + CONFIG_EXTENSION
@@ -30,7 +32,6 @@ func getDefaultConfigPaths() []string {
 	return []string{
 		"/etc/lumeweb/portal",
 		"$HOME/.lumeweb/portal",
-		"./portal.yaml",
 		"./",
 	}
 }

--- a/config/manager.go
+++ b/config/manager.go
@@ -33,7 +33,8 @@ func findConfigFile(options findConfigFileOptions, cm configmanager.Manager) (st
 		// Expand environment variables in path
 		expandedPath := os.ExpandEnv(_path)
 
-		// Check if path is a directory
+		// Append CoreConfigFile for core config paths
+		// All paths (defaults and PORTAL__CONFIG_PATHS) must be directories
 		if options.Core {
 			expandedPath = path.Join(expandedPath, CoreConfigFile)
 		}
@@ -239,8 +240,16 @@ func NewManager(opts ...ManagerOption) (*ManagerDefault, error) {
 	var paths []string
 	if len(m.configPaths) > 0 {
 		paths = m.configPaths
-	} else if customPaths := os.Getenv(ENV_PREFIX + "CONFIG_PATHS"); customPaths != "" {
+	} else if customPaths := os.Getenv(ENV_CONFIG_PATHS); customPaths != "" {
 		paths = strings.Split(customPaths, string(os.PathListSeparator))
+		// Validate that all paths are directories, not file paths
+		for _, p := range paths {
+			expandedPath := os.ExpandEnv(p)
+			info, err := os.Stat(expandedPath)
+			if err == nil && !info.IsDir() {
+				return nil, fmt.Errorf("%s must contain directories, not file paths: %s", ENV_CONFIG_PATHS, p)
+			}
+		}
 	} else {
 		paths = DefaultConfigPaths
 	}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the code changes provided, here is a precise description of this pull request:

**fix(config): validate CONFIG_PATHS as directories and update defaults**

This pull request updates the configuration path handling to ensure consistency and proper validation. The changes include:

1. **Removed file path from defaults**: Removed "./portal.yaml" from the default configuration paths, ensuring all default paths are directories.

2. **Added validation for custom paths**: When using the PORTAL__CONFIG_PATHS environment variable, the system now validates that all provided paths are directories, not file paths. If a file path is detected, an error is returned.

3. **Improved path handling**: All configuration paths (both defaults and custom) are now consistently treated as directories, with the core configuration file name appended when needed.

These changes ensure that the configuration system maintains a consistent directory-based approach for all configuration paths, preventing potential issues with mixed file and directory path usage.
<!-- kody-pr-summary:end -->