### PR TITLE
fix(access): use keyMatch2 matcher for dynamic route patterns

### DIFF
--- a/service/access.go
+++ b/service/access.go
@@ -168,7 +168,7 @@ func (a *AccessServiceDefault) IInit() error {
 	m.AddDef("e", "e", "some(where (p.eft == allow))")
 
 	// Matchers
-	m.AddDef("m", "m", "g(r.sub, p.sub) && r.dom == p.dom && keyMatch5(r.obj, p.obj) && r.act == p.act")
+	m.AddDef("m", "m", "g(r.sub, p.sub) && r.dom == p.dom && keyMatch2(r.obj, p.obj) && r.act == p.act")
 
 	// Load the model
 	enforcer, err := casbin.NewEnforcer(m)


### PR DESCRIPTION
- Replace keyMatch5 with keyMatch2 in Casbin matcher
- keyMatch2 supports Echo router's :param syntax
- Fixes authorization checks for dynamic routes like /api/account/keys/:keyID
- Enables proper ACL computation for UUID-based paths


---

<!-- kody-pr-summary:start -->
 **Fix access control matching for dynamic route patterns by switching to keyMatch2 matcher**

Changed the Casbin policy matcher from `keyMatch5` to `keyMatch2` in the access service initialization. 

This updates the route pattern matching logic to use colon-style parameter syntax (e.g., `/resource/:id`) instead of brace-style syntax (e.g., `/resource/{id}`) when evaluating access control policies against request paths. The `keyMatch2` matcher is specifically designed to handle dynamic route segments defined with `:` prefixes, ensuring proper authorization checks for parameterized URLs throughout the application.
<!-- kody-pr-summary:end -->