### PR TITLE
feat(dns): add custom DNS resolver port support

### DIFF
--- a/config/core.go
+++ b/config/core.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net"
+	"strings"
 	z "github.com/Oudwins/zog"
 	"github.com/docker/go-units"
 	"go.lumeweb.com/configmanager"
@@ -86,6 +87,13 @@ func (c CoreConfig) DNSResolverAddr() (host string, port string) {
 	h, p, err := net.SplitHostPort(c.DNSResolver)
 	if err != nil {
 		// SplitHostPort fails if there's no port, which is expected.
+		// Check if it's a bracketed IPv6 address without port.
+		// Trim brackets and validate it's a valid IP address.
+		host := strings.Trim(c.DNSResolver, "[]")
+		if net.ParseIP(host) != nil && host != c.DNSResolver {
+			// Was bracketed and is a valid IP
+			return host, "53"
+		}
 		// Treat the entire string as the host and use default port.
 		return c.DNSResolver, "53"
 	}
@@ -95,4 +103,14 @@ func (c CoreConfig) DNSResolverAddr() (host string, port string) {
 	}
 
 	return h, p
+}
+
+// DNSResolverString returns the DNS resolver address in host:port format.
+// Returns empty string if no DNS resolver is configured.
+func (c CoreConfig) DNSResolverString() string {
+	host, port := c.DNSResolverAddr()
+	if host == "" {
+		return ""
+	}
+	return net.JoinHostPort(host, port)
 }

--- a/config/core.go
+++ b/config/core.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	z "github.com/Oudwins/zog"
 	"github.com/docker/go-units"
 	"go.lumeweb.com/configmanager"
@@ -73,4 +74,25 @@ func (c CoreConfig) Defaults() map[string]any {
 
 func (c CoreConfig) ClusterEnabled() bool {
 	return c.Clustered != nil && c.Clustered.Enabled
+}
+
+// DNSResolverAddr returns the DNS resolver host and port.
+// If DNSResolver contains a port, it extracts both. Otherwise, it returns the host with default port 53.
+func (c CoreConfig) DNSResolverAddr() (host string, port string) {
+	if c.DNSResolver == "" {
+		return "", ""
+	}
+
+	h, p, err := net.SplitHostPort(c.DNSResolver)
+	if err != nil {
+		// SplitHostPort fails if there's no port, which is expected.
+		// Treat the entire string as the host and use default port.
+		return c.DNSResolver, "53"
+	}
+
+	if p == "" {
+		return h, "53"
+	}
+
+	return h, p
 }

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -26,7 +26,7 @@ func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 			d := net.Dialer{
 				Timeout: time.Millisecond * time.Duration(3000),
 			}
-			return d.DialContext(ctx, network, net.JoinHostPort(dnsResolver, "53"))
+			return d.DialContext(ctx, network, dnsResolver)
 		},
 	}
 }
@@ -50,7 +50,7 @@ func CustomDialer(dnsResolver string) func(ctx context.Context, network, address
 					dd := net.Dialer{
 						Timeout: time.Millisecond * time.Duration(3000),
 					}
-					return dd.DialContext(ctx, netType, net.JoinHostPort(dnsResolver, "53"))
+					return dd.DialContext(ctx, netType, dnsResolver)
 				},
 			},
 		}

--- a/portal.go
+++ b/portal.go
@@ -3,7 +3,6 @@ package portal
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"reflect"
 	"sync"
@@ -133,9 +132,7 @@ func (p *PortalImpl) Init() error {
 	logger.SetLevelFromConfig()
 
 	// Setup DNS override if configured
-	dnsResolverHost, dnsResolverPort := ctx.Config().Config().Core.DNSResolverAddr()
-	if dnsResolverHost != "" {
-		dnsResolver := net.JoinHostPort(dnsResolverHost, dnsResolverPort)
+	if dnsResolver := ctx.Config().Config().Core.DNSResolverString(); dnsResolver != "" {
 		pkgDNS.SetupDNSResolver(dnsResolver, logger)
 	}
 

--- a/portal.go
+++ b/portal.go
@@ -3,6 +3,7 @@ package portal
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"reflect"
 	"sync"
@@ -132,8 +133,9 @@ func (p *PortalImpl) Init() error {
 	logger.SetLevelFromConfig()
 
 	// Setup DNS override if configured
-	dnsResolver := ctx.Config().Config().Core.DNSResolver
-	if dnsResolver != "" {
+	dnsResolverHost, dnsResolverPort := ctx.Config().Config().Core.DNSResolverAddr()
+	if dnsResolverHost != "" {
+		dnsResolver := net.JoinHostPort(dnsResolverHost, dnsResolverPort)
 		pkgDNS.SetupDNSResolver(dnsResolver, logger)
 	}
 

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"io/fs"
+	"net"
 	"path"
 	"strings"
 	"text/template"
@@ -172,8 +173,10 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 			}
 
 			// Add custom dialer for DNS resolver
-			dnsResolver := ctx.Config().Config().Core.DNSResolver
-			if dialer := pkgDNS.CustomDialer(dnsResolver); dialer != nil {
+			dnsResolverHost, dnsResolverPort := ctx.Config().Config().Core.DNSResolverAddr()
+			if dnsResolverHost != "" {
+				dnsResolver := net.JoinHostPort(dnsResolverHost, dnsResolverPort)
+				dialer := pkgDNS.CustomDialer(dnsResolver)
 				ctx.Logger().Debug("Configuring mail client with custom DNS resolver",
 					zap.String("dns_resolver", dnsResolver),
 				)

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"io/fs"
-	"net"
 	"path"
 	"strings"
 	"text/template"
@@ -173,9 +172,7 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 			}
 
 			// Add custom dialer for DNS resolver
-			dnsResolverHost, dnsResolverPort := ctx.Config().Config().Core.DNSResolverAddr()
-			if dnsResolverHost != "" {
-				dnsResolver := net.JoinHostPort(dnsResolverHost, dnsResolverPort)
+			if dnsResolver := ctx.Config().Config().Core.DNSResolverString(); dnsResolver != "" {
 				dialer := pkgDNS.CustomDialer(dnsResolver)
 				ctx.Logger().Debug("Configuring mail client with custom DNS resolver",
 					zap.String("dns_resolver", dnsResolver),


### PR DESCRIPTION
- Add DNSResolverAddr() helper method to CoreConfig
- Parse DNS resolver string to extract host and optional port
- Default to port 53 if not specified
- Update SetupDNSResolver and CustomDialer to use parsed address
- Update callers to use new helper method


---

<!-- kody-pr-summary:start -->
 Add support for specifying custom ports in DNS resolver configuration. Previously, the DNS resolver was hardcoded to use port 53. This change allows users to configure DNS resolvers with custom ports (e.g., `8.8.8.8:5353`) while maintaining backward compatibility by defaulting to port 53 when no port is specified.

**Changes:**
- Added `DNSResolverAddr()` method to `CoreConfig` that parses the DNS resolver configuration to extract host and port, defaulting to port 53 when not provided
- Updated portal initialization to use the new method when configuring the global DNS resolver
- Updated mailer service to support custom DNS resolver ports for SMTP connections
- Modified internal DNS package functions to accept pre-formatted `host:port` addresses rather than hardcoding port 53
<!-- kody-pr-summary:end -->