### PR TITLE
fix(testing): resolve mock helper footgun causing ignored test expectations

### DIFF
--- a/core/testing/jwt_helper.go
+++ b/core/testing/jwt_helper.go
@@ -4,8 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	gjwt "github.com/golang-jwt/jwt/v5"
 	"go.lumeweb.com/portal-middleware/auth/jwt"
 	"go.lumeweb.com/portal/config"
@@ -237,4 +240,50 @@ func (h *JWTHelper) GenerateExpiredTestToken(userID uint) string {
 // Useful for tests that need to simulate invalid tokens.
 func (h *JWTHelper) GenerateInvalidTestToken() string {
 	return "invalid_test_token"
+}
+
+// ===== Top-level Test Helpers =====
+
+// CreateTestJWTToken generates a valid JWT token for testing purposes.
+// These are convenient top-level functions that can be used without needing a JWTHelper instance.
+func CreateTestJWTToken(tb testing.TB, ctx TestContext, userID string, purpose jwt.Purpose, duration time.Duration) string {
+	pk := ctx.Config().Config().Core.Identity.PrivateKey()
+	jwtToken, err := jwt.CreateToken(pk, ctx.Config().Config().Core.Domain, userID, purpose, duration)
+	require.NoError(tb, err, "Failed to generate test JWT")
+	return jwtToken
+}
+
+// CreateTestLoginToken generates a valid JWT token with login purpose for testing.
+// Uses a default 90-day expiration.
+func CreateTestLoginToken(tb testing.TB, ctx TestContext, userID string) string {
+	return CreateTestJWTToken(tb, ctx, userID, jwt.PurposeLogin, 90*24*time.Hour)
+}
+
+// CreateTest2FAToken generates a valid JWT token with 2FA purpose for testing.
+// Uses a default 90-day expiration.
+func CreateTest2FAToken(tb testing.TB, ctx TestContext, userID string) string {
+	return CreateTestJWTToken(tb, ctx, userID, jwt.Purpose2FA, 90*24*time.Hour)
+}
+
+// CreateTestAPIToken generates a valid JWT token with API purpose for testing.
+// Uses a default 90-day expiration.
+func CreateTestAPIToken(tb testing.TB, ctx TestContext, userID string) string {
+	return CreateTestJWTToken(tb, ctx, userID, jwt.PurposeAPI, 90*24*time.Hour)
+}
+
+// CreateTestAPIKeyToken generates a valid API key JWT for testing purposes with custom key ID.
+func CreateTestAPIKeyToken(tb testing.TB, ctx TestContext, userID string, keyID uuid.UUID) string {
+	pk := ctx.Config().Config().Core.Identity.PrivateKey()
+	apiKeyToken, err := jwt.CreateToken(
+		pk,
+		ctx.Config().Config().Core.Domain,
+		userID,
+		jwt.PurposeAPI,
+		24*time.Hour,
+		jwt.WithClaims(&gjwt.RegisteredClaims{
+			ID: keyID.String(),
+		}),
+	)
+	require.NoError(tb, err, "Failed to generate test API key token")
+	return apiKeyToken
 }

--- a/core/testing/mock_auth.go
+++ b/core/testing/mock_auth.go
@@ -1,7 +1,9 @@
 package testing
 
 import (
+	"context"
 	"fmt"
+	"sync"
 
 	"github.com/stretchr/testify/mock"
 	"go.lumeweb.com/portal/config"
@@ -13,12 +15,20 @@ import (
 
 // MockAuthService provides high-level helper functions that embed MockAuthService.
 // It automatically sets up mock expectations and provides convenient methods for common auth operations.
+// LoginTokenRegistry holds pre-registered token data for lazy login handling.
+type LoginTokenRegistry struct {
+	token string
+	user  *models.User
+}
+
 type MockAuthService struct {
 	*mocks.MockAuthService
-	userSvc   *MockUserService
+	userSvc        *MockUserService
 	componentConfig config.Manager
-	ctx        TestContext
-	jwtHelper  *JWTHelper
+	ctx             TestContext
+	jwtHelper       *JWTHelper
+	tokenRegistry   map[string]LoginTokenRegistry // email => token+user for lazy setup
+	registryMutex   sync.RWMutex
 }
 
 // NewMockAuthService creates a new MockAuthService that embeds auth mock and has private user mock.
@@ -27,6 +37,7 @@ func NewMockAuthService(ctx TestContext) *MockAuthService {
 		MockAuthService: mocks.NewMockAuthService(ctx.T()),
 		ctx:             ctx,
 		jwtHelper:       NewJWTHelper(ctx),
+		tokenRegistry:   make(map[string]LoginTokenRegistry),
 	}
 
 	// Register a startup function to get the user service
@@ -38,29 +49,97 @@ func NewMockAuthService(ctx TestContext) *MockAuthService {
 	return mockAuth
 }
 
-// CreateAndLoginUser creates a test user and returns JWT token with automatic mock setup.
+// ===== Token Registration =====
+
+// RegisterLoginToken registers a token for a specific email. When LoginPassword is called
+// for this email, it will return this token lazily along with a default user.
+// Use this before making HTTP requests to ensure the mock returns your pre-generated token.
+func (m *MockAuthService) RegisterLoginToken(email string, token string) {
+	m.RegisterLoginTokenWithUser(email, token, nil)
+}
+
+// RegisterLoginTokenWithUser registers a token and user for a specific email. When LoginPassword is called
+// for this email, it will return this token and the provided user lazily without needing prior expectation setup.
+// Use this when you need to return a user with specific properties (e.g., OTPEnabled=true).
+// Pass nil for user to get a default user with just ID and email set.
+func (m *MockAuthService) RegisterLoginTokenWithUser(email string, token string, user *models.User) {
+	m.registryMutex.Lock()
+	defer m.registryMutex.Unlock()
+	m.tokenRegistry[email] = LoginTokenRegistry{
+		token: token,
+		user:  user,
+	}
+}
+
+// GetRegisteredToken returns the registered token and user for an email.
+func (m *MockAuthService) GetRegisteredToken(email string) (string, *models.User, bool) {
+	m.registryMutex.RLock()
+	defer m.registryMutex.RUnlock()
+	entry, exists := m.tokenRegistry[email]
+	if !exists {
+		return "", nil, false
+	}
+	return entry.token, entry.user, true
+}
+
+// ===== Expectation Setup Helpers =====
+
+// ExpectLoginForUser sets up a LoginPassword expectation for a specific user with a pre-generated token.
+// Use this in tests before making HTTP requests - the token will be returned when LoginPassword is called.
+func (m *MockAuthService) ExpectLoginForUser(email string, password string, user *models.User, token string) {
+	m.EXPECT().LoginPassword(mock.Anything, email, password, mock.Anything, mock.Anything).
+		Return(token, user, nil)
+}
+
+// ExpectLoginForUserWithErr sets up a LoginPassword expectation that returns an error.
+func (m *MockAuthService) ExpectLoginForUserWithErr(email string, password string, err error) {
+	m.EXPECT().LoginPassword(mock.Anything, email, password, mock.Anything, mock.Anything).
+		Return("", nil, err)
+}
+
+// ExpectLoginID sets up a LoginID expectation with a specific token.
+func (m *MockAuthService) ExpectLoginID(userID uint, token string, err error) {
+	m.EXPECT().LoginID(mock.Anything, userID, mock.Anything, mock.Anything).Return(token, err)
+}
+
+// ExpectLoginOTP sets up a LoginOTP expectation with a specific token.
+func (m *MockAuthService) ExpectLoginOTP(userID uint, otpCode string, token string, err error) {
+	m.EXPECT().LoginOTP(mock.Anything, userID, otpCode, mock.Anything).Return(token, err)
+}
+
+// ExpectLoginPubkey sets up a LoginPubkey expectation with a specific token.
+func (m *MockAuthService) ExpectLoginPubkey(pubkey string, token string, err error) {
+	m.EXPECT().LoginPubkey(mock.Anything, pubkey, mock.Anything, mock.Anything).Return(token, err)
+}
+
+// RegisterLoginForUser generates a token and sets up expectation - returns token for testing.
+// Use this when you need the token but want one-step setup.
+func (m *MockAuthService) RegisterLoginForUser(email string, password string, user *models.User) (string, error) {
+	token := m.generateTestToken(user.ID)
+	m.ExpectLoginForUser(email, password, user, token)
+	return token, nil
+}
+
+// ===== High-Level Helper Methods =====
+
+// CreateAndLoginUser creates a test user and sets up login expectation with valid JWT token.
+// Returns the generated token and user for use in tests.
 func (m *MockAuthService) CreateAndLoginUser(email, password string) (string, *models.User, error) {
-	// Create test user object
 	user := &models.User{
-		Model:        gorm.Model{ID: 1},
-		Email:        email,
+		Model:    gorm.Model{ID: 1},
+		Email:    email,
 		PasswordHash: m.hashPassword(password),
-		Verified:     true,
+		Verified: true,
 	}
 
-	// Setup mock expectations for login
-	m.setupLoginExpectations(user, "127.0.0.1", false)
-
-	// Mock of login response
 	token := m.generateTestToken(user.ID)
-	m.EXPECT().LoginPassword(mock.Anything, email, password, "127.0.0.1", false).Return(token, user, nil)
+	m.ExpectLoginForUser(email, password, user, token)
 
 	return token, user, nil
 }
 
-// CreateAndLoginUserWithRemember creates a test user and returns long-lived JWT token with automatic mock setup.
+// CreateAndLoginUserWithRemember creates a test user and sets up expectation with long-lived token.
 func (m *MockAuthService) CreateAndLoginUserWithRemember(email, password string) (string, *models.User, error) {
-	// Create test user object
 	user := &models.User{
 		Model:        gorm.Model{ID: 1},
 		Email:        email,
@@ -68,23 +147,17 @@ func (m *MockAuthService) CreateAndLoginUserWithRemember(email, password string)
 		Verified:     true,
 	}
 
-	// Setup mock expectations for login
-	m.setupLoginExpectations(user, "127.0.0.1", true)
-
-	// Mock of login response with long-lived token
-	token, err := m.jwtHelper.CreateLongLivedToken(user.ID, 30) // 30 days
+	token, err := m.jwtHelper.CreateLongLivedToken(user.ID, 30)
 	if err != nil {
-		// Fallback to regular token if long-lived token creation fails
 		token = m.generateTestToken(user.ID)
 	}
-	m.EXPECT().LoginPassword(mock.Anything, email, password, "127.0.0.1", true).Return(token, user, nil).Maybe()
+	m.ExpectLoginForUser(email, password, user, token)
 
 	return token, user, nil
 }
 
-// LoginUser logs in an existing user and returns JWT token with automatic mock setup.
+// LoginUser sets up expectation for existing user login (no password check).
 func (m *MockAuthService) LoginUser(email, password string) (string, *models.User, error) {
-	// Create test user object (would normally be found via user service)
 	user := &models.User{
 		Model:        gorm.Model{ID: 1},
 		Email:        email,
@@ -92,80 +165,126 @@ func (m *MockAuthService) LoginUser(email, password string) (string, *models.Use
 		Verified:     true,
 	}
 
-	// Setup mock expectations for login
-	m.setupLoginExpectations(user, "127.0.0.1", false)
-
-	// Mock of login response
 	token := m.generateTestToken(user.ID)
-	m.EXPECT().LoginPassword(mock.Anything, email, password, "127.0.0.1", false).Return(token, user, nil)
+	m.ExpectLoginForUser(email, password, user, token)
 
 	return token, user, nil
 }
 
-// LoginUserWithIP logs in an existing user with custom IP and returns JWT token with automatic mock setup.
-func (m *MockAuthService) LoginUserWithIP(email, password, ip string) (string, *models.User, error) {
-	// Create test user object
-	user := &models.User{
-		Model:        gorm.Model{ID: 1},
-		Email:        email,
-		PasswordHash: m.hashPassword(password),
-		Verified:     true,
-	}
-
-	// Setup mock expectations for login
-	m.setupLoginExpectations(user, ip, false)
-
-	// Mock of login response
-	token := m.generateTestToken(user.ID)
-	m.EXPECT().LoginPassword(mock.Anything, email, password, ip, false).Return(token, user, nil).Maybe()
-
-	return token, user, nil
-}
-
-// LoginUserByID logs in by user ID and returns JWT token with automatic mock setup.
+// LoginUserByID sets up expectation for login by ID.
 func (m *MockAuthService) LoginUserByID(userID uint) (string, error) {
-	// Create test user object
-	user := &models.User{
-		Model:        gorm.Model{ID: userID},
-		Email:        fmt.Sprintf("user%d@example.com", userID),
-		PasswordHash: m.hashPassword("password"),
-		Verified:     true,
-	}
-
-	// Setup mock expectations for login
-	m.setupLoginExpectations(user, "127.0.0.1", false)
-
-	// Mock of login response
-	token := m.generateTestToken(user.ID)
-	m.EXPECT().LoginID(mock.Anything, userID, "127.0.0.1", false).Return(token, nil)
-
+	token := m.generateTestToken(userID)
+	m.ExpectLoginID(userID, token, nil)
 	return token, nil
 }
 
-// LoginUserWithOTP logs in using OTP and returns JWT token with automatic mock setup.
+// LoginUserWithOTP sets up expectation for OTP login.
 func (m *MockAuthService) LoginUserWithOTP(userID uint, otpCode string) (string, error) {
-	// Setup mock expectations for OTP login
-	m.setupOTPLoginExpectations(userID)
-
-	// Mock of OTP login response with 2FA token
 	token, err := m.jwtHelper.Create2FAToken(userID)
 	if err != nil {
-		// Fallback to regular token if 2FA token creation fails
 		token = m.generateTestToken(userID)
 	}
-	m.EXPECT().LoginOTP(mock.Anything, userID, otpCode, false).Return(token, nil)
-
+	m.ExpectLoginOTP(userID, otpCode, token, nil)
 	return token, nil
 }
 
-// ValidatePassword validates password for a user with automatic mock setup.
-func (m *MockAuthService) ValidatePassword(user *models.User, password string) bool {
-	// Mock of password validation
-	isValid := m.validatePasswordHash(user.PasswordHash, password)
-	m.EXPECT().ValidLoginByUserObj(mock.Anything, user, password).Return(isValid)
+// ===== Interface Implementations =====
 
-	return isValid
+// LoginPassword implements core.AuthService.
+// Lazily handles registered tokens or generates default if no expectation set.
+func (m *MockAuthService) LoginPassword(ctx context.Context, email string, password string, ip string, rememberMe bool) (string, *models.User, error) {
+	// If test already set up an expectation, delegate to mock
+	if HasExpectationForMethod(&m.MockAuthService.Mock, "LoginPassword") {
+		return m.MockAuthService.LoginPassword(ctx, email, password, ip, rememberMe)
+	}
+
+	// Check if a token was registered for this email
+	if token, user, exists := m.GetRegisteredToken(email); exists {
+		// If user was provided with the registration, use it; otherwise create default
+		if user == nil {
+			user = &models.User{
+				Model:    gorm.Model{ID: 1},
+				Email:    email,
+				Verified: true,
+			}
+		}
+		return token, user, nil
+	}
+
+	// No expectation and no registered token - generate default
+	user := &models.User{
+		Model:    gorm.Model{ID: 1},
+		Email:    email,
+		Verified: true,
+	}
+	token := m.generateTestToken(1)
+	return token, user, nil
 }
+
+// LoginID implements core.AuthService.
+// Lazily generates default token if no expectation set.
+func (m *MockAuthService) LoginID(ctx context.Context, id uint, ip string, rememberMe bool) (string, error) {
+	if HasExpectationForMethod(&m.MockAuthService.Mock, "LoginID") {
+		return m.MockAuthService.LoginID(ctx, id, ip, rememberMe)
+	}
+	return m.generateTestToken(id), nil
+}
+
+// LoginOTP implements core.AuthService.
+// Lazily generates default token if no expectation set.
+func (m *MockAuthService) LoginOTP(ctx context.Context, userId uint, code string, rememberMe bool) (string, error) {
+	if HasExpectationForMethod(&m.MockAuthService.Mock, "LoginOTP") {
+		return m.MockAuthService.LoginOTP(ctx, userId, code, rememberMe)
+	}
+	return m.generateTestToken(userId), nil
+}
+
+// LoginPubkey implements core.AuthService.
+// Lazily generates default token if no expectation set.
+func (m *MockAuthService) LoginPubkey(ctx context.Context, pubkey string, ip string, rememberMe bool) (string, error) {
+	if HasExpectationForMethod(&m.MockAuthService.Mock, "LoginPubkey") {
+		return m.MockAuthService.LoginPubkey(ctx, pubkey, ip, rememberMe)
+	}
+	return m.generateTestToken(1), nil
+}
+
+// ValidLoginByUserObj implements core.AuthService.
+func (m *MockAuthService) ValidLoginByUserObj(ctx context.Context, user *models.User, password string) bool {
+	return m.validatePasswordHash(user.PasswordHash, password)
+}
+
+// ValidLoginByEmail implements core.AuthService.
+func (m *MockAuthService) ValidLoginByEmail(ctx context.Context, email string, password string) (bool, *models.User, error) {
+	if HasExpectationForMethod(&m.MockAuthService.Mock, "ValidLoginByEmail") {
+		return m.MockAuthService.ValidLoginByEmail(ctx, email, password)
+	}
+
+	user := &models.User{
+		Model:    gorm.Model{ID: 1},
+		Email:    email,
+		PasswordHash: m.hashPassword(password),
+		Verified: true,
+	}
+	valid := m.validatePasswordHash(m.hashPassword(password), password)
+	return valid, user, nil
+}
+
+// ValidLoginByUserID implements core.AuthService.
+func (m *MockAuthService) ValidLoginByUserID(ctx context.Context, id uint, password string) (bool, *models.User, error) {
+	if HasExpectationForMethod(&m.MockAuthService.Mock, "ValidLoginByUserID") {
+		return m.MockAuthService.ValidLoginByUserID(ctx, id, password)
+	}
+
+	user := &models.User{
+		Model:    gorm.Model{ID: id},
+		PasswordHash: m.hashPassword(password),
+		Verified: true,
+	}
+	valid := m.validatePasswordHash(m.hashPassword(password), password)
+	return valid, user, nil
+}
+
+// ===== Setup Methods =====
 
 // SetupLoginExpectations manually sets up login expectations for a user.
 func (m *MockAuthService) SetupLoginExpectations(user *models.User, ip string, rememberMe bool) {
@@ -195,9 +314,10 @@ func (m *MockAuthService) setupOTPLoginExpectations(userID uint) {
 	m.userSvc.MockUserService.EXPECT().UpdateAccountInfo(mock.Anything, userID, mock.Anything).Return(nil).Maybe()
 }
 
+// ===== Private Methods =====
+
 // hashPassword creates a simple hash for testing (in real scenario would use bcrypt)
 func (m *MockAuthService) hashPassword(password string) string {
-	// Simple hash for testing - in real implementation would use bcrypt
 	return fmt.Sprintf("hashed_%s", password)
 }
 
@@ -216,47 +336,51 @@ func (m *MockAuthService) generateTestToken(userID uint) string {
 	return token
 }
 
+// ===== Service Getters =====
+
 // GetUserService returns embedded user service for advanced usage.
 func (m *MockAuthService) GetUserService() *MockUserService {
 	return m.userSvc
 }
 
-// Config implements core.Component
+// ===== Component Implementation =====
+
+// Config implements core.Component.
 func (m *MockAuthService) Config() config.Manager {
 	return m.componentConfig
 }
 
-// SetConfig implements core.Component
+// SetConfig implements core.Component.
 func (m *MockAuthService) SetConfig(cfg config.Manager) {
 	m.componentConfig = cfg
 }
 
-// Context implements core.Component
+// Context implements core.Component.
 func (m *MockAuthService) Context() core.Context {
 	return m.ctx
 }
 
-// SetContext implements core.Component
+// SetContext implements core.Component.
 func (m *MockAuthService) SetContext(coreCtx core.Context) {
 	if testCtx, ok := coreCtx.(TestContext); ok {
 		m.ctx = testCtx
 	}
 }
 
-// Logger implements core.Component
+// Logger implements core.Component.
 func (m *MockAuthService) Logger() *core.Logger {
 	return nil
 }
 
-// SetLogger implements core.Component
+// SetLogger implements core.Component.
 func (m *MockAuthService) SetLogger(logger *core.Logger) {
 }
 
-// DB implements core.Component
+// DB implements core.Component.
 func (m *MockAuthService) DB() *gorm.DB {
 	return nil
 }
 
-// SetDB implements core.Component
+// SetDB implements core.Component.
 func (m *MockAuthService) SetDB(db *gorm.DB) {
 }

--- a/core/testing/mock_http.go
+++ b/core/testing/mock_http.go
@@ -54,13 +54,29 @@ func NewMockHTTPService(t TB) *MockHTTPService {
 	return httpService
 }
 
-// APISubdomain implements core.HTTPService with automatic mock setup
-func (m *MockHTTPService) APISubdomain(id string, proto bool) string {
-	// Set up expectation if not already set
-	if !WasMethodCalled(&m.MockHTTPService.Mock, "APISubdomain", id, proto) {
-		m.EXPECT().APISubdomain(id, proto).Return("")
+// Router implements core.HTTPService with automatic mock setup.
+// If no expectation was set by the test, adds a safe default expectation.
+func (m *MockHTTPService) Router() router.Router {
+	// Check if test already set up an expectation for Router
+	// If not, add a safe default expectation
+	if !HasExpectationForMethod(&m.MockHTTPService.Mock, "Router") {
+		m.EXPECT().Router().Return(m.router).Maybe()
 	}
 
+	// Delegate to the underlying mock implementation
+	return m.MockHTTPService.Router()
+}
+
+// APISubdomain implements core.HTTPService with automatic mock setup.
+// If no expectation was set by the test, adds a safe default expectation.
+func (m *MockHTTPService) APISubdomain(id string, proto bool) string {
+	// Check if test already set up an expectation for APISubdomain
+	// If not, add a safe default expectation
+	if !HasExpectationForMethod(&m.MockHTTPService.Mock, "APISubdomain") {
+		m.EXPECT().APISubdomain(mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return("").Maybe()
+	}
+
+	// Delegate to the underlying mock implementation
 	return m.MockHTTPService.APISubdomain(id, proto)
 }
 
@@ -82,33 +98,42 @@ func (m *MockHTTPService) apiSubdomainFunc(id string, proto bool) func(string, b
 	}
 }
 
-// Serve implements core.HTTPService with automatic mock setup
+// Serve implements core.HTTPService with automatic mock setup.
+// If no expectation was set by the test, adds a safe default expectation.
 func (m *MockHTTPService) Serve() error {
-	// Set up expectation if not already set
-	if !WasMethodCalled(&m.MockHTTPService.Mock, "Serve") {
-		m.EXPECT().Serve().Return(nil)
+	// Check if test already set up an expectation for Serve
+	// If not, add a safe default expectation
+	if !HasExpectationForMethod(&m.MockHTTPService.Mock, "Serve") {
+		m.EXPECT().Serve().Return(nil).Maybe()
 	}
 
+	// Delegate to the underlying mock implementation
 	return m.MockHTTPService.Serve()
 }
 
-// Init implements core.HTTPService with automatic mock setup
+// Init implements core.HTTPService with automatic mock setup.
+// If no expectation was set by the test, adds a safe default expectation.
 func (m *MockHTTPService) Init() error {
-	// Set up expectation if not already set
-	if !WasMethodCalled(&m.MockHTTPService.Mock, "Init") {
-		m.EXPECT().Init().Return(nil)
+	// Check if test already set up an expectation for Init
+	// If not, add a safe default expectation
+	if !HasExpectationForMethod(&m.MockHTTPService.Mock, "Init") {
+		m.EXPECT().Init().Return(nil).Maybe()
 	}
 
+	// Delegate to the underlying mock implementation
 	return m.MockHTTPService.Init()
 }
 
-// RegisterGlobalPath implements core.HTTPService with automatic mock setup
+// RegisterGlobalPath implements core.HTTPService with automatic mock setup.
+// If no expectation was set by the test, adds a safe default expectation.
 func (m *MockHTTPService) RegisterGlobalPath(path string) error {
-	// Set up expectation if not already set
-	if !WasMethodCalled(&m.MockHTTPService.Mock, "RegisterGlobalPath", path) {
-		m.EXPECT().RegisterGlobalPath(path).Return(nil)
+	// Check if test already set up an expectation for RegisterGlobalPath
+	// If not, add a safe default expectation
+	if !HasExpectationForMethod(&m.MockHTTPService.Mock, "RegisterGlobalPath") {
+		m.EXPECT().RegisterGlobalPath(mock.AnythingOfType("string")).Return(nil).Maybe()
 	}
 
+	// Delegate to the underlying mock implementation
 	return m.MockHTTPService.RegisterGlobalPath(path)
 }
 

--- a/core/testing/mock_user.go
+++ b/core/testing/mock_user.go
@@ -139,21 +139,6 @@ func (m *MockUserService) UserDoesNotExist(userID uint) (bool, *models.User, err
 	return false, nil, nil
 }
 
-// EmailExists checks if email exists with automatic mock setup.
-func (m *MockUserService) EmailExists(ctx context.Context, email string) (bool, *models.User, error) {
-	// Create test user object
-	user := &models.User{
-		Model:    gorm.Model{ID: 1},
-		Email:    email,
-		Verified: true,
-	}
-
-	// Mock of EmailExists response
-	m.EXPECT().EmailExists(mock.Anything, email).Return(true, user, nil)
-
-	return true, user, nil
-}
-
 // EmailDoesNotExist checks if email does not exist with automatic mock setup.
 func (m *MockUserService) EmailDoesNotExist(email string) (bool, *models.User, error) {
 	// Mock of EmailExists response for not found
@@ -210,16 +195,6 @@ func (m *MockUserService) AddPublicKeyFails(user *models.User, publicKey string)
 	return fmt.Errorf("key already exists")
 }
 
-// HashPassword hashes a password with automatic mock setup.
-func (m *MockUserService) HashPassword(password string) (string, error) {
-	hash := m.hashPassword(password)
-
-	// Mock of HashPassword response
-	m.EXPECT().HashPassword(password).Return(hash, nil)
-
-	return hash, nil
-}
-
 // HashPasswordFails simulates password hashing failure with automatic mock setup.
 func (m *MockUserService) HashPasswordFails(password string) (string, error) {
 	// Mock of HashPassword response with error
@@ -241,6 +216,49 @@ func (m *MockUserService) SetupEmailExistsExpectation(email string, exists bool,
 // SetupUpdateAccountInfoExpectation sets up account info update expectation.
 func (m *MockUserService) SetupUpdateAccountInfoExpectation(userID uint, updateData map[string]any, err error) {
 	m.EXPECT().UpdateAccountInfo(mock.Anything, userID, updateData).Return(err)
+}
+
+// AccountExists checks if account exists by ID with automatic mock setup.
+// If no expectation was set by the test, adds a safe default expectation.
+func (m *MockUserService) AccountExists(ctx context.Context, userID uint) (bool, *models.User, error) {
+	// Check if test already set up an expectation for AccountExists
+	// If not, add a safe default expectation (account does not exist)
+	if !HasExpectationForMethod(&m.MockUserService.Mock, "AccountExists") {
+		m.EXPECT().AccountExists(mock.Anything, mock.AnythingOfType("uint")).
+			Return(false, nil, nil).Maybe()
+	}
+
+	// Delegate to the underlying mock implementation
+	return m.MockUserService.AccountExists(ctx, userID)
+}
+
+// EmailExists checks if email exists with automatic mock setup.
+// If no expectation was set by the test, adds a safe default expectation.
+func (m *MockUserService) EmailExists(ctx context.Context, email string) (bool, *models.User, error) {
+	// Check if test already set up an expectation for EmailExists
+	// If not, add a safe default expectation (email does not exist)
+	if !HasExpectationForMethod(&m.MockUserService.Mock, "EmailExists") {
+		m.EXPECT().EmailExists(mock.Anything, mock.AnythingOfType("string")).
+			Return(false, nil, nil).Maybe()
+	}
+
+	// Delegate to the underlying mock implementation
+	return m.MockUserService.EmailExists(ctx, email)
+}
+
+// HashPassword hashes a password with automatic mock setup.
+// If no expectation was set by the test, adds a safe default expectation.
+func (m *MockUserService) HashPassword(password string) (string, error) {
+	// Check if test already, add a safe default expectation
+	if !HasExpectationForMethod(&m.MockUserService.Mock, "HashPassword") {
+		// Generate a simple hash for the default return
+		hash := m.hashPassword(password)
+		m.EXPECT().HashPassword(mock.AnythingOfType("string")).
+			Return(hash, nil).Maybe()
+	}
+
+	// Delegate to the underlying mock implementation
+	return m.MockUserService.HashPassword(password)
 }
 
 // hashPassword creates a simple hash for testing (in real scenario would use bcrypt)

--- a/core/testing/mock_util.go
+++ b/core/testing/mock_util.go
@@ -4,6 +4,18 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// HasExpectationForMethod checks if any expectation already exists for a given method.
+// This allows helper methods to avoid adding duplicate expectations.
+// Used in mock helper implementations to ensure we only add defaults when needed.
+func HasExpectationForMethod(m *mock.Mock, methodName string) bool {
+	for _, call := range m.ExpectedCalls {
+		if call.Method == methodName {
+			return true
+		}
+	}
+	return false
+}
+
 // WasMethodCalled checks if a method was called on the mock with the given arguments.
 // Returns true if the method was called with matching arguments, false otherwise.
 // Unlike testify's AssertCalled, this doesn't fail the test if not called.


### PR DESCRIPTION
Resolves a design flaw where helper methods on mock objects shadowed interface methods and returned hardcoded values instead of delegating to the underlying mock. This caused test expectations to be silently ignored.

Changes:
- Fixed mock UserService helpers (EmailExists, HashPassword, AccountExists) to delegate to underlying mock instead of returning immediately
- Added HasExpectationForMethod utility to detect if test already set up expectations, only adding safe defaults when needed
- Refactored MockAuthService to delegate LoginPassword properly and added token registry for lazy expectation setup
- Added top-level JWT helper functions for convenient token creation in tests

Impact:
Tests can now properly set expectations on mocked interface methods, and helper methods respect those expectations instead of bypassing them. This eliminates flaky test failures where expectations were incorrectly ignored.


---

<!-- kody-pr-summary:start -->
 This pull request resolves a critical issue in the testing framework where mock helper methods were unconditionally setting expectations, causing test-specific expectations to be ignored or overwritten (the "footgun").

**Key Changes:**

**1. Fixed Mock Expectation Handling**
- Added `HasExpectationForMethod` utility to detect when tests have already set explicit expectations
- Modified mock helpers (`MockAuthService`, `MockUserService`, `MockHTTPService`) to only apply safe default expectations when none exist, preventing automatic overrides of test-defined behavior
- Changed default expectations to use `.Maybe()` to avoid strict assertion failures when tests provide their own expectations

**2. Introduced Token Registration System for Auth Testing**
- Added `LoginTokenRegistry` with thread-safe storage for pre-registering authentication tokens by email
- New methods `RegisterLoginToken` and `RegisterLoginTokenWithUser` allow tests to register tokens before making HTTP requests, enabling lazy evaluation during login flows
- Tests can now pre-configure specific user states (e.g., OTP-enabled users) without complex setup sequences

**3. Added Explicit Expectation Helpers**
- New explicit setup methods: `ExpectLoginForUser`, `ExpectLoginForUserWithErr`, `ExpectLoginID`, `ExpectLoginOTP`, `ExpectLoginPubkey`
- These provide clear intent-based APIs for setting up mock behavior versus the previous automatic setup that could mask test failures

**4. Implemented Lazy Interface Methods**
- Auth service methods (`LoginPassword`, `LoginID`, `LoginOTP`, `LoginPubkey`) now check for existing expectations first, falling back to registered tokens or safe defaults only when needed
- User service methods (`AccountExists`, `EmailExists`, `HashPassword`) follow the same pattern

**5. Added Top-Level JWT Helpers**
- New convenience functions `CreateTestJWTToken`, `CreateTestLoginToken`, `CreateTest2FAToken`, `CreateTestAPIToken`, `CreateTestAPIKeyToken` that work without requiring a `JWTHelper` instance

**Impact:** Tests now have full control over mock expectations without helper methods silently overriding them, while still benefiting from sensible defaults when no specific expectations are set. This eliminates false positives where tests passed due to ignored assertions.
<!-- kody-pr-summary:end -->