### PR TITLE
feat(mailer): validate auth_type against SMTPAuthType constants

### DIFF
--- a/config/mail.go
+++ b/config/mail.go
@@ -40,7 +40,22 @@ func (m MailConfig) Schema() z.ZogSchema {
 		"from": z.String().
 			Required(z.Message("core.mail.from is required")),
 		"port": z.Int(),
-		"auth_type": z.String(),
+		"auth_type": z.String().
+			OneOf([]string{
+				string(mail.SMTPAuthCramMD5),
+				string(mail.SMTPAuthCustom),
+				string(mail.SMTPAuthLogin),
+				string(mail.SMTPAuthLoginNoEnc),
+				string(mail.SMTPAuthNoAuth),
+				string(mail.SMTPAuthPlain),
+				string(mail.SMTPAuthPlainNoEnc),
+				string(mail.SMTPAuthXOAUTH2),
+				string(mail.SMTPAuthSCRAMSHA1),
+				string(mail.SMTPAuthSCRAMSHA1PLUS),
+				string(mail.SMTPAuthSCRAMSHA256),
+				string(mail.SMTPAuthSCRAMSHA256PLUS),
+				string(mail.SMTPAuthAutoDiscover),
+			}, z.Message("auth_type must be a valid SMTP auth type")),
 		"ssl": z.Bool(),
 		"tls_policy": z.String().
 			OneOf([]string{TLSPolicyNoTLS, TLSPolicyOpportunistic, TLSPolicyMandatory}, z.Message("tls_policy must be one of: NoTLS, TLSOpportunistic, TLSMandatory")),
@@ -50,7 +65,7 @@ func (m MailConfig) Schema() z.ZogSchema {
 func (m MailConfig) Defaults() map[string]interface{} {
 	return map[string]interface{}{
 		"host":       "",
-		"auth_type":  "plain",
+		"auth_type":  string(mail.SMTPAuthPlain),
 		"port":       25,
 		"ssl":        false,
 		"tls_policy": mail.TLSMandatory.String(),

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -192,8 +192,11 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 				zap.String("tls_policy", mailCfg.TLSPolicy),
 			)
 
-			options = append(options, mail.WithUsername(mailCfg.Username))
-			options = append(options, mail.WithPassword(mailCfg.Password))
+			// Only set username/password if authentication is configured
+			if mail.SMTPAuthType(strings.ToUpper(mailCfg.AuthType)) != mail.SMTPAuthNoAuth {
+				options = append(options, mail.WithUsername(mailCfg.Username))
+				options = append(options, mail.WithPassword(mailCfg.Password))
+			}
 
 			if mailCfg.Host != "" {
 				domain := mailCfg.Host

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -193,7 +193,7 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 			)
 
 			// Only set username/password if authentication is configured
-			if mail.SMTPAuthType(strings.ToUpper(mailCfg.AuthType)) != mail.SMTPAuthNoAuth {
+			if mail.SMTPAuthType(mailCfg.AuthType) != mail.SMTPAuthNoAuth {
 				options = append(options, mail.WithUsername(mailCfg.Username))
 				options = append(options, mail.WithPassword(mailCfg.Password))
 			}


### PR DESCRIPTION
- Add OneOf validation for auth_type using mail.SMTPAuthType constants
- Only set username/password when auth_type is not SMTPAuthNoAuth
- Change default from "plain" to string(mail.SMTPAuthPlain)


---

<!-- kody-pr-summary:start -->
 This pull request enhances the mailer service configuration validation and credential handling:

**Configuration Validation**
- Restricts the `auth_type` field to only accept valid SMTP authentication types from the defined constants (including CRAM-MD5, Plain, Login, SCRAM-SHA variants, XOAUTH2, AutoDiscover, NoAuth, etc.)
- Updates the default `auth_type` value to use the typed constant `SMTPAuthPlain` instead of a hardcoded string

**Conditional Authentication**
- Modifies the mailer initialization to only set username and password credentials when authentication is explicitly configured
- Skips credential injection when `auth_type` is set to `SMTPAuthNoAuth`, preventing unnecessary credential transmission to SMTP servers that don't require authentication

These changes ensure configuration integrity by validating authentication types at the schema level and improve security by conditionally applying credentials based on the authentication requirements.
<!-- kody-pr-summary:end -->