### PR TITLE
feat(config): add DNS resolver override support

### DIFF
--- a/config/core.go
+++ b/config/core.go
@@ -30,6 +30,7 @@ type CoreConfig struct {
 	Cron            CronConfig           `config:"cron"`
 	Account         AccountConfig        `config:"account"`
 	Observability   ObservabilityConfig  `config:"observability"`
+	DNSResolver     string               `config:"dns_resolver"`
 }
 
 func (c CoreConfig) Schema() z.ZogSchema {
@@ -66,6 +67,7 @@ func (c CoreConfig) Defaults() map[string]any {
 		"PortalName":      "",
 		"Port":            8080,
 		"Secure":          true,
+		"DNSResolver":     "",
 	}
 }
 

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -24,7 +24,7 @@ func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 			d := net.Dialer{
 				Timeout: time.Millisecond * time.Duration(3000),
 			}
-			return d.DialContext(ctx, "udp", dnsResolver+":53")
+			return d.DialContext(ctx, network, net.JoinHostPort(dnsResolver, "53"))
 		},
 	}
 }

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -1,0 +1,30 @@
+package dns
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+)
+
+// SetupDNSResolver configures the default DNS resolver to use a custom DNS server if specified.
+// This affects all networking operations including HTTP clients, SMTP, and other network connections.
+func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
+	if dnsResolver == "" {
+		return
+	}
+
+	logger.Info("Setting custom DNS resolver", zap.String("dns_resolver", dnsResolver))
+
+	net.DefaultResolver = &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: time.Millisecond * time.Duration(3000),
+			}
+			return d.DialContext(ctx, "udp", dnsResolver+":53")
+		},
+	}
+}

--- a/portal.go
+++ b/portal.go
@@ -12,6 +12,7 @@ import (
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db"
 	"go.lumeweb.com/portal/event"
+	pkgDNS "go.lumeweb.com/portal/internal/dns"
 	pkgReflect "go.lumeweb.com/portal/internal/reflect"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -40,6 +41,12 @@ func (p *PortalImpl) Init() error {
 	ctx := p.Context()
 	logger := ctx.Logger()
 	logger.Info("Initializing portal")
+
+	// Setup DNS override if configured
+	dnsResolver := ctx.Config().Config().Core.DNSResolver
+	if dnsResolver != "" {
+		pkgDNS.SetupDNSResolver(dnsResolver, logger)
+	}
 
 	// Fire init start event
 	if err := core.Fire(ctx, event.EVENT_INIT_START, event.NewInitStartEvent(ctx, ctx.GetContext())); err != nil {


### PR DESCRIPTION
Add DNSResolver configuration option to override default DNS resolver
for all networking operations including HTTP clients and SMTP.

- Add DNSResolver field to CoreConfig with empty string default
- Create internal/dns package with SetupDNSResolver function
- Apply DNS override during portal initialization when configured
- Uses net.DefaultResolver with custom dial function for DNS queries


---

<!-- kody-pr-summary:start -->
 This pull request introduces support for overriding the default DNS resolver used by the portal.

**Changes:**
- Added a new `dns_resolver` configuration option under core settings
- Implemented DNS resolver override functionality that, when configured, redirects all DNS resolution operations (affecting HTTP clients, SMTP, and other network connections) to the specified custom DNS server
- The override is applied during portal initialization if a non-empty resolver address is provided

**Configuration:**
- New field: `Core.DNSResolver` (string)
- Default: empty string (uses system default resolver)
- When set, uses the specified resolver on UDP port 53 with a 3-second timeout
<!-- kody-pr-summary:end -->