### PR TITLE
fix(core, tus): detach context in long-running workflows

### DIFF
--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -245,8 +245,10 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 	}
 
 	// Define the task function
+	// Detach context to avoid cancellation in long-running jobs
+	jobCtx := core.DetachContext(ctx)
 	taskFunc := func(jobID uuid.UUID) error {
-		return s.ExecuteJob(ctx, jobID)
+		return s.ExecuteJob(jobCtx, jobID)
 	}
 
 	// Validate retry policy before computing delay
@@ -292,7 +294,7 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 			zap.String("jobName", jobName))
 
 		// Perform any pre-execution tasks here
-		if err := s.SetupJob(ctx, jobID); err != nil {
+		if err := s.SetupJob(jobCtx, jobID); err != nil {
 			s.logger.Error("Failed to setup job",
 				zap.String("jobID", jobID.String()),
 				zap.Error(err))
@@ -303,7 +305,7 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 	afterJobRuns := func(jobID uuid.UUID, jobName string) {
 		s.logger.Debug("After job runs", zap.String("jobID", jobID.String()), zap.String("jobName", jobName))
 		// Perform any post-execution tasks here
-		if err = s.CleanupJob(ctx, jobID); err != nil {
+		if err = s.CleanupJob(jobCtx, jobID); err != nil {
 			s.logger.Error("Failed to cleanup job", zap.String("jobID", jobID.String()), zap.Error(err))
 		}
 	}
@@ -322,7 +324,7 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 		s.failureMu.Unlock()
 
 		// Handle all failure transitions through HandleFailedJob
-		if err := s.HandleFailedJob(ctx, jobID, uint(failures)); err != nil {
+		if err := s.HandleFailedJob(jobCtx, jobID, uint(failures)); err != nil {
 			s.logger.Error("Failed to handle failed job",
 				zap.String("jobID", jobID.String()),
 				zap.Error(err))
@@ -344,7 +346,7 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 
 		// Handle all failure transitions through HandleFailedJob
 		// For panic recovery, we'll treat it as a retryable failure (not permanent)
-		if err := s.HandleFailedJob(ctx, jobID, uint(failures)); err != nil {
+		if err := s.HandleFailedJob(jobCtx, jobID, uint(failures)); err != nil {
 			s.logger.Error("Failed to handle failed job", zap.String("jobID", jobID.String()), zap.Error(err))
 		}
 	}

--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -353,7 +353,10 @@ func (t *TusHandlerDefault) init(ctx context.Context, handlerConfig core.TUSHand
 	return nil
 }
 func (t *TusHandlerDefault) worker() {
-	ctx := t.ctx
+	// Detach context to avoid cancellation in long-running goroutines
+	// The service context may be canceled during shutdown, but upload processing
+	// should continue to completion.
+	ctx := core.DetachContext(t.ctx)
 
 	// Handle created uploads
 	go func() {
@@ -624,9 +627,7 @@ func DefaultUploadCompletedHandler(ctx core.Context, processHandler core.TUSUplo
 			}
 
 			// Get the upload reader
-			// IMPORTANT: Use the service context (ctx) instead of hook.Context
-			// because hook.Context is the HTTP request context which is canceled after
-			// the upload completes, and this handler runs in a goroutine after completion.
+			// Note: ctx is already detached from the worker goroutine
 			reader, err := handlr.UploadReader(ctx, hook.Upload.ID, protocol, 0)
 			if err != nil {
 				errMessage := fmt.Sprintf("failed to get upload reader for %s: %v", hook.Upload.ID, err)

--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -32,20 +32,21 @@ const CtxRangeKey CtxRangeKeyType = "range"
 var _ core.TusHandler = (*TusHandlerDefault)(nil)
 
 type TusHandlerDefault struct {
-	handlerConfig core.TUSHandlerConfig
-	ctx           core.Context
-	db            *gorm.DB
-	config        config.Manager
-	logger        *core.Logger
-	tusService    core.TUSService
-	cron          core.CronService
-	storage       core.StorageService
-	users         core.UserService
-	metadata      core.UploadService
-	requests      core.RequestService
-	tus           *handler.Handler
-	tusStore      handler.DataStore
-	s3Client      *s3.Client
+	handlerConfig  core.TUSHandlerConfig
+	ctx            core.Context
+	db             *gorm.DB
+	config         config.Manager
+	logger         *core.Logger
+	tusService     core.TUSService
+	cron           core.CronService
+	storage        core.StorageService
+	users          core.UserService
+	metadata       core.UploadService
+	requests       core.RequestService
+	tus            *handler.Handler
+	tusStore       handler.DataStore
+	s3Client       *s3.Client
+	workerCancel   context.CancelFunc
 }
 
 func (t *TusHandlerDefault) GetTusHandler() *handler.Handler {
@@ -353,16 +354,21 @@ func (t *TusHandlerDefault) init(ctx context.Context, handlerConfig core.TUSHand
 	return nil
 }
 func (t *TusHandlerDefault) worker() {
-	// Detach context to avoid cancellation in long-running goroutines
-	// The service context may be canceled during shutdown, but upload processing
-	// should continue to completion.
-	ctx := core.DetachContext(t.ctx)
+	// Detach context for upload operations to survive service cancellation
+	// This allows in-progress uploads to complete during shutdown
+	detachedCtx := core.DetachContext(t.ctx)
+
+	// Create cancellable sub-context for worker lifecycle management
+	// This allows graceful shutdown while preserving upload operation context
+	workerCtx, cancel := context.WithCancel(detachedCtx)
+	t.workerCancel = cancel
+	defer cancel()
 
 	// Handle created uploads
 	go func() {
 		for {
 			select {
-			case <-ctx.Done():
+			case <-workerCtx.Done():
 				return
 			case info := <-t.tus.CreatedUploads:
 				if t.handlerConfig.CreatedUploadHandler != nil {
@@ -376,7 +382,7 @@ func (t *TusHandlerDefault) worker() {
 	go func() {
 		for {
 			select {
-			case <-ctx.Done():
+			case <-workerCtx.Done():
 				return
 			case info := <-t.tus.UploadProgress:
 				if t.handlerConfig.UploadProgressHandler != nil {
@@ -390,7 +396,7 @@ func (t *TusHandlerDefault) worker() {
 	go func() {
 		for {
 			select {
-			case <-ctx.Done():
+			case <-workerCtx.Done():
 				return
 			case info := <-t.tus.TerminatedUploads:
 				if t.handlerConfig.TerminatedUploadHandler != nil {
@@ -404,7 +410,7 @@ func (t *TusHandlerDefault) worker() {
 	go func() {
 		for {
 			select {
-			case <-ctx.Done():
+			case <-workerCtx.Done():
 				return
 			case info := <-t.tus.CompleteUploads:
 				if t.handlerConfig.CompletedUploadHandler != nil {
@@ -413,6 +419,14 @@ func (t *TusHandlerDefault) worker() {
 			}
 		}
 	}()
+}
+
+// Shutdown gracefully terminates the worker goroutines
+// This should be called during service shutdown to prevent goroutine leaks
+func (t *TusHandlerDefault) Shutdown() {
+	if t.workerCancel != nil {
+		t.workerCancel()
+	}
 }
 
 func getLockerMode(cm config.Manager, logger *core.Logger) string {


### PR DESCRIPTION
Apply DetachContext in TUS worker and cron closures to prevent
"context canceled" errors during service shutdown.

- TUS worker: Detach context in goroutines
- Cron closures: Use detached job context in event listeners


---

<!-- kody-pr-summary:start -->
This PR fixes context propagation issues in long-running workflows that could cause premature cancellation of background operations.

In the cron job coordinator, job execution contexts are now detached from the original scheduling context to prevent cancellation signals from propagating to long-running background jobs. This ensures that job setup, execution, cleanup, and failure handling continue processing even if the original context is canceled.

Similarly, in the TUS upload handler, the worker goroutine now operates with a detached context to ensure upload processing continues to completion even if the service context is canceled during shutdown or the HTTP request context expires.

These changes improve the reliability of background operations by ensuring they are not prematurely terminated by context cancellation signals.
<!-- kody-pr-summary:end -->