### PR TITLE
fix(testing): prevent malformed FQDN when mock API returns empty subdomain

### DIFF
--- a/core/testing/mock_http.go
+++ b/core/testing/mock_http.go
@@ -67,10 +67,15 @@ func (m *MockHTTPService) APISubdomain(id string, proto bool) string {
 // apiSubdomainFunc generates the return function for APISubdomain expectations
 func (m *MockHTTPService) apiSubdomainFunc(id string, proto bool) func(string, bool) string {
 	return func(id string, proto bool) string {
+		domain := m.cmanager.Config().Core.Domain
 		if core.GetAPI(id) == nil {
 			return ""
 		}
-		return fmt.Sprintf("%s.%s", core.GetAPI(id).Subdomain(), m.cmanager.Config().Core.Domain)
+		subdomain := core.GetAPI(id).Subdomain()
+		if subdomain == "" {
+			return domain
+		}
+		return fmt.Sprintf("%s.%s", subdomain, domain)
 	}
 }
 

--- a/core/testing/mock_http.go
+++ b/core/testing/mock_http.go
@@ -67,6 +67,9 @@ func (m *MockHTTPService) APISubdomain(id string, proto bool) string {
 // apiSubdomainFunc generates the return function for APISubdomain expectations
 func (m *MockHTTPService) apiSubdomainFunc(id string, proto bool) func(string, bool) string {
 	return func(id string, proto bool) string {
+		if m.cmanager == nil {
+			return ""
+		}
 		domain := m.cmanager.Config().Core.Domain
 		if core.GetAPI(id) == nil {
 			return ""


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes an issue in the mock HTTP service that could generate malformed fully qualified domain names (FQDNs) when the mock API returns an empty subdomain. The fix ensures that if a subdomain is empty, only the domain is returned, preventing the creation of invalid FQDNs like `.example.com`. This change improves the reliability of the testing framework by handling edge cases in subdomain generation.
<!-- kody-pr-summary:end -->