### PR TITLE
fix(testing): move renter mock to first position ensure storage service dependency

### DIFF
--- a/service/testing/presets.go
+++ b/service/testing/presets.go
@@ -22,6 +22,8 @@ func PresetE2E() coreTesting.TestContextBuilderOption {
 	// Layer 4 (requiring layer 3): auth (depends on user + otp), password reset (depends on user + mailer)
 	// Layer 5 (globally required, always initialized): access, http
 	return coreTesting.CombineOptions(
+		// Renter service - must be first as storage service depends on it
+		coreTesting.WithStatefulMockRenterService(),
 
 		// Layer 1: Foundation services
 		coreTesting.WithServiceFactory(core.CRON_SERVICE, service.NewCronService),
@@ -53,8 +55,5 @@ func PresetE2E() coreTesting.TestContextBuilderOption {
 		// Layer 5: Globally required services
 		coreTesting.WithServiceFactory(core.ACCESS_SERVICE, service.NewAccessService),
 		coreTesting.WithServiceFactory(core.HTTP_SERVICE, service.NewHTTPService),
-
-		// Renter service - needs stateful mock for testing
-		coreTesting.WithStatefulMockRenterService(),
 	)
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 Fixes the service initialization order in the E2E testing preset by moving the renter mock service to the first position in the dependency chain. This ensures the storage service, which depends on the renter service, has its required dependency available during initialization. The change resolves a potential dependency resolution issue where the storage service would attempt to initialize before its renter dependency was properly mocked in the test context.
<!-- kody-pr-summary:end -->