### PR TITLE
fix(dns): implement custom DNS resolution with monkey-patching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/go-co-op/gocron/mocks/v2 v2.0.0-20260128162720-c4a0fed4ed3e
 	github.com/go-co-op/gocron/v2 v2.19.1
 	github.com/go-gorm/caches/v4 v4.0.5
+	github.com/go-kiss/monkey v0.0.0-20240508030602-d03795257a64
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/uuid v1.6.0
@@ -37,6 +38,7 @@ require (
 	github.com/labstack/echo-contrib v0.17.4
 	github.com/labstack/echo/v4 v4.15.0
 	github.com/looplab/fsm v1.0.3
+	github.com/miekg/dns v1.1.72
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/pquerna/otp v1.5.0
@@ -187,6 +189,7 @@ require (
 	github.com/gotd/contrib v0.21.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hbollon/go-edlib v1.6.0 // indirect
+	github.com/huandu/go-tls v1.0.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
@@ -227,6 +230,8 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/arch v0.0.0-20210901143047-ebb09ed340f1 // indirect
+	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -3,14 +3,53 @@ package dns
 import (
 	"context"
 	"net"
+	"reflect"
 	"time"
 
+	"github.com/go-kiss/monkey"
+	"github.com/miekg/dns"
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
 )
 
-// SetupDNSResolver configures the default DNS resolver to use a custom DNS server if specified.
-// This affects all networking operations including HTTP clients, SMTP, and other network connections.
+var customDNSAddr string
+
+func customLookupMX(name string) ([]*net.MX, error) {
+	if customDNSAddr == "" {
+		return net.DefaultResolver.LookupMX(context.Background(), name)
+	}
+
+	c := &dns.Client{Timeout: 5 * time.Second}
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(name), dns.TypeMX)
+	m.RecursionDesired = true
+
+	r, _, err := c.Exchange(m, customDNSAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	var mxRecords []*net.MX
+	for _, ans := range r.Answer {
+		if mx, ok := ans.(*dns.MX); ok {
+			mxRecords = append(mxRecords, &net.MX{
+				Host: mx.Mx,
+				Pref: uint16(mx.Preference),
+			})
+		}
+	}
+
+	if len(mxRecords) == 0 {
+		return nil, &net.DNSError{
+			Name:       name,
+			Err:        "no such host",
+			IsNotFound: true,
+		}
+	}
+
+	return mxRecords, nil
+}
+
 func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 	if dnsResolver == "" {
 		return
@@ -20,37 +59,39 @@ func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 		logger.Info("Setting custom DNS resolver", zap.String("dns_resolver", dnsResolver))
 	}
 
-	net.DefaultResolver = &net.Resolver{
+	customDNSAddr = dnsResolver
+
+	customResolver := &net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			d := net.Dialer{
-				Timeout: time.Millisecond * time.Duration(3000),
-			}
+			d := net.Dialer{Timeout: 3 * time.Second}
 			return d.DialContext(ctx, network, dnsResolver)
 		},
 	}
+
+	net.DefaultResolver = customResolver
+
+	resolverType := reflect.TypeOf(customResolver)
+	monkey.PatchInstanceMethod(resolverType, "LookupMX", func(r *net.Resolver, ctx context.Context, name string) ([]*net.MX, error) {
+		return customLookupMX(name)
+	})
 }
 
