### PR TITLE
feat(mailer): add TLS policy configuration support

### DIFF
--- a/config/mail.go
+++ b/config/mail.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/Oudwins/zog"
+	z "github.com/Oudwins/zog"
 	"github.com/wneessen/go-mail"
 	"go.lumeweb.com/configmanager"
 )
@@ -15,7 +15,7 @@ type MailConfig struct {
 	Host      string                 `config:"host"`
 	Port      int                    `config:"port"`
 	SSL       bool                   `config:"ssl"`
-	TLSPolicy mail.TLSPolicy         `config:"tls_policy"`
+	TLSPolicy int                    `config:"tls_policy"`
 	AuthType  string                 `config:"auth_type"`
 	Username  string                 `config:"username"`
 	Password  string                 `config:"password"`
@@ -35,7 +35,8 @@ func (m MailConfig) Schema() z.ZogSchema {
 		"port": z.Int(),
 		"auth_type": z.String(),
 		"ssl": z.Bool(),
-		"tls_policy": z.Enum(string(mail.NoTLS), string(mail.TLSOpportunistic), string(mail.TLSMandatory)),
+		"tls_policy": z.Int().
+			OneOf([]int{int(mail.NoTLS), int(mail.TLSOpportunistic), int(mail.TLSMandatory)}, z.Message("tls_policy must be one of: NoTLS, TLSOpportunistic, TLSMandatory")),
 	})
 }
 
@@ -45,7 +46,7 @@ func (m MailConfig) Defaults() map[string]interface{} {
 		"auth_type":  "plain",
 		"port":       25,
 		"ssl":        false,
-		"tls_policy": string(mail.TLSMandatory),
+		"tls_policy": int(mail.TLSMandatory),
 		"from":       "",
 		"username":   "",
 		"password":   "",

--- a/config/mail.go
+++ b/config/mail.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	z "github.com/Oudwins/zog"
+	"github.com/Oudwins/zog"
+	"github.com/wneessen/go-mail"
 	"go.lumeweb.com/configmanager"
 )
 
@@ -11,13 +12,14 @@ var (
 )
 
 type MailConfig struct {
-	Host     string `config:"host"`
-	Port     int    `config:"port"`
-	SSL      bool   `config:"ssl"`
-	AuthType string `config:"auth_type"`
-	Username string `config:"username"`
-	Password string `config:"password"`
-	From     string `config:"from"`
+	Host      string                 `config:"host"`
+	Port      int                    `config:"port"`
+	SSL       bool                   `config:"ssl"`
+	TLSPolicy mail.TLSPolicy         `config:"tls_policy"`
+	AuthType  string                 `config:"auth_type"`
+	Username  string                 `config:"username"`
+	Password  string                 `config:"password"`
+	From      string                 `config:"from"`
 }
 
 func (m MailConfig) Schema() z.ZogSchema {
@@ -30,23 +32,22 @@ func (m MailConfig) Schema() z.ZogSchema {
 			Required(z.Message("core.mail.password is required")),
 		"from": z.String().
 			Required(z.Message("core.mail.from is required")),
-		"port": z.Int().
-			Default(25),
-		"auth_type": z.String().
-			Default("plain"),
-		"ssl": z.Bool().
-			Default(false),
+		"port": z.Int(),
+		"auth_type": z.String(),
+		"ssl": z.Bool(),
+		"tls_policy": z.Enum(string(mail.NoTLS), string(mail.TLSOpportunistic), string(mail.TLSMandatory)),
 	})
 }
 
 func (m MailConfig) Defaults() map[string]interface{} {
 	return map[string]interface{}{
-		"host":      "",
-		"auth_type": "plain",
-		"port":      25,
-		"ssl":       false,
-		"from":      "",
-		"username":  "",
-		"password":  "",
+		"host":       "",
+		"auth_type":  "plain",
+		"port":       25,
+		"ssl":        false,
+		"tls_policy": string(mail.TLSMandatory),
+		"from":       "",
+		"username":   "",
+		"password":   "",
 	}
 }

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -143,6 +143,7 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 				zap.String("host", mailCfg.Host),
 				zap.Int("port", mailCfg.Port),
 				zap.Bool("ssl", mailCfg.SSL),
+				zap.String("tls_policy", mailCfg.TLSPolicy),
 				zap.String("auth_type", mailCfg.AuthType),
 				zap.String("from", mailCfg.From),
 				zap.String("username", mailCfg.Username),
@@ -158,6 +159,14 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 
 			if mailCfg.SSL {
 				options = append(options, mail.WithSSLPort(true))
+			}
+
+			// Configure TLS policy
+			if mailCfg.TLSPolicy != "" {
+				options = append(options, mail.WithTLSPortPolicy(mailCfg.TLSPolicy))
+				ctx.Logger().Debug("Configuring TLS policy",
+					zap.String("tls_policy", string(mailCfg.TLSPolicy)),
+				)
 			}
 
 			options = append(options, mail.WithUsername(mailCfg.Username))

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -143,7 +143,7 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 				zap.String("host", mailCfg.Host),
 				zap.Int("port", mailCfg.Port),
 				zap.Bool("ssl", mailCfg.SSL),
-				zap.String("tls_policy", mailCfg.TLSPolicy),
+				zap.Int("tls_policy", mailCfg.TLSPolicy),
 				zap.String("auth_type", mailCfg.AuthType),
 				zap.String("from", mailCfg.From),
 				zap.String("username", mailCfg.Username),
@@ -162,12 +162,10 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 			}
 
 			// Configure TLS policy
-			if mailCfg.TLSPolicy != "" {
-				options = append(options, mail.WithTLSPortPolicy(mailCfg.TLSPolicy))
-				ctx.Logger().Debug("Configuring TLS policy",
-					zap.String("tls_policy", string(mailCfg.TLSPolicy)),
-				)
-			}
+			options = append(options, mail.WithTLSPortPolicy(mail.TLSPolicy(mailCfg.TLSPolicy)))
+			ctx.Logger().Debug("Configuring TLS policy",
+				zap.Int("tls_policy", mailCfg.TLSPolicy),
+			)
 
 			options = append(options, mail.WithUsername(mailCfg.Username))
 			options = append(options, mail.WithPassword(mailCfg.Password))


### PR DESCRIPTION
- Add TLSPolicy field to MailConfig struct
- Add TLS policy logging in mailer service initialization


---

<!-- kody-pr-summary:start -->
 This PR introduces TLS policy configuration support for the mailer service, allowing explicit control over SMTP encryption behavior.

**Key Changes:**
- Added new `tls_policy` configuration field to mail settings with support for three policies: `NoTLS`, `TLSOpportunistic`, and `TLSMandatory`
- Updated the mailer service to apply the configured TLS policy when establishing SMTP connections using the go-mail library
- Added logging for the TLS policy configuration to aid in debugging connection issues
- Simplified validation schema for optional mail configuration fields (port, auth_type, ssl)

**Functional Impact:**
Administrators can now explicitly define encryption requirements for email delivery based on their mail server capabilities and security policies, rather than relying solely on the existing SSL toggle. This provides granular control for environments requiring mandatory TLS, opportunistic TLS, or no TLS connections.
<!-- kody-pr-summary:end -->