### PR TITLE
fix(user): make registration more resilient to email failures

### DIFF
--- a/db/models/user.go
+++ b/db/models/user.go
@@ -32,6 +32,19 @@ type User struct {
 	PasswordResets     []PasswordReset
 }
 
+func (u *User) BeforeCreate(tx *gorm.DB) error {
+	if u.Email != "" {
+		verify, err := getEmailVerifier().Verify(u.Email)
+		if err != nil {
+			return err
+		}
+		if !verify.Syntax.Valid {
+			return errors.New("email is invalid")
+		}
+	}
+	return nil
+}
+
 func (u *User) BeforeUpdate(tx *gorm.DB) error {
 	var email string
 	var changed bool

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -162,6 +162,14 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 			options = append(options, mail.WithUsername(mailCfg.Username))
 			options = append(options, mail.WithPassword(mailCfg.Password))
 
+			if mailCfg.Host != "" {
+				domain := mailCfg.Host
+				if ctx.Config().Config().Core.Domain != "" {
+					domain = ctx.Config().Config().Core.Domain
+				}
+				options = append(options, mail.WithHELO(domain))
+			}
+
 			client, err := mail.NewClient(mailCfg.Host, options...)
 			if err != nil {
 				ctx.Logger().Error("Failed to create mail client",

--- a/service/user.go
+++ b/service/user.go
@@ -13,8 +13,10 @@ import (
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/event"
 	dbHelper "go.lumeweb.com/portal/service/internal/db"
+	"go.lumeweb.com/portal/service/internal/mailer"
 	"go.lumeweb.com/portal/service/internal/user"
 	userInternal "go.lumeweb.com/portal/service/internal/user"
+	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -273,7 +275,11 @@ func (u UserServiceDefault) CreateAccount(ctx context.Context, email string, pas
 				}
 			} else if verifyEmail {
 				if err := u.SendEmailVerification(ctx, _user.ID); err != nil {
-					return nil, err
+					u.Logger().Warn("Failed to send email verification during account creation, but account was created successfully",
+						zap.Uint("user_id", _user.ID),
+						zap.String("email", _user.Email),
+						zap.Error(err))
+					mailer.MailerFailed.WithLabelValues(mailer.LabelOpSend).Inc()
 				}
 			}
 


### PR DESCRIPTION
- Add BeforeCreate hook to validate email syntax before user creation
- Make email verification sending non-fatal during account creation
- Log warning when email fails to send but allow registration to succeed
- Track failed email sends with metrics


---

<!-- kody-pr-summary:start -->
Based on the code changes provided, here's a precise description for this pull request:

**Pull Request Description:**
This PR makes the user registration process more resilient by implementing email validation and handling email sending failures gracefully. The changes ensure that registration doesn't fail completely when email services encounter issues.

**Key Changes:**
1. **Email Validation**: Added email syntax validation during user creation using a verification service to catch invalid email addresses before account creation.

2. **Email Failure Handling**: Modified the account creation process to continue successfully even when email verification fails. Instead of returning an error, the system now logs a warning and creates a metrics counter for email failures, allowing the account to be created while tracking the email service issue.

3. **Email Configuration Enhancement**: Improved the mailer service configuration by adding HELO domain support, which can help with email deliverability and server compatibility.

The primary functional impact is that users can now successfully register accounts even if the email verification system encounters temporary issues, while still maintaining email validation for syntax correctness.
<!-- kody-pr-summary:end -->