### PR TITLE
fix(access): register keyMatchEcho before enforcer is used

### DIFF
--- a/service/access.go
+++ b/service/access.go
@@ -170,28 +170,32 @@ func (a *AccessServiceDefault) IInit() error {
 	// Matchers
 	m.AddDef("m", "m", "g(r.sub, p.sub) && r.dom == p.dom && keyMatchEcho(r.obj, p.obj) && r.act == p.act")
 
-	// Load the model
-	enforcer, err := casbin.NewEnforcer(m)
-	if err != nil {
-		return err
-	}
-
-	enforcer.EnableAutoSave(true)
-
-	// Register custom key matcher for Echo's colon syntax
-	enforcer.AddFunction("keyMatchEcho", access.KeyMatchEchoFunc)
-
-	a.enforcer = enforcer
-
 	db := a.DB()
 
 	// Load policies from database
 	gormadapter.TurnOffAutoMigrate(db)
 	tbl := models.AccessRule{}
 	tableName := db.NamingStrategy.TableName(reflect.TypeOf(tbl).Name())
-	adapter, _ := gormadapter.NewAdapterByDBWithCustomTable(db, &tbl, tableName)
+	adapter, err := gormadapter.NewAdapterByDBWithCustomTable(db, &tbl, tableName)
+	if err != nil {
+		return err
+	}
 
-	return a.enforcer.InitWithModelAndAdapter(m, adapter)
+	// Load the model with adapter
+	enforcer, err := casbin.NewEnforcer(m, adapter)
+	if err != nil {
+		return err
+	}
+
+	// Register custom key matcher for Echo's colon syntax
+	// Must be registered before the enforcer is used
+	enforcer.AddFunction("keyMatchEcho", access.KeyMatchEchoFunc)
+
+	enforcer.EnableAutoSave(true)
+
+	a.enforcer = enforcer
+
+	return nil
 }
 
 func (a *AccessServiceDefault) GetEnforcer() *casbin.Enforcer {


### PR DESCRIPTION
Fixes 'Undefined function keyMatchEcho' error by ensuring the custom
function is registered before the enforcer performs any enforcement.

Changes:
- Create adapter before enforcer initialization
- Pass adapter to NewEnforcer to avoid separate InitWithModelAndAdapter call
- Register keyMatchEcho function immediately after enforcer creation
- Enable auto-save after function registration

This ensures the custom matcher is available before any access checks occur.


---

<!-- kody-pr-summary:start -->
 Fixes an initialization order issue in the access control service where the custom `keyMatchEcho` matcher function was registered after the Casbin enforcer was initialized with the policy adapter. 

The change ensures that the custom function required for matching Echo framework path patterns (colon syntax) is registered before the enforcer loads and evaluates policies from the database. This prevents access control rules using Echo-style route patterns from failing to match during authorization checks.
<!-- kody-pr-summary:end -->