### PR TITLE
fix(config): use dot separator in StripPluginNamePrefix

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -14,14 +14,14 @@ import (
 )
 
 // StripPluginNamePrefix removes the plugin name prefix from a service ID if present.
-// If the serviceName starts with pluginName+"-", it strips the prefix.
-// This handles cases where service IDs include the plugin name (e.g., "my-plugin-service-id").
+// If the serviceName starts with pluginName+".", it strips the prefix.
+// This handles cases where service IDs include the plugin name (e.g., "ipfs.dns" → "dns").
 func StripPluginNamePrefix(pluginName, serviceName string) string {
 	if pluginName == "" || serviceName == "" {
 		return serviceName
 	}
 	lowerPluginName := strings.ToLower(pluginName)
-	prefix := lowerPluginName + "-"
+	prefix := lowerPluginName + "."
 	if strings.HasPrefix(strings.ToLower(serviceName), prefix) {
 		// Strip the prefix and keep the rest of the service name
 		return serviceName[len(prefix):]


### PR DESCRIPTION
The service ID format uses dot separator (e.g., 'ipfs.dns') not hyphen.
Changed the prefix separator from '-' to '.' to correctly strip
plugin name from service IDs like 'ipfs.dns' → 'dns'.


---

<!-- kody-pr-summary:start -->
**Pull Request Description:**

Fixes the `StripPluginNamePrefix` function to use a dot (`.`) separator instead of a hyphen (`-`) when identifying and stripping plugin name prefixes from service IDs.

**Changes:**
- Updated the prefix separator from `"-"` to `"."` in the `StripPluginNamePrefix` function
- Updated documentation comments to reflect the new format (e.g., `"ipfs.dns"` instead of `"my-plugin-service-id"`)

**Impact:**
Service IDs that include plugin name prefixes will now be parsed using dot notation. For example, a service named `ipfs.dns` will correctly strip the `ipfs.` prefix to return `dns`, whereas previously it expected `ipfs-dns` format.
<!-- kody-pr-summary:end -->