### PR TITLE
refactor(workflow): remove automatic deletion from CleanupWorkflow

### DIFF
--- a/core/internal/service_tests/workflow_test.go
+++ b/core/internal/service_tests/workflow_test.go
@@ -160,10 +160,11 @@ func TestSingleStepWorkflowCompletion(t *testing.T) {
 		err = workflowService.CompleteWorkflowStep(context.Background(), req.ID)
 		assert.NoError(tb, err)
 
-		// Verify workflow is completed and cleaned up
+		// Verify workflow is completed (requests remain in database with completed status)
 		updatedReq, err := requestService.GetRequest(context.Background(), req.ID)
-		assert.Error(tb, err) // Should be deleted
-		assert.Nil(tb, updatedReq)
+		assert.NoError(tb, err)
+		assert.NotNil(tb, updatedReq)
+		assert.Equal(tb, models.RequestStatusCompleted, updatedReq.Status)
 
 	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, service.NewRequestService),
 		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, service.NewWorkflowCoordinator),
@@ -665,11 +666,11 @@ func TestWorkflowCleanup(t *testing.T) {
 		err = workflowService.CompleteWorkflowStep(context.Background(), req3.ID)
 		assert.NoError(tb, err)
 
-		// Verify all requests are cleaned up
+		// Verify all requests remain in database with completed status
 		var count int64
-		err = ctx.DB().Model(&models.Request{}).Where("id IN (?, ?, ?)", req1.ID, req2.ID, req3.ID).Count(&count).Error
+		err = ctx.DB().Model(&models.Request{}).Where("id IN (?, ?, ?) AND status = ?", req1.ID, req2.ID, req3.ID, models.RequestStatusCompleted).Count(&count).Error
 		require.NoError(tb, err)
-		assert.Equal(tb, int64(0), count)
+		assert.Equal(tb, int64(3), count)
 
 	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, service.NewRequestService),
 		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, service.NewWorkflowCoordinator),

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -1078,41 +1078,6 @@ func (w *WorkflowCoordinatorDefault) CleanupWorkflow(ctx context.Context, reques
 		workflowMetrics.WorkflowsFailed.WithLabelValues(metadata.WorkflowName, protocol, workflowMetrics.LabelFailureBehaviorFail).Inc()
 	}
 
-	// Iterate through all requests in the workflow
-	currentReqID := requestID
-	for {
-		// Delete the request through RequestService which handles cleanup
-		err = w.requestSvc.DeleteRequest(ctx, currentReqID)
-		if err != nil {
-			w.Logger().Warn("Failed to delete request during cleanup",
-				zap.Uint("requestID", currentReqID),
-				zap.Error(err))
-		}
-
-		// Get the request to check for previous IDs
-		req, err := w.requestSvc.GetRequestWithDeleted(ctx, currentReqID)
-		if err != nil {
-			break // Stop if we can't get the request
-		}
-
-		// Parse metadata to find the previous request
-		metadata, err = w.parseWorkflowMetadata(req.Metadata)
-		if err != nil {
-			w.Logger().Warn("Failed to parse metadata during cleanup",
-				zap.Uint("requestID", currentReqID),
-				zap.Error(err))
-			break
-		}
-
-		// Move to the previous request
-		currentReqID = metadata.PrevRequestID
-
-		// If there is no previous request, we are done
-		if currentReqID == 0 {
-			break
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Remove automatic soft-deletion of workflow requests upon completion.
Status lifecycle (pending → processing → completed/failed) is now
orthogonal to deletion actions.

- DeleteRequest remains as a separate explicit administrative action
- Requests persist in database with their final status
- Enables transparent operation history and debugging visibility
- Updated tests to verify requests remain accessible after completion


---

<!-- kody-pr-summary:start -->
 This pull request modifies the workflow cleanup process to preserve completed workflow requests in the database rather than automatically deleting them.

**Changes:**
- **Removed automatic deletion**: The `CleanupWorkflow` function no longer iterates through and deletes workflow requests upon completion. Previously, the system would physically remove all request records associated with a completed workflow.
- **Preserved audit trail**: Workflow requests now remain in the database with a `completed` status, maintaining a historical record of workflow execution for auditing and debugging purposes.
- **Updated test expectations**: Test cases were adjusted to verify that completed workflows persist in the database with the appropriate status rather than verifying their deletion.

**Impact:**
Workflow history is now retained after completion, allowing for better traceability and post-hoc analysis of workflow execution while still properly finalizing workflows through the cleanup process.
<!-- kody-pr-summary:end -->