-// CustomDialer returns a dial function that uses a custom DNS resolver.
-// Required for libraries using net.Dialer{} directly, which bypasses net.DefaultResolver.
 func CustomDialer(dnsResolver string) func(ctx context.Context, network, address string) (net.Conn, error) {
 	if dnsResolver == "" {
 		return func(ctx context.Context, network, address string) (net.Conn, error) {
-			d := net.Dialer{}
-			return d.DialContext(ctx, network, address)
+			return (&net.Dialer{}).DialContext(ctx, network, address)
 		}
 	}
 
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
 		d := net.Dialer{
-			Timeout: time.Second * 30,
+			Timeout: 30 * time.Second,
 			Resolver: &net.Resolver{
 				PreferGo: true,
-				Dial: func(ctx context.Context, netType, addr string) (net.Conn, error) {
-					dd := net.Dialer{
-						Timeout: time.Millisecond * time.Duration(3000),
-					}
-					return dd.DialContext(ctx, netType, dnsResolver)
+				Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					dd := net.Dialer{Timeout: 3 * time.Second}
+					return dd.DialContext(ctx, "udp", dnsResolver)
 				},
 			},
 		}

--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"reflect"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-kiss/monkey"
@@ -12,11 +13,12 @@ import (
 	"go.uber.org/zap"
 )
 
-var customDNSAddr string
+var customDNSAddr atomic.Value // stores string
 
-func customLookupMX(name string) ([]*net.MX, error) {
-	if customDNSAddr == "" {
-		return net.DefaultResolver.LookupMX(context.Background(), name)
+func customLookupMX(ctx context.Context, name string) ([]*net.MX, error) {
+	addr, _ := customDNSAddr.Load().(string)
+	if addr == "" {
+		return net.DefaultResolver.LookupMX(ctx, name)
 	}
 
 	c := &dns.Client{Timeout: 5 * time.Second}
@@ -24,7 +26,7 @@ func customLookupMX(name string) ([]*net.MX, error) {
 	m.SetQuestion(dns.Fqdn(name), dns.TypeMX)
 	m.RecursionDesired = true
 
-	r, _, err := c.Exchange(m, customDNSAddr)
+	r, _, err := c.Exchange(m, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +61,7 @@ func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 		logger.Info("Setting custom DNS resolver", zap.String("dns_resolver", dnsResolver))
 	}
 
-	customDNSAddr = dnsResolver
+	customDNSAddr.Store(dnsResolver)
 
 	customResolver := &net.Resolver{
 		PreferGo: true,
@@ -73,7 +75,7 @@ func SetupDNSResolver(dnsResolver string, logger *core.Logger) {
 
 	resolverType := reflect.TypeOf(customResolver)
 	monkey.PatchInstanceMethod(resolverType, "LookupMX", func(r *net.Resolver, ctx context.Context, name string) ([]*net.MX, error) {
-		return customLookupMX(name)
+		return customLookupMX(ctx, name)
 	})
 }
 
@@ -89,9 +91,9 @@ func CustomDialer(dnsResolver string) func(ctx context.Context, network, address
 			Timeout: 30 * time.Second,
 			Resolver: &net.Resolver{
 				PreferGo: true,
-				Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
 					dd := net.Dialer{Timeout: 3 * time.Second}
-					return dd.DialContext(ctx, "udp", dnsResolver)
+					return dd.DialContext(ctx, network, dnsResolver)
 				},
 			},
 		}

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -70,24 +70,25 @@ func TestCustomDialer(t *testing.T) {
 	})
 
 	t.Run("valid address format", func(t *testing.T) {
-		conn, err := dialer(ctx, "tcp", "example.com:25")
-		if err != nil && conn != nil {
+		conn, _ := dialer(ctx, "tcp", "example.com:25")
+		if conn != nil {
 			conn.Close()
 		}
 	})
 }
 
-const mockDNSPort = "15353"
 const mockMXRecord = "mock-mx-server.test.local."
 
 func startMockDNSServer(t *testing.T) (*dns.Server, string) {
-	addr := "127.0.0.1:" + mockDNSPort
 	server := &dns.Server{
-		Addr: addr,
+		Addr: "127.0.0.1:0",
 		Net:  "udp",
 	}
 
 	server.Handler = dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		if len(r.Question) == 0 {
+			return
+		}
 		m := new(dns.Msg)
 		m.SetReply(r)
 		m.Answer = append(m.Answer, &dns.MX{
@@ -103,11 +104,22 @@ func startMockDNSServer(t *testing.T) (*dns.Server, string) {
 		w.WriteMsg(m)
 	})
 
+	ready := make(chan struct{})
+	server.NotifyStartedFunc = func() { close(ready) }
+
 	go func() {
-		server.ListenAndServe()
+		if err := server.ListenAndServe(); err != nil {
+			t.Errorf("mock DNS server failed: %v", err)
+		}
 	}()
 
-	time.Sleep(1 * time.Second)
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for mock DNS server")
+	}
+	
+	addr := server.PacketConn.LocalAddr().String()
 	return server, addr
 }
 

--- a/internal/dns/dns_test.go
+++ b/internal/dns/dns_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/miekg/dns"
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
 )
@@ -30,17 +31,14 @@ func TestSetupDNSResolver(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Save original resolver and ensure restoration even on panic
 			originalResolver := net.DefaultResolver
 			defer func() {
 				net.DefaultResolver = originalResolver
 			}()
 
-			// Call SetupDNSResolver with a test logger
 			logger := core.NewLogger(nil, zap.NewNop())
 			SetupDNSResolver(tt.dnsResolver, logger)
 
-			// Check if DefaultResolver was modified
 			if tt.wantSet {
 				if net.DefaultResolver == originalResolver {
 					t.Error("Expected net.DefaultResolver to be modified")
@@ -64,7 +62,6 @@ func TestCustomDialer(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Test with invalid address format
 	t.Run("invalid address format", func(t *testing.T) {
 		_, err := dialer(ctx, "tcp", "invalid-address")
 		if err == nil {
@@ -72,61 +69,82 @@ func TestCustomDialer(t *testing.T) {
 		}
 	})
 
-	// Test with valid address format (will fail to resolve, but validates parsing)
-	t.Run("valid address format with resolution", func(t *testing.T) {
-		// This will fail to actually connect since we're using a fake DNS server,
-		// but it should at least parse the address correctly
+	t.Run("valid address format", func(t *testing.T) {
 		conn, err := dialer(ctx, "tcp", "example.com:25")
-		if err != nil {
-			// Expected to fail due to DNS resolution, but not due to parsing
-			if len(err.Error()) > 0 {
-				t.Logf("Expected resolution failure: %v", err)
-			}
-		}
-		if conn != nil {
+		if err != nil && conn != nil {
 			conn.Close()
 		}
 	})
 }
 
-func TestCustomDialerResolution(t *testing.T) {
-	// This test verifies that CustomDialer properly resolves hostnames
-	// using the configured DNS server
+const mockDNSPort = "15353"
+const mockMXRecord = "mock-mx-server.test.local."
 
-	dnsResolver := "8.8.8.8"
-	dialer := CustomDialer(dnsResolver)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+func startMockDNSServer(t *testing.T) (*dns.Server, string) {
+	addr := "127.0.0.1:" + mockDNSPort
+	server := &dns.Server{
+		Addr: addr,
+		Net:  "udp",
+	}
 
-	// Test with a well-known hostname that should resolve
-	t.Run("resolves known hostname", func(t *testing.T) {
-		conn, err := dialer(ctx, "tcp", "dns.google:53")
-		if err != nil {
-			// Connection might fail due to network, but resolution should work
-			// Check if error is related to DNS resolution vs connection
-			t.Logf("Connection error (expected if network unavailable): %v", err)
-		}
-		if conn != nil {
-			conn.Close()
-		}
+	server.Handler = dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = append(m.Answer, &dns.MX{
+			Hdr: dns.RR_Header{
+				Name:   r.Question[0].Name,
+				Rrtype: dns.TypeMX,
+				Class:  dns.ClassINET,
+				Ttl:    3600,
+			},
+			Preference: 10,
+			Mx:         mockMXRecord,
+		})
+		w.WriteMsg(m)
 	})
+
+	go func() {
+		server.ListenAndServe()
+	}()
+
+	time.Sleep(1 * time.Second)
+	return server, addr
 }
 
-func TestCustomDialerIPv6(t *testing.T) {
-	// Test that IPv6 addresses are properly formatted
-	dnsResolver := "::1"
-	dialer := CustomDialer(dnsResolver)
-	ctx := context.Background()
+func verifyMockMXRecord(mxRecords []*net.MX) bool {
+	for _, mx := range mxRecords {
+		if mx.Host == mockMXRecord {
+			return true
+		}
+	}
+	return false
+}
 
-	// Test with IPv6 address in host:port format
-	t.Run("handles IPv6 addresses", func(t *testing.T) {
-		// This should properly join IPv6 address with port
-		conn, err := dialer(ctx, "tcp", "[::1]:25")
-		if err != nil {
-			t.Logf("Expected connection failure (no server): %v", err)
-		}
-		if conn != nil {
-			conn.Close()
-		}
-	})
+func runSetupDNSResolverTest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	originalResolver := net.DefaultResolver
+	defer func() {
+		net.DefaultResolver = originalResolver
+	}()
+
+	mockServer, mockAddr := startMockDNSServer(t)
+	defer mockServer.Shutdown()
+
+	SetupDNSResolver(mockAddr, nil)
+
+	mxRecords, err := net.LookupMX("example.com")
+	if err != nil {
+		t.Fatalf("net.LookupMX error: %v", err)
+	}
+
+	if !verifyMockMXRecord(mxRecords) {
+		t.Error("Expected mock MX record from SetupDNSResolver")
+	}
+}
+
+func TestSetupDNSResolverIntegration(t *testing.T) {
+	runSetupDNSResolverTest(t)
 }


### PR DESCRIPTION
- Add github.com/go-kiss/monkey for monkey-patching
- Add github.com/miekg/dns for direct DNS queries
- Implement customLookupMX() using miekg/dns to bypass stdlib bug
- Patch *net.Resolver.LookupMX method to use custom DNS server
- Clean up and consolidate DNS tests

Fixes issue where net.LookupMX doesn't respect net.DefaultResolver's
custom dial function, causing it to read /etc/resolv.conf instead of
using the configured custom DNS server.


---

<!-- kody-pr-summary:start -->
 This PR fixes custom DNS resolution by implementing a custom MX record lookup mechanism and applying it through monkey-patching to ensure all DNS queries respect the configured DNS server.

**Key Changes:**

- **Custom MX Lookup Implementation**: Added `customLookupMX` function that queries MX records using the `miekg/dns` library directly against the custom DNS server, ensuring MX lookups (commonly used for email validation) are not resolved through the system default resolver.

- **Monkey-Patching**: Uses `github.com/go-kiss/monkey` to patch `net.Resolver.LookupMX` at runtime, redirecting MX queries to the custom DNS server when one is configured. This addresses the limitation where setting `net.DefaultResolver` alone does not intercept all DNS lookup methods.

- **DNS Resolver Setup**: Modified `SetupDNSResolver` to store the custom DNS address globally and apply the monkey patch after setting the default resolver.

- **Custom Dialer Improvements**: Refactored `CustomDialer` for cleaner syntax and explicitly specifies UDP protocol when connecting to the custom DNS server.

- **Integration Testing**: Added comprehensive integration tests with a mock DNS server (`startMockDNSServer`) that validates the custom DNS resolution actually works by verifying that `net.LookupMX` returns records from the mocked custom server rather than the system resolver.
<!-- kody-pr-summary:end -->