### PR TITLE
fix(tus): block worker to prevent immediate shutdown

### DIFF
--- a/service/internal/tus/tus.go
+++ b/service/internal/tus/tus.go
@@ -419,6 +419,9 @@ func (t *TusHandlerDefault) worker() {
 			}
 		}
 	}()
+
+	// Wait for shutdown signal
+	<-workerCtx.Done()
 }
 
 // Shutdown gracefully terminates the worker goroutines


### PR DESCRIPTION
Worker function was exiting immediately after spawning goroutines, causing all
upload event handlers to shut down before processing any events.


---

<!-- kody-pr-summary:start -->
 This pull request fixes an issue where the TUS worker would exit immediately after starting, rather than remaining active to process operations. 

The change adds a blocking operation that waits for the shutdown signal (`workerCtx.Done()`), ensuring the worker goroutine stays alive and continues processing until a graceful shutdown is explicitly requested. This prevents premature termination of the TUS upload handler service.
<!-- kody-pr-summary:end -->