### PR TITLE
fix(mailer): add 'none' alias for SMTP auth type

### DIFF
--- a/config/mail.go
+++ b/config/mail.go
@@ -18,6 +18,9 @@ const (
 	TLSPolicyMandatory     = "TLSMandatory"
 )
 
+// SMTP auth type alias constant - provides a user-friendly alias for NOAUTH
+const SMTPAuthAliasNone = "none"
+
 type MailConfig struct {
 	Host      string                 `config:"host"`
 	Port      int                    `config:"port"`
@@ -42,7 +45,7 @@ func (m MailConfig) Schema() z.ZogSchema {
 		"port": z.Int(),
 		"auth_type": z.String().
 			OneOf([]string{
-				"none",
+				SMTPAuthAliasNone,
 				string(mail.SMTPAuthCramMD5),
 				string(mail.SMTPAuthCustom),
 				string(mail.SMTPAuthLogin),

--- a/config/mail.go
+++ b/config/mail.go
@@ -42,6 +42,7 @@ func (m MailConfig) Schema() z.ZogSchema {
 		"port": z.Int(),
 		"auth_type": z.String().
 			OneOf([]string{
+				"none",
 				string(mail.SMTPAuthCramMD5),
 				string(mail.SMTPAuthCustom),
 				string(mail.SMTPAuthLogin),

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -20,6 +20,14 @@ var _ core.MailerService = (*Mailer)(nil)
 
 var ErrEmailTemplateNotFound = mailer.ErrTemplateNotFound
 
+// normalizeAuthType converts "none" alias to "NOAUTH"
+func normalizeAuthType(authType string) string {
+	if strings.EqualFold(authType, "none") {
+		return string(mail.SMTPAuthNoAuth)
+	}
+	return authType
+}
+
 // parseTLSPolicy converts a string representation to mail.TLSPolicy
 func parseTLSPolicy(policy string) (mail.TLSPolicy, error) {
 	switch policy {
@@ -170,8 +178,11 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 				options = append(options, mail.WithPort(mailCfg.Port))
 			}
 
+			// Normalize auth_type (e.g., "none" -> "NOAUTH")
+			normalizedAuthType := normalizeAuthType(mailCfg.AuthType)
+
 			if mailCfg.AuthType != "" {
-				options = append(options, mail.WithSMTPAuth(mail.SMTPAuthType(strings.ToUpper(mailCfg.AuthType))))
+				options = append(options, mail.WithSMTPAuth(mail.SMTPAuthType(normalizedAuthType)))
 			}
 
 			if mailCfg.SSL {
@@ -193,7 +204,7 @@ func NewMailerService(templateRegistry *mailer.TemplateRegistry) (core.Service, 
 			)
 
 			// Only set username/password if authentication is configured
-			if mail.SMTPAuthType(mailCfg.AuthType) != mail.SMTPAuthNoAuth {
+			if mail.SMTPAuthType(normalizedAuthType) != mail.SMTPAuthNoAuth {
 				options = append(options, mail.WithUsername(mailCfg.Username))
 				options = append(options, mail.WithPassword(mailCfg.Password))
 			}

--- a/service/mailer.go
+++ b/service/mailer.go
@@ -22,7 +22,7 @@ var ErrEmailTemplateNotFound = mailer.ErrTemplateNotFound
 
 // normalizeAuthType converts "none" alias to "NOAUTH"
 func normalizeAuthType(authType string) string {
-	if strings.EqualFold(authType, "none") {
+	if strings.EqualFold(authType, config.SMTPAuthAliasNone) {
 		return string(mail.SMTPAuthNoAuth)
 	}
 	return authType


### PR DESCRIPTION
- Add 'none' as valid auth_type value in config schema
- Create normalizeAuthType() function to convert 'none' to 'NOAUTH'
- Apply normalization before using auth_type
- This allows users to use auth_type: 'none' as a more intuitive alias for 'NOAUTH'


---

<!-- kody-pr-summary:start -->
 Add support for "none" as a valid SMTP authentication type alias in mail configuration.

**Changes:**
- Added "none" to the allowed values for `auth_type` in the mail configuration schema
- Implemented normalization logic to convert the "none" alias to the internal "NOAUTH" representation
- Updated credential handling to properly skip username/password configuration when "none" is specified

**Functional Impact:**
Users can now specify `auth_type: "none"` (case-insensitive) in mail configuration to disable SMTP authentication, providing a more intuitive alternative to the existing "NOAUTH" value. When "none" is configured, the mailer service will correctly initialize without requiring or setting username/password credentials.
<!-- kody-pr-summary:end -->