### PR TITLE
fix(testing): apply service config to regular services in MockPluginBuilder

### DIFF
--- a/core/testing/mock_plugin.go
+++ b/core/testing/mock_plugin.go
@@ -191,7 +191,31 @@ func (b *MockPluginBuilder) Build() (core.Service, []core.ContextBuilderOption, 
 
 	if len(b.services) > 0 || len(b.mockServices) > 0 || len(b.mockServiceFactories) > 0 {
 		allServices := make([]core.ServiceInfo, 0, len(b.services)+len(b.mockServices)+len(b.mockServiceFactories))
-		allServices = append(allServices, b.services...)
+		// Process regular services - wrap factories to apply config
+		for _, svc := range b.services {
+			id := svc.ID
+			factory := svc.Factory
+			depends := svc.Depends
+
+			// Wrap the factory to apply config after service is created
+			allServices = append(allServices, core.ServiceInfo{
+				ID: id,
+				Factory: func() (core.Service, []core.ContextBuilderOption, error) {
+					svcInstance, opts, err := factory()
+					if err != nil {
+						return nil, nil, err
+					}
+
+					// Apply config if provided for this service
+					if err := b.applyServiceConfig(id, svcInstance); err != nil {
+						return nil, nil, err
+					}
+
+					return svcInstance, opts, nil
+				},
+				Depends: depends,
+			})
+		}
 
 		// Process mock services - add to services list with no-op factories
 		for _, mockSvc := range b.mockServices {


### PR DESCRIPTION
Previously, WithServiceConfig only worked for mock services added via
WithMockService. Now regular services added via WithService also have
their config applied using the same applyServiceConfig mechanism.

The factory for regular services is now wrapped to apply config after
the service instance is created, ensuring consistent behavior between
mock and regular services.


---

<!-- kody-pr-summary:start -->
 This pull request fixes an issue in the `MockPluginBuilder` testing utility where service configuration was not being applied to regular services.

**Changes:**
- Modified the `Build()` method to wrap regular service factories with configuration logic
- Regular services now have their configuration applied via `applyServiceConfig()` after instantiation, matching the existing behavior for mock services
- Ensures that test configurations defined for services are properly injected during the service creation process

**Impact:**
Regular services registered with `MockPluginBuilder` will now correctly receive their specified test configurations, ensuring consistent behavior between mock and real services in test scenarios.
<!-- kody-pr-summary:end -->