### PR TITLE
fix: move DNS resolver setup after config init

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -42,12 +42,6 @@ func (p *PortalImpl) Init() error {
 	logger := ctx.Logger()
 	logger.Info("Initializing portal")
 
-	// Setup DNS override if configured
-	dnsResolver := ctx.Config().Config().Core.DNSResolver
-	if dnsResolver != "" {
-		pkgDNS.SetupDNSResolver(dnsResolver, logger)
-	}
-
 	// Fire init start event
 	if err := core.Fire(ctx, event.EVENT_INIT_START, event.NewInitStartEvent(ctx, ctx.GetContext())); err != nil {
 		logger.Error("Error firing init start event", zap.Error(err))
@@ -136,6 +130,12 @@ func (p *PortalImpl) Init() error {
 	}
 
 	logger.SetLevelFromConfig()
+
+	// Setup DNS override if configured
+	dnsResolver := ctx.Config().Config().Core.DNSResolver
+	if dnsResolver != "" {
+		pkgDNS.SetupDNSResolver(dnsResolver, logger)
+	}
 
 	// Stage 3: Database & Models Setup
 	// Initialize database connection and register all data models


### PR DESCRIPTION
SetupDNSResolver cannot be called before ctx.Config().Init() because
Config().Config() returns nil until config is initialized.
Moved the DNS resolver setup to after config initialization.


---

<!-- kody-pr-summary:start -->
 Moves the DNS resolver initialization to occur later in the portal startup sequence, specifically after the logger configuration is set from the config.

This fixes an initialization order issue where the DNS resolver was being set up at the beginning of the `Init()` method, potentially before the configuration was fully initialized. The DNS resolver setup now executes after `logger.SetLevelFromConfig()`, ensuring the configuration is properly loaded before attempting to read and apply the custom DNS resolver setting.
<!-- kody-pr-summary:end -->