### PR TITLE
fix(testing): add mock S3 service after renter for safe testing

### DIFF
--- a/service/testing/presets.go
+++ b/service/testing/presets.go
@@ -24,6 +24,8 @@ func PresetE2E() coreTesting.TestContextBuilderOption {
 	return coreTesting.CombineOptions(
 		// Renter service - must be first as storage service depends on it
 		coreTesting.WithStatefulMockRenterService(),
+		// Mock S3 storage for safe testing without network calls
+		coreTesting.WithMockS3(),
 
 		// Layer 1: Foundation services
 		coreTesting.WithServiceFactory(core.CRON_SERVICE, service.NewCronService),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
 This pull request updates the E2E testing preset to include a mock S3 service, ensuring that end-to-end tests execute safely without making actual network calls to external S3 storage.

**Changes:**
- Added `WithMockS3()` to the `PresetE2E()` configuration, positioned immediately after the renter service to satisfy storage service dependencies
- Prevents tests from attempting real S3 API calls during execution, eliminating external network dependencies and potential side effects

**Impact:**
- E2E tests now run in a fully isolated environment with mocked storage
- Eliminates risk of accidental data operations on live S3 infrastructure during testing
- Ensures consistent test behavior regardless of network connectivity or external service availability
<!-- kody-pr-summary:end -->