### PR TITLE
fix(config): override ConfigDir and ConfigFile methods to return ManagerDefault paths

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -162,6 +162,18 @@ func (m *ManagerDefault) setConfigPaths(configFile string) {
 	m.configDir = filepath.Dir(configFile)
 }
 
+// ConfigDir returns the path to the configuration directory
+// This overrides the embedded configmanager.Manager's ConfigDir() method
+func (m *ManagerDefault) ConfigDir() string {
+	return m.configDir
+}
+
+// ConfigFile returns the path to the configuration file
+// This overrides the embedded configmanager.Manager's ConfigFile() method
+func (m *ManagerDefault) ConfigFile() string {
+	return m.configFile
+}
+
 var _ Manager = (*ManagerDefault)(nil)
 
 // ManagerConfig holds dependencies and options required to construct a Manager, including the ConfigManager for


### PR DESCRIPTION
ManagerDefault embeds configmanager.Manager which has its own configDir
field defaulting to ".". ManagerDefault also has its own configDir/
configFile fields that are correctly set via setConfigPaths().

When protocol code calls ctx.Config().ConfigDir(), it was returning the
embedded Manager's ConfigDir() value (".") instead of ManagerDefault's
local fields (temp directory paths).

This fix adds method overrides to ensure ConfigDir() and ConfigFile()
return the values from ManagerDefault's own fields.


---

<!-- kody-pr-summary:start -->
 Override the `ConfigDir()` and `ConfigFile()` methods in `ManagerDefault` to return the instance-specific configuration directory and file paths. This fixes an issue where the embedded config manager's methods would be called instead, potentially returning incorrect paths that don't match the values set via `setConfigPaths()`.
<!-- kody-pr-summary:end -->