### PR TITLE
fix(config): fallback to next path when config creation fails

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -20,6 +20,7 @@ type findConfigFileOptions struct {
 	CheckWritable   bool       // Check if existing files are writable
 	FS              FileSystem // Filesystem interface for operations
 	Core            bool
+	Logger          *zap.Logger
 }
 
 // findConfigFile searches for a config file in specified locations with more robust handling
@@ -59,6 +60,11 @@ func findConfigFile(options findConfigFileOptions, cm configmanager.Manager) (st
 			// File doesn't exist and we should create it
 			if err := CreateDefaultConfig(expandedPath, options.FS); err != nil {
 				// Failed to create, try next path
+				if options.Logger != nil {
+					options.Logger.Warn("failed to create config file, trying next path",
+						zap.String("path", expandedPath),
+						zap.Error(err))
+				}
 				continue
 			}
 			return expandedPath, nil
@@ -261,6 +267,7 @@ func NewManager(opts ...ManagerOption) (*ManagerDefault, error) {
 		CheckWritable:   true,
 		FS:              m.fs, // Use the configured filesystem
 		Core:            true,
+		Logger:          m.logger,
 	}, m.Manager)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find or create config file: %w", err)
@@ -430,6 +437,7 @@ func (m *ManagerDefault) getPluginConfigFile(pluginName, subDir string, configTy
 		CreateIfMissing: true,
 		CheckWritable:   true,
 		FS:              m.fs,
+		Logger:          m.logger,
 	}, m)
 	if err != nil {
 		return "", fmt.Errorf("failed to find/create config file for %s '%s': %w", configType, pluginName, err)
@@ -518,6 +526,7 @@ func (m *ManagerDefault) ConfigureService(pluginName string, serviceName string,
 		CreateIfMissing: true,
 		CheckWritable:   true,
 		FS:              m.fs,
+		Logger:          m.logger,
 	}, m)
 	if err != nil {
 		return fmt.Errorf("failed to find/create config file for Service '%s/%s': %w", pluginName, serviceName, err)

--- a/config/manager.go
+++ b/config/manager.go
@@ -58,7 +58,8 @@ func findConfigFile(options findConfigFileOptions, cm configmanager.Manager) (st
 		if os.IsNotExist(err) && options.CreateIfMissing {
 			// File doesn't exist and we should create it
 			if err := CreateDefaultConfig(expandedPath, options.FS); err != nil {
-				return "", fmt.Errorf("failed to create default config at %s: %w", expandedPath, err)
+				// Failed to create, try next path
+				continue
 			}
 			return expandedPath, nil
 		}

--- a/config/manager_test.go
+++ b/config/manager_test.go
@@ -90,6 +90,58 @@ func (m *MockFileSystem) Create(name string) (*os.File, error) {
 	return tmpfile, nil
 }
 
+// conditionalMkdirAllFS is a mock filesystem that fails MkdirAll on specific paths
+type conditionalMkdirAllFS struct {
+	Files    map[string][]byte
+	Dirs     map[string]bool
+	failPath string // Path on which MkdirAll should fail
+}
+
+func (m *conditionalMkdirAllFS) Stat(name string) (os.FileInfo, error) {
+	if _, ok := m.Files[name]; ok || m.Dirs[name] {
+		return mockFileInfo{name: name, isDir: m.Dirs[name]}, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *conditionalMkdirAllFS) MkdirAll(path string, perm os.FileMode) error {
+	// Check if the path contains the failPath
+	if m.failPath != "" && strings.HasPrefix(path, m.failPath) {
+		return os.ErrPermission
+	}
+	m.Dirs[path] = true
+	return nil
+}
+
+func (m *conditionalMkdirAllFS) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	if content, ok := m.Files[name]; ok {
+		tmpfile, err := os.CreateTemp("", "testfile")
+		if err != nil {
+			return nil, err
+		}
+		if _, err := tmpfile.Write(content); err != nil {
+			return nil, err
+		}
+		if err := tmpfile.Close(); err != nil {
+			return nil, err
+		}
+		return os.OpenFile(tmpfile.Name(), flag, perm)
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *conditionalMkdirAllFS) Create(name string) (*os.File, error) {
+	if m.Files == nil {
+		m.Files = make(map[string][]byte)
+	}
+	tmpfile, err := os.CreateTemp("", "testfile")
+	if err != nil {
+		return nil, err
+	}
+	m.Files[name] = []byte{}
+	return tmpfile, nil
+}
+
 type mockFileInfo struct {
 	name  string
 	size  int64
@@ -117,6 +169,7 @@ func TestFindConfigFile(t *testing.T) {
 			name: "File exists in default path",
 			options: findConfigFileOptions{
 				Paths: []string{"/etc/lumeweb/portal"},
+				Core:  true,
 			},
 			setup: func(h *testHelper) {
 				h.withMockFS(map[string][]byte{"/etc/lumeweb/portal/core.yaml": []byte("test")})
@@ -127,6 +180,7 @@ func TestFindConfigFile(t *testing.T) {
 			name: "File exists in home path",
 			options: findConfigFileOptions{
 				Paths: []string{"$HOME/.lumeweb/portal"},
+				Core:  true,
 			},
 			setup: func(h *testHelper) {
 				h.withMockFS(map[string][]byte{
@@ -136,9 +190,27 @@ func TestFindConfigFile(t *testing.T) {
 			expectedPath: filepath.Join(os.Getenv("HOME"), ".lumeweb/portal/core.yaml"),
 		},
 		{
+			name: "Create fails on first path with permission, succeeds on second",
+			options: findConfigFileOptions{
+				Paths:           []string{"/etc/lumeweb/portal", "/tmp"},
+				CreateIfMissing: true,
+				FS:              nil,
+				Core:            true,
+			},
+			setup: func(h *testHelper) {
+				h.fs = &conditionalMkdirAllFS{
+					Files:    make(map[string][]byte),
+					Dirs:     make(map[string]bool),
+					failPath: "/etc/lumeweb/portal",
+				}
+			},
+			expectedPath: "/tmp/core.yaml",
+		},
+		{
 			name: "File exists in current directory",
 			options: findConfigFileOptions{
 				Paths: []string{"./"},
+				Core:  true,
 			},
 			setup: func(h *testHelper) {
 				h.withMockFS(map[string][]byte{"core.yaml": []byte("test")})
@@ -150,6 +222,7 @@ func TestFindConfigFile(t *testing.T) {
 			options: findConfigFileOptions{
 				Paths: []string{"/etc/lumeweb/portal", "$HOME/.lumeweb/portal", "./"},
 				FS:    &MockFileSystem{},
+				Core:  true,
 			},
 			expectedError: "no valid config file found in paths: [/etc/lumeweb/portal $HOME/.lumeweb/portal ./]",
 		},
@@ -159,6 +232,7 @@ func TestFindConfigFile(t *testing.T) {
 				Paths:           []string{"/tmp"},
 				CreateIfMissing: true,
 				FS:              &MockFileSystem{},
+				Core:            true,
 			},
 			expectedPath: "/tmp/core.yaml",
 		},
@@ -167,6 +241,7 @@ func TestFindConfigFile(t *testing.T) {
 			options: findConfigFileOptions{
 				Paths:         []string{"/tmp"},
 				CheckWritable: true,
+				Core:          true,
 			},
 			setup: func(h *testHelper) {
 				h.fs = &MockFileSystem{
@@ -218,8 +293,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 		Dirs:  make(map[string]bool),
 	}
 
-	// Mock ConfigManager
-	cm, err := configmanager.NewConfigManager(
+	// Mock ConfigManager (not used in this test but kept for consistency)
+	_, err := configmanager.NewConfigManager(
 		[]source.ConfigSource{source.NewEnvConfigSource(ENV_PREFIX, ENV_SEPARATOR)},
 		configmanager.WithLogger(zap.NewNop()),
 	)
@@ -228,8 +303,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 	// Define test path
 	testPath := "/tmp/test_config.yaml"
 
-	// Execute createDefaultConfig
-	err = createDefaultConfig(testPath, fs)
+	// Execute CreateDefaultConfig
+	err = CreateDefaultConfig(testPath, fs)
 	require.NoError(t, err)
 
 	// Verify that the file was created in the mock file system
@@ -264,15 +339,19 @@ portal_name: "test_portal"
 	m, err := NewManager(WithConfigPaths([]string{tempDir}))
 	require.NoError(t, err)
 
+	// Configure a test plugin first so directories will be created on Init
+	err = m.ConfigureProtocol("test_plugin", newTestProtocolConfig())
+	require.NoError(t, err)
+
 	// Initialize
 	err = m.Init()
 	require.NoError(t, err)
 
 	// Verify directories were created
 	expectedDirs := []string{
-		filepath.Join(m.configDir, ProtoDir),
-		filepath.Join(m.configDir, APIDir),
-		filepath.Join(m.configDir, ServiceDir),
+		filepath.Join(m.configDir, PluginsDir, "test_plugin", ProtoDir),
+		filepath.Join(m.configDir, PluginsDir, "test_plugin", APIDir),
+		filepath.Join(m.configDir, PluginsDir, "test_plugin", ServiceDir),
 	}
 	for _, dir := range expectedDirs {
 		_, err := os.Stat(dir)
@@ -370,11 +449,11 @@ portal_name: test_portal
 			configFile := ""
 			switch tt.configType {
 			case "protocol":
-				configFile = filepath.Join(tempDir, ProtoDir, tt.pluginName+CONFIG_EXTENSION)
+				configFile = filepath.Join(tempDir, PluginsDir, tt.pluginName, ProtoDir, SectionConfigFile)
 			case "api":
-				configFile = filepath.Join(tempDir, APIDir, tt.pluginName+CONFIG_EXTENSION)
+				configFile = filepath.Join(tempDir, PluginsDir, tt.pluginName, APIDir, SectionConfigFile)
 			case "service":
-				configFile = filepath.Join(tempDir, ServiceDir, tt.pluginName+"_"+tt.serviceName+CONFIG_EXTENSION)
+				configFile = filepath.Join(tempDir, PluginsDir, tt.pluginName, ServiceDir, tt.serviceName+CONFIG_EXTENSION)
 			}
 
 			// Write test config
@@ -510,7 +589,7 @@ func createTempFile(t *testing.T, dir, content string) string {
 
 type testHelper struct {
 	t      *testing.T
-	fs     *MockFileSystem
+	fs     FileSystem
 	cmd    *cli.Command
 	logger *zap.Logger
 }


### PR DESCRIPTION
When findConfigFile fails to create a config file at one location
(e.g., permission denied on /etc/lumeweb/portal), it now continues
to try remaining paths instead of immediately returning an error.

This ensures the system gracefully falls back through default config
locations until one succeeds or all fail.

Changes:
- Modified findConfigFile to continue instead of returning error when
  CreateDefaultConfig fails
- Added test case with conditionalMkdirAllFS to verify fallback behavior
- Fixed related tests to match actual plugin directory structure


---

<!-- kody-pr-summary:start -->
 This pull request modifies the configuration file discovery logic to improve resilience when creating default configuration files.

**Functional Change:**
When the system attempts to create a default configuration file at a specified path (e.g., `/etc/lumeweb/portal`) and encounters a failure (such as permission denied), it now falls back to the next available path in the search list rather than terminating with an error. Previously, any failure during default config creation would immediately return an error, preventing the system from attempting alternative locations.

**Impact:**
This ensures the application can bootstrap successfully even when the primary configuration directory is not writable, by automatically trying secondary locations (such as user home directories or temporary paths) until it finds a writable location or exhausts all options.

**Test Coverage:**
Added specific test cases to verify the fallback behavior when directory creation fails due to permissions, along with updates to existing tests to align with the current configuration directory structure and API signatures.
<!-- kody-pr-summary:end -->