### PR TITLE
fix(testing): correct mailer service factory return type

### DIFF
--- a/service/testing/presets.go
+++ b/service/testing/presets.go
@@ -25,7 +25,12 @@ func PresetE2E() coreTesting.TestContextBuilderOption {
 
 		// Layer 1: Foundation services
 		coreTesting.WithServiceFactory(core.CRON_SERVICE, service.NewCronService),
-		coreTesting.WithServiceFactory(core.MAILER_SERVICE, service.NewMailerService),
+
+		// Mailer requires a templateRegistry parameter
+		coreTesting.WithServiceFactory(core.MAILER_SERVICE, func() (core.Service, []core.ContextBuilderOption, error) {
+			return service.NewMailerService(service.NewMailerTemplateRegistry())
+		}),
+
 		coreTesting.WithServiceFactory(core.REQUEST_SERVICE, service.NewRequestService),
 		coreTesting.WithServiceFactory(core.UPLOAD_SERVICE, service.NewMetadataService),
 		coreTesting.WithServiceFactory(core.CONTENT_SCANNER_SERVICE, service.NewContentScannerService),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fixes the mailer service factory registration in the E2E testing preset to properly instantiate the service with its required template registry dependency. 

The previous implementation incorrectly registered the mailer service factory without providing the necessary `templateRegistry` parameter, causing initialization failures. This change wraps the service creation in a closure that properly constructs the mailer service with `NewMailerTemplateRegistry()` and returns the correct signature expected by the testing framework `(core.Service, []core.ContextBuilderOption, error)`.
<!-- kody-pr-summary:end -->