### PR TITLE
ci: migrate to external LumeWeb/workflows build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master, develop ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     uses: LumeWeb/workflows/.github/workflows/build-portal.yml@develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,12 @@
 name: Build
 
 on:
-    push:
-        branches:
-            - '**'
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
-    build:
-        uses: ./.github/workflows/_build.yml
+  build:
+    uses: LumeWeb/workflows/.github/workflows/build-portal.yml@develop
+    secrets: inherit

--- a/build.sh
+++ b/build.sh
@@ -1,26 +1,12 @@
 #!/bin/bash
 
-# Define the base command
-command="xportal build"
+set -e
 
-# Check if the XPORTAL_PLUGINS environment variable is set
-if [[ -n "$XPORTAL_PLUGINS" ]]; then
-  # Split the XPORTAL_PLUGINS value into an array
-  IFS=',' read -ra plugins <<< "$XPORTAL_PLUGINS"
+# Docker image for portal builder
+BUILDER_IMAGE="ghcr.io/lumeweb/portal-builder:ubuntu"
 
-  # Dynamically add plugins to the command
-  for plugin in "${plugins[@]}"
-  do
-    command+=" --with $plugin"
-  done
-
-  command+=" --replace go.lumeweb.com/portal=$(readlink -f .)"
-  command+=" --replace go.lumeweb.com/portal/core=$(readlink -f .)/core"
-  command+=" --replace go.lumeweb.com/portal/cmd=$(readlink -f .)/cmd"
-  command+=" --replace go.lumeweb.com/portal/service=$(readlink -f .)/service"
-  command+=" --replace go.lumeweb.com/portal/db=$(readlink -f .)/db"
-  command+=" --replace go.lumeweb.com/portal/config=$(readlink -f .)/config"
-fi
+# Get the absolute path of the project root
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Check if DEV environment variable is set
 if [[ -n "$DEV" ]]; then
@@ -28,6 +14,58 @@ if [[ -n "$DEV" ]]; then
   echo "Running in development mode with XPORTAL_DEBUG=1"
 fi
 
-# Execute the dynamically created command
-echo "Executing command: $command"
-eval "$command"
+# Create dist directory if it doesn't exist
+mkdir -p "${PROJECT_ROOT}/dist"
+
+# Get current git commit hash if available
+CURRENT_COMMIT=""
+if git rev-parse --git-dir > /dev/null 2>&1; then
+  CURRENT_COMMIT=$(git rev-parse HEAD)
+  echo "Current commit: ${CURRENT_COMMIT}"
+fi
+
+# Use current commit as default portal version, or 'develop' if not available
+PORTAL_VERSION="${CURRENT_COMMIT:-develop}"
+
+# Create plugin manifest
+echo "Creating portal-plugins.yaml manifest..."
+if [[ -n "$XPORTAL_PLUGINS" ]]; then
+  # Start with portal version
+  yq -n ".portalVersion = \"${PORTAL_VERSION}\"" > "${PROJECT_ROOT}/portal-plugins.yaml"
+  
+  # Parse plugins and add to manifest
+  IFS=',' read -ra plugins <<< "$XPORTAL_PLUGINS"
+  for plugin_entry in "${plugins[@]}"; do
+    # Check if plugin has @ syntax for git hash
+    if [[ "$plugin_entry" == *@* ]]; then
+      plugin_name="${plugin_entry%@*}"
+      plugin_hash="${plugin_entry#*@}"
+      yq -i ".plugins[\"$plugin_name\"] = \"$plugin_hash\"" "${PROJECT_ROOT}/portal-plugins.yaml"
+    else
+      # Use current commit for plugin if available
+      if [[ -n "$CURRENT_COMMIT" ]]; then
+        yq -i ".plugins[\"$plugin_entry\"] = \"$CURRENT_COMMIT\"" "${PROJECT_ROOT}/portal-plugins.yaml"
+      else
+        # No hash specified and no git repo available
+        yq -i ".plugins += [\"$plugin_entry\"]" "${PROJECT_ROOT}/portal-plugins.yaml"
+      fi
+    fi
+  done
+else
+  # Create manifest with portal version only (no plugins)
+  yq -n ".portalVersion = \"${PORTAL_VERSION}\"" > "${PROJECT_ROOT}/portal-plugins.yaml"
+fi
+
+echo "Created portal-plugins.yaml:"
+cat "${PROJECT_ROOT}/portal-plugins.yaml"
+
+# Run build in Docker container
+echo "Building portal using Docker container..."
+docker run --rm \
+  -v "${PROJECT_ROOT}:/workspace" \
+  -v "${PROJECT_ROOT}/dist:/dist" \
+  -e XPORTAL_DEBUG="${XPORTAL_DEBUG:-0}" \
+  "${BUILDER_IMAGE}" \
+  build-portal
+
+echo "Build completed successfully!"


### PR DESCRIPTION
- Update build.yml to use LumeWeb/workflows/build-portal.yml
- Remove local _build.yml workflow
- Restrict triggers to master and develop branches
- Add pull_request trigger


---

<!-- kody-pr-summary:start -->
 Migrates the CI build workflow from a local configuration to an external shared workflow hosted in the `LumeWeb/workflows` repository.

**Changes:**
- Replaces the local workflow reference (`./.github/workflows/_build.yml`) with the external reusable workflow `LumeWeb/workflows/.github/workflows/build-portal.yml@develop`
- Restricts trigger events to `master` and `develop` branches for both push and pull request events (previously triggered on all branches)
- Adds `secrets: inherit` to pass repository secrets to the external workflow
- Removes the concurrency configuration previously defined at the workflow level
<!-- kody-pr-summary:end -->