### PR TITLE
fix(access): add custom key matcher for Echo's colon syntax

### DIFF
--- a/service/access.go
+++ b/service/access.go
@@ -9,10 +9,10 @@ import (
 	"github.com/casbin/casbin/v3"
 	"github.com/casbin/casbin/v3/model"
 	_ "github.com/casbin/casbin/v3/rbac/default-role-manager"
-	"github.com/casbin/gorm-adapter/v3"
+	gormadapter "github.com/casbin/gorm-adapter/v3"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
-	accessMetrics "go.lumeweb.com/portal/service/internal/access"
+	access "go.lumeweb.com/portal/service/internal/access"
 )
 
 var _ core.AccessService = (*AccessServiceDefault)(nil)
@@ -27,7 +27,7 @@ func init() {
 	core.RegisterService(core.ServiceInfo{
 		ID:      core.ACCESS_SERVICE,
 		Factory: NewAccessService,
-		Metrics: accessMetrics.GetCollectors(),
+		Metrics: access.GetCollectors(),
 	})
 }
 
@@ -51,13 +51,13 @@ func (a *AccessServiceDefault) RegisterRoute(ctx context.Context, subdomain, pat
 	defer span.End()
 
 	return core.MetricTrack(
-		accessMetrics.AccessDuration.WithLabelValues(accessMetrics.LabelOpRegisterRoute),
-		accessMetrics.AccessFailed.WithLabelValues(accessMetrics.LabelOpRegisterRoute),
+		access.AccessDuration.WithLabelValues(access.LabelOpRegisterRoute),
+		access.AccessFailed.WithLabelValues(access.LabelOpRegisterRoute),
 		func() error {
 			fqdn := fmt.Sprintf("%s.%s", subdomain, a.Context().Config().Config().Core.Domain)
 			_, err := a.enforcer.AddPolicy(role, fqdn, path, method)
 			if err == nil {
-				accessMetrics.RoutesRegistered.WithLabelValues(accessMetrics.LabelOpRegisterRoute).Inc()
+				access.RoutesRegistered.WithLabelValues(access.LabelOpRegisterRoute).Inc()
 			}
 			return err
 		},
@@ -69,13 +69,13 @@ func (a *AccessServiceDefault) AssignRoleToUser(ctx context.Context, userId uint
 	defer span.End()
 
 	return core.MetricTrack(
-		accessMetrics.AccessDuration.WithLabelValues(accessMetrics.LabelOpAssignRole),
-		accessMetrics.AccessFailed.WithLabelValues(accessMetrics.LabelOpAssignRole),
+		access.AccessDuration.WithLabelValues(access.LabelOpAssignRole),
+		access.AccessFailed.WithLabelValues(access.LabelOpAssignRole),
 		func() error {
 			userIdStr := strconv.FormatUint(uint64(userId), 10)
 			_, err := a.enforcer.AddRoleForUser(userIdStr, role)
 			if err == nil {
-				accessMetrics.RolesAssigned.WithLabelValues(accessMetrics.LabelOpAssignRole).Inc()
+				access.RolesAssigned.WithLabelValues(access.LabelOpAssignRole).Inc()
 			}
 			return err
 		},
@@ -87,15 +87,15 @@ func (a *AccessServiceDefault) CheckAccess(ctx context.Context, userId uint, fqd
 	defer span.End()
 
 	result, err := core.MetricTrackResult(
-		accessMetrics.AccessDuration.WithLabelValues(accessMetrics.LabelOpCheckAccess),
-		accessMetrics.AccessFailed.WithLabelValues(accessMetrics.LabelOpCheckAccess),
+		access.AccessDuration.WithLabelValues(access.LabelOpCheckAccess),
+		access.AccessFailed.WithLabelValues(access.LabelOpCheckAccess),
 		func() (bool, error) {
 			return a.enforcer.Enforce(strconv.FormatUint(uint64(userId), 10), fqdn, path, method)
 		},
 	)
 
 	if err == nil {
-		accessMetrics.AccessChecked.WithLabelValues(accessMetrics.LabelOpCheckAccess).Inc()
+		access.AccessChecked.WithLabelValues(access.LabelOpCheckAccess).Inc()
 	}
 	return result, err
 }
@@ -105,8 +105,8 @@ func (a *AccessServiceDefault) ExportUserPolicy(ctx context.Context, userId uint
 	defer span.End()
 
 	result, err := core.MetricTrackResult(
-		accessMetrics.AccessDuration.WithLabelValues(accessMetrics.LabelOpExportPolicy),
-		accessMetrics.AccessFailed.WithLabelValues(accessMetrics.LabelOpExportPolicy),
+		access.AccessDuration.WithLabelValues(access.LabelOpExportPolicy),
+		access.AccessFailed.WithLabelValues(access.LabelOpExportPolicy),
 		func() ([]*core.AccessPolicy, error) {
 			userIdStr := strconv.FormatUint(uint64(userId), 10)
 			// Get all roles for the user
@@ -147,7 +147,7 @@ func (a *AccessServiceDefault) ExportUserPolicy(ctx context.Context, userId uint
 	)
 
 	if err == nil {
-		accessMetrics.PolicyExported.WithLabelValues(accessMetrics.LabelOpExportPolicy).Inc()
+		access.PolicyExported.WithLabelValues(access.LabelOpExportPolicy).Inc()
 	}
 	return result, err
 }
@@ -168,7 +168,7 @@ func (a *AccessServiceDefault) IInit() error {
 	m.AddDef("e", "e", "some(where (p.eft == allow))")
 
 	// Matchers
-	m.AddDef("m", "m", "g(r.sub, p.sub) && r.dom == p.dom && keyMatch2(r.obj, p.obj) && r.act == p.act")
+	m.AddDef("m", "m", "g(r.sub, p.sub) && r.dom == p.dom && keyMatchEcho(r.obj, p.obj) && r.act == p.act")
 
 	// Load the model
 	enforcer, err := casbin.NewEnforcer(m)
@@ -177,6 +177,9 @@ func (a *AccessServiceDefault) IInit() error {
 	}
 
 	enforcer.EnableAutoSave(true)
+
+	// Register custom key matcher for Echo's colon syntax
+	enforcer.AddFunction("keyMatchEcho", access.KeyMatchEchoFunc)
 
 	a.enforcer = enforcer
 

--- a/service/internal/access/key_matcher.go
+++ b/service/internal/access/key_matcher.go
@@ -1,0 +1,54 @@
+package access
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/casbin/casbin/v3/util"
+)
+
+// KeyMatchEcho determines whether key1 matches the pattern of key2 using Echo's colon syntax.
+// Supports :param for single path segments and :param/* for sub-resources.
+// For example:
+//   "/api/account/keys/ec6a9c56-2d04-4450-b6e3-1d10985e275b" matches "/api/account/keys/:keyID"
+//   "/api/account/keys/123/subresource" matches "/api/account/keys/:keyID/*"
+func KeyMatchEcho(key1 string, key2 string) bool {
+	// Try standard KeyMatch2 first for :param syntax
+	if util.KeyMatch2(key1, key2) {
+		return true
+	}
+
+	// Handle :param/* patterns where the path must have at least one segment after the parameter
+	key2 = strings.Replace(key2, "/*", "/.*", -1)
+
+	// Check if pattern contains :param/* syntax
+	re := regexp.MustCompile(`:([^/]+)/\.\*`)
+	if !re.MatchString(key2) {
+		return false
+	}
+
+	// Replace :param/.* with regex that requires at least one segment after the parameter
+	key2 = re.ReplaceAllString(key2, "([^/]+)/.+$")
+
+	// Replace other :param patterns
+	re = regexp.MustCompile(`:[^/]+`)
+	key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
+
+	return util.RegexMatch(key1, "^"+key2+"$")
+}
+
+// KeyMatchEchoFunc is the wrapper for KeyMatchEcho.
+func KeyMatchEchoFunc(args ...interface{}) (interface{}, error) {
+	if len(args) != 2 {
+		return false, nil
+	}
+
+	name1, ok1 := args[0].(string)
+	name2, ok2 := args[1].(string)
+
+	if !ok1 || !ok2 {
+		return false, nil
+	}
+
+	return bool(KeyMatchEcho(name1, name2)), nil
+}

--- a/service/internal/access/key_matcher.go
+++ b/service/internal/access/key_matcher.go
@@ -7,34 +7,29 @@ import (
 	"github.com/casbin/casbin/v3/util"
 )
 
+var (
+	paramRegex = regexp.MustCompile(`:[^/]+`)
+)
+
 // KeyMatchEcho determines whether key1 matches the pattern of key2 using Echo's colon syntax.
 // Supports :param for single path segments and :param/* for sub-resources.
 // For example:
 //   "/api/account/keys/ec6a9c56-2d04-4450-b6e3-1d10985e275b" matches "/api/account/keys/:keyID"
 //   "/api/account/keys/123/subresource" matches "/api/account/keys/:keyID/*"
 func KeyMatchEcho(key1 string, key2 string) bool {
-	// Try standard KeyMatch2 first for :param syntax
-	if util.KeyMatch2(key1, key2) {
-		return true
-	}
+	// Escape all static path segments first
+	// This prevents regex metacharacters like '.' in paths from being interpreted as wildcards
+	pattern := regexp.QuoteMeta(key2)
 
-	// Handle :param/* patterns where the path must have at least one segment after the parameter
-	key2 = strings.Replace(key2, "/*", "/.*", -1)
+	// Now unescape the parts we want to be regex: :param and /*
+	// Replace escaped :param with actual regex
+	pattern = strings.ReplaceAll(pattern, regexp.QuoteMeta(":"), ":")
+	pattern = paramRegex.ReplaceAllString(pattern, "[^/]+")
 
-	// Check if pattern contains :param/* syntax
-	re := regexp.MustCompile(`:([^/]+)/\.\*`)
-	if !re.MatchString(key2) {
-		return false
-	}
+	// Replace escaped /* with .*
+	pattern = strings.ReplaceAll(pattern, regexp.QuoteMeta("/*"), "/.*")
 
-	// Replace :param/.* with regex that requires at least one segment after the parameter
-	key2 = re.ReplaceAllString(key2, "([^/]+)/.+$")
-
-	// Replace other :param patterns
-	re = regexp.MustCompile(`:[^/]+`)
-	key2 = re.ReplaceAllString(key2, "$1[^/]+$2")
-
-	return util.RegexMatch(key1, "^"+key2+"$")
+	return util.RegexMatch(key1, "^"+pattern+"$")
 }
 
 // KeyMatchEchoFunc is the wrapper for KeyMatchEcho.

--- a/service/internal/access/key_matcher_test.go
+++ b/service/internal/access/key_matcher_test.go
@@ -1,0 +1,234 @@
+package access
+
+import (
+	"testing"
+)
+
+func TestKeyMatchEcho(t *testing.T) {
+	tests := []struct {
+		name     string
+		key1     string
+		key2     string
+		expected bool
+	}{
+		// Basic :param tests
+		{
+			name:     "exact match",
+			key1:     "/api/account/keys",
+			key2:     "/api/account/keys",
+			expected: true,
+		},
+		{
+			name:     "single :param",
+			key1:     "/api/account/keys/ec6a9c56-2d04-4450-b6e3-1d10985e275b",
+			key2:     "/api/account/keys/:keyID",
+			expected: true,
+		},
+		{
+			name:     "multiple :params",
+			key1:     "/api/account/123/keys/456",
+			key2:     "/api/account/:accountID/keys/:keyID",
+			expected: true,
+		},
+		{
+			name:     "UUID :param",
+			key1:     "/api/account/keys/ec6a9c56-2d04-4450-b6e3-1d10985e275b",
+			key2:     "/api/account/keys/:keyID",
+			expected: true,
+		},
+		{
+			name:     "numeric :param",
+			key1:     "/api/account/keys/12345",
+			key2:     "/api/account/keys/:keyID",
+			expected: true,
+		},
+		{
+			name:     "no match - missing segment",
+			key1:     "/api/account/keys",
+			key2:     "/api/account/keys/:keyID",
+			expected: false,
+		},
+		{
+			name:     "no match - extra segment",
+			key1:     "/api/account/keys/123/extra",
+			key2:     "/api/account/keys/:keyID",
+			expected: false,
+		},
+		{
+			name:     "no match - wrong path",
+			key1:     "/api/account/keys/123",
+			key2:     "/api/account/users/:userID",
+			expected: false,
+		},
+
+		// :param/* sub-resource tests
+		{
+			name:     "sub-resource with one segment",
+			key1:     "/api/account/keys/123/subresource",
+			key2:     "/api/account/keys/:keyID/*",
+			expected: true,
+		},
+		{
+			name:     "sub-resource with multiple segments",
+			key1:     "/api/account/keys/123/sub/resource/path",
+			key2:     "/api/account/keys/:keyID/*",
+			expected: true,
+		},
+		{
+			name:     "sub-resource with UUID",
+			key1:     "/api/account/keys/ec6a9c56-2d04-4450-b6e3-1d10985e275b/subresource",
+			key2:     "/api/account/keys/:keyID/*",
+			expected: true,
+		},
+		{
+			name:     "sub-resource no match - ends at param",
+			key1:     "/api/account/keys/123",
+			key2:     "/api/account/keys/:keyID/*",
+			expected: false,
+		},
+		{
+			name:     "sub-resource no match - missing param",
+			key1:     "/api/account/keys/subresource",
+			key2:     "/api/account/keys/:keyID/*",
+			expected: false,
+		},
+
+		// Wildcard tests (standard KeyMatch2 behavior)
+		{
+			name:     "wildcard basic",
+			key1:     "/api/account/keys",
+			key2:     "/api/account/*",
+			expected: true,
+		},
+		{
+			name:     "wildcard with segment",
+			key1:     "/api/account/keys/123",
+			key2:     "/api/account/*",
+			expected: true,
+		},
+		{
+			name:     "wildcard no match",
+			key1:     "/api/users/123",
+			key2:     "/api/account/*",
+			expected: false,
+		},
+
+		// Edge cases
+		{
+			name:     "empty strings",
+			key1:     "",
+			key2:     "",
+			expected: true,
+		},
+		{
+			name:     "root path",
+			key1:     "/",
+			key2:     "/",
+			expected: true,
+		},
+		{
+			name:     "trailing slashes - both",
+			key1:     "/api/account/keys/",
+			key2:     "/api/account/keys/",
+			expected: true,
+		},
+		{
+			name:     "trailing slashes - pattern only",
+			key1:     "/api/account/keys",
+			key2:     "/api/account/keys/",
+			expected: false,
+		},
+		{
+			name:     "trailing slashes - key only",
+			key1:     "/api/account/keys/",
+			key2:     "/api/account/keys",
+			expected: false,
+		},
+		{
+			name:     "complex nested path with params",
+			key1:     "/api/v1/accounts/123/keys/456/actions/789",
+			key2:     "/api/v1/accounts/:accountID/keys/:keyID/actions/:actionID",
+			expected: true,
+		},
+		{
+			name:     "complex nested path with sub-resources",
+			key1:     "/api/v1/accounts/123/keys/456/sub/extra/path",
+			key2:     "/api/v1/accounts/:accountID/keys/:keyID/*",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := KeyMatchEcho(tt.key1, tt.key2)
+			if result != tt.expected {
+				t.Errorf("KeyMatchEcho(%q, %q) = %v, expected %v", tt.key1, tt.key2, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestKeyMatchEchoFunc(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []interface{}
+		expected bool
+		wantErr  bool
+	}{
+		{
+			name:     "basic match",
+			args:     []interface{}{"/api/account/keys/123", "/api/account/keys/:keyID"},
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "no match",
+			args:     []interface{}{"/api/account/keys", "/api/account/keys/:keyID"},
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "sub-resource match",
+			args:     []interface{}{"/api/account/keys/123/sub", "/api/account/keys/:keyID/*"},
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "wrong number of args - one",
+			args:     []interface{}{"/api/account/keys/123"},
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "wrong number of args - three",
+			args:     []interface{}{"/api/account/keys/123", "/api/account/keys/:keyID", "extra"},
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "non-string args",
+			args:     []interface{}{123, "/api/account/keys/:keyID"},
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "both non-string args",
+			args:     []interface{}{123, 456},
+			expected: false,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := KeyMatchEchoFunc(tt.args...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("KeyMatchEchoFunc() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("KeyMatchEchoFunc() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/service/internal/access/key_matcher_test.go
+++ b/service/internal/access/key_matcher_test.go
@@ -156,6 +156,31 @@ func TestKeyMatchEcho(t *testing.T) {
 			key2:     "/api/v1/accounts/:accountID/keys/:keyID/*",
 			expected: true,
 		},
+		// Security: regex metacharacters in static segments
+		{
+			name:     "dot in version should be escaped",
+			key1:     "/api/v1.0/keys/123",
+			key2:     "/api/v1.0/keys/:keyID",
+			expected: true,
+		},
+		{
+			name:     "dot in version should not match other chars",
+			key1:     "/api/v1X0/keys/123",
+			key2:     "/api/v1.0/keys/:keyID",
+			expected: false,
+		},
+		{
+			name:     "dot in version with sub-resource",
+			key1:     "/api/v2.1/keys/123/sub",
+			key2:     "/api/v2.1/keys/:keyID/*",
+			expected: true,
+		},
+		{
+			name:     "dot in version should not match X",
+			key1:     "/api/v2X1/keys/123/sub",
+			key2:     "/api/v2.1/keys/:keyID/*",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Implement custom keyMatchEcho matcher to properly handle Echo framework's
colon syntax (:param) for dynamic route patterns, including support for
sub-resources with :param/* patterns.

KeyMatchEcho extends Casbin's KeyMatch2 to support:
- Single segment parameters: /api/account/keys/:keyID
- Sub-resource patterns: /api/account/keys/:keyID/*
- UUID and numeric values in parameters
- Standard wildcard patterns (/api/account/*)

Previously, using keyMatch2 or keyMatch5 alone did not properly handle
Echo's colon syntax, causing authorization failures for dynamic routes
like '/api/account/keys/ec6a9c56-2d04-4450-b6e3-1d10985e275b'.

Changes:
- Add service/internal/access/key_matcher.go with KeyMatchEcho implementation
- Update service/access.go to register custom matcher with Casbin
- Add comprehensive unit tests covering all patterns


---

<!-- kody-pr-summary:start -->
 This pull request introduces a custom key matcher for the Casbin authorization system to support Echo framework's colon-based URL syntax.

**Changes:**
- Replaced the standard `keyMatch2` matcher with a new `keyMatchEcho` function in the access control model configuration
- Added custom `KeyMatchEcho` implementation that supports:
  - Single path parameter matching (e.g., `/api/account/keys/:keyID`)
  - Sub-resource matching with wildcard (e.g., `/api/account/keys/:keyID/*`)
  - Fallback compatibility with standard KeyMatch2 patterns
- Registered the custom matcher function with the Casbin enforcer during service initialization
- Added comprehensive unit tests covering parameterized routes, sub-resources, wildcards, and edge cases

**Impact:**
This fix enables the access control system to properly match authorization policies against routes using Echo's colon syntax, allowing accurate permission checks for dynamic routes with path parameters and their sub-resources.
<!-- kody-pr-summary:end -->