### PR TITLE
feat: add custom DNS resolver support for mail client

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -16,7 +17,9 @@ func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 		return
 	}
 
-	logger.Info("Setting custom DNS resolver", zap.String("dns_resolver", dnsResolver))
+	if logger != nil {
+		logger.Info("Setting custom DNS resolver", zap.String("dns_resolver", dnsResolver))
+	}
 
 	net.DefaultResolver = &net.Resolver{
 		PreferGo: true,
@@ -26,5 +29,43 @@ func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 			}
 			return d.DialContext(ctx, network, net.JoinHostPort(dnsResolver, "53"))
 		},
+	}
+}
+
+// CustomDialer returns a dial function that uses a custom DNS resolver.
+// Required for libraries using net.Dialer{} directly, which bypasses net.DefaultResolver.
+func CustomDialer(dnsResolver string) func(ctx context.Context, network, address string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("failed to split host:port: %w", err)
+		}
+
+		// Create a resolver that uses the custom DNS server
+		resolver := &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, netType, addr string) (net.Conn, error) {
+				d := net.Dialer{
+					Timeout: time.Millisecond * time.Duration(3000),
+				}
+				return d.DialContext(ctx, netType, net.JoinHostPort(dnsResolver, "53"))
+			},
+		}
+
+		// Resolve the hostname using the custom resolver
+		ips, err := resolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve %s: %w", host, err)
+		}
+
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("no IPs found for %s", host)
+		}
+
+		// Use the first IP address to dial
+		targetAddr := net.JoinHostPort(ips[0].String(), port)
+
+		d := net.Dialer{}
+		return d.DialContext(ctx, network, targetAddr)
 	}
 }

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"time"
 
@@ -35,37 +34,26 @@ func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 // CustomDialer returns a dial function that uses a custom DNS resolver.
 // Required for libraries using net.Dialer{} directly, which bypasses net.DefaultResolver.
 func CustomDialer(dnsResolver string) func(ctx context.Context, network, address string) (net.Conn, error) {
-	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		host, port, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, fmt.Errorf("failed to split host:port: %w", err)
+	if dnsResolver == "" {
+		return func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{}
+			return d.DialContext(ctx, network, address)
 		}
+	}
 
-		// Create a resolver that uses the custom DNS server
-		resolver := &net.Resolver{
-			PreferGo: true,
-			Dial: func(ctx context.Context, netType, addr string) (net.Conn, error) {
-				d := net.Dialer{
-					Timeout: time.Millisecond * time.Duration(3000),
-				}
-				return d.DialContext(ctx, netType, net.JoinHostPort(dnsResolver, "53"))
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		d := net.Dialer{
+			Timeout: time.Second * 30,
+			Resolver: &net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, netType, addr string) (net.Conn, error) {
+					dd := net.Dialer{
+						Timeout: time.Millisecond * time.Duration(3000),
+					}
+					return dd.DialContext(ctx, netType, net.JoinHostPort(dnsResolver, "53"))
+				},
 			},
 		}
-
-		// Resolve the hostname using the custom resolver
-		ips, err := resolver.LookupIPAddr(ctx, host)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve %s: %w", host, err)
-		}
-
-		if len(ips) == 0 {
-			return nil, fmt.Errorf("no IPs found for %s", host)
-		}
-
-		// Use the first IP address to dial
-		targetAddr := net.JoinHostPort(ips[0].String(), port)
-
-		d := net.Dialer{}
-		return d.DialContext(ctx, network, targetAddr)
+		return d.DialContext(ctx, network, address)
 	}
 }

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -30,8 +30,11 @@ func TestSetupDNSResolver(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Save original resolver
+			// Save original resolver and ensure restoration even on panic
 			originalResolver := net.DefaultResolver
+			defer func() {
+				net.DefaultResolver = originalResolver
+			}()
 
 			// Call SetupDNSResolver with a test logger
 			logger := core.NewLogger(nil, zap.NewNop())
@@ -47,9 +50,6 @@ func TestSetupDNSResolver(t *testing.T) {
 					t.Error("Expected net.DefaultResolver to remain unchanged")
 				}
 			}
-
-			// Restore original resolver
-			net.DefaultResolver = originalResolver
 		})
 	}
 }

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -1,0 +1,132 @@
+package dns
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+)
+
+func TestSetupDNSResolver(t *testing.T) {
+	tests := []struct {
+		name        string
+		dnsResolver string
+		wantSet     bool
+	}{
+		{
+			name:        "empty resolver does not modify default resolver",
+			dnsResolver: "",
+			wantSet:     false,
+		},
+		{
+			name:        "valid resolver configures default resolver",
+			dnsResolver: "8.8.8.8",
+			wantSet:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original resolver
+			originalResolver := net.DefaultResolver
+
+			// Call SetupDNSResolver with a test logger
+			logger := core.NewLogger(nil, zap.NewNop())
+			SetupDNSResolver(tt.dnsResolver, logger)
+
+			// Check if DefaultResolver was modified
+			if tt.wantSet {
+				if net.DefaultResolver == originalResolver {
+					t.Error("Expected net.DefaultResolver to be modified")
+				}
+			} else {
+				if net.DefaultResolver != originalResolver {
+					t.Error("Expected net.DefaultResolver to remain unchanged")
+				}
+			}
+
+			// Restore original resolver
+			net.DefaultResolver = originalResolver
+		})
+	}
+}
+
+func TestCustomDialer(t *testing.T) {
+	dnsResolver := "127.0.0.1"
+	dialer := CustomDialer(dnsResolver)
+
+	if dialer == nil {
+		t.Fatal("Expected non-nil dialer function")
+	}
+
+	ctx := context.Background()
+
+	// Test with invalid address format
+	t.Run("invalid address format", func(t *testing.T) {
+		_, err := dialer(ctx, "tcp", "invalid-address")
+		if err == nil {
+			t.Error("Expected error for invalid address format")
+		}
+	})
+
+	// Test with valid address format (will fail to resolve, but validates parsing)
+	t.Run("valid address format with resolution", func(t *testing.T) {
+		// This will fail to actually connect since we're using a fake DNS server,
+		// but it should at least parse the address correctly
+		conn, err := dialer(ctx, "tcp", "example.com:25")
+		if err != nil {
+			// Expected to fail due to DNS resolution, but not due to parsing
+			if len(err.Error()) > 0 {
+				t.Logf("Expected resolution failure: %v", err)
+			}
+		}
+		if conn != nil {
+			conn.Close()
+		}
+	})
+}
+
+func TestCustomDialerResolution(t *testing.T) {
+	// This test verifies that CustomDialer properly resolves hostnames
+	// using the configured DNS server
+
+	dnsResolver := "8.8.8.8"
+	dialer := CustomDialer(dnsResolver)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Test with a well-known hostname that should resolve
+	t.Run("resolves known hostname", func(t *testing.T) {
+		conn, err := dialer(ctx, "tcp", "dns.google:53")
+		if err != nil {
+			// Connection might fail due to network, but resolution should work
+			// Check if error is related to DNS resolution vs connection
+			t.Logf("Connection error (expected if network unavailable): %v", err)
+		}
+		if conn != nil {
+			conn.Close()
+		}
+	})
+}
+
+func TestCustomDialerIPv6(t *testing.T) {
+	// Test that IPv6 addresses are properly formatted
+	dnsResolver := "::1"
+	dialer := CustomDialer(dnsResolver)
+	ctx := context.Background()
+
+	// Test with IPv6 address in host:port format
+	t.Run("handles IPv6 addresses", func(t *testing.T) {
+		// This should properly join IPv6 address with port
+		conn, err := dialer(ctx, "tcp", "[::1]:25")
+		if err != nil {
+			t.Logf("Expected connection failure (no server): %v", err)
+		}
+		if conn != nil {
+			conn.Close()
+		}
+	})
+}

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -171,13 +171,13 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 				options = append(options, mail.WithHELO(domain))
 			}
 
-			// Add custom dialer if DNS resolver is configured
+			// Add custom dialer for DNS resolver
 			dnsResolver := ctx.Config().Config().Core.DNSResolver
-			if dnsResolver != "" {
+			if dialer := pkgDNS.CustomDialer(dnsResolver); dialer != nil {
 				ctx.Logger().Debug("Configuring mail client with custom DNS resolver",
 					zap.String("dns_resolver", dnsResolver),
 				)
-				options = append(options, mail.WithDialContextFunc(pkgDNS.CustomDialer(dnsResolver)))
+				options = append(options, mail.WithDialContextFunc(dialer))
 			}
 
 			client, err := mail.NewClient(mailCfg.Host, options...)

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/wneessen/go-mail"
 	"go.lumeweb.com/portal/core"
+	pkgDNS "go.lumeweb.com/portal/internal/dns"
 	"go.lumeweb.com/portal/service/internal/mailer"
 	mailerMetrics "go.lumeweb.com/portal/service/internal/mailer"
 	"go.uber.org/zap"
@@ -168,6 +169,15 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 					domain = ctx.Config().Config().Core.Domain
 				}
 				options = append(options, mail.WithHELO(domain))
+			}
+
+			// Add custom dialer if DNS resolver is configured
+			dnsResolver := ctx.Config().Config().Core.DNSResolver
+			if dnsResolver != "" {
+				ctx.Logger().Debug("Configuring mail client with custom DNS resolver",
+					zap.String("dns_resolver", dnsResolver),
+				)
+				options = append(options, mail.WithDialContextFunc(pkgDNS.CustomDialer(dnsResolver)))
 			}
 
 			client, err := mail.NewClient(mailCfg.Host, options...)


### PR DESCRIPTION
Mail client now respects portal.core.dns_resolver config setting.
Previously, go-mail used net.Dialer{} directly which bypassed
net.DefaultResolver and system DNS settings.

Changes:
- Added CustomDialer function in internal/dns package that returns
  a dial function using the configured DNS server for resolution
- Updated mailer service to use mail.WithDialContextFunc when
  DNS resolver is configured
- Added comprehensive unit tests for DNS resolution functionality

This ensures mail client uses the same DNS resolver as other
networking operations in the application.


---

<!-- kody-pr-summary:start -->
 This pull request adds custom DNS resolver support specifically for the mail client to ensure DNS resolution respects configured custom DNS servers.

**Key Changes:**

1. **Added `CustomDialer` function** (`internal/dns/dns.go`): Introduces a new dial function that explicitly uses a custom DNS resolver when establishing connections. This addresses a gap where libraries using `net.Dialer{}` directly (such as the mail client) bypass `net.DefaultResolver`, causing them to ignore globally configured custom DNS settings.

2. **Integrated custom DNS into mailer service** (`service/mailer.go`): Updated the mail client initialization to use the new `CustomDialer` when a DNS resolver is configured in the core configuration, ensuring outbound mail connections resolve hostnames through the specified DNS server.

3. **Defensive nil check** (`internal/dns/dns.go`): Added a nil check for the logger in `SetupDNSResolver` to prevent potential panics when the logger is not initialized.

4. **Comprehensive test coverage** (`internal/dns/dns_test.go`): Added unit tests covering the DNS resolver setup, custom dialer functionality, address parsing, hostname resolution, and IPv6 handling.
<!-- kody-pr-summary:end -->