### PR TITLE
fix(cron): implement initCron job registration for plugins

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -186,7 +186,7 @@ func (p *PortalImpl) Init() error {
 	}
 	ctxOpts = append(ctxOpts, opts...)
 
-	opts = p.initCron()
+	opts = p.initCron(ctx)
 	ctxOpts = append(ctxOpts, opts...)
 
 	ctxOpts = append(ctxOpts, svcOpts...)
@@ -643,17 +643,28 @@ func (p *PortalImpl) initAPIs(ctx core.Context) (ctxOpts []core.ContextBuilderOp
 	return ctxOpts, nil
 }
 
-func (p *PortalImpl) initCron() (ctxOpts []core.ContextBuilderOption) {
-	/*	for _, plugin := range core.GetPlugins() {
-		if core.PluginHasCron(plugin) {
-			cronFactory := plugin.Cron()
-			if cronFactory == nil {
-				continue
-			}
-
-			ctxOpts = append(ctxOpts, core.ContextWithCron(cronFactory))
+func (p *PortalImpl) initCron(ctx core.Context) (ctxOpts []core.ContextBuilderOption) {
+	ctxOpts = append(ctxOpts, core.ContextWithStartupFunc(func(ctx core.Context) error {
+		cronSvc := core.GetServiceOptional[core.CronService](ctx, core.CRON_SERVICE)
+		if cronSvc == nil {
+			ctx.Logger().Error("Cron service not found")
+			return errors.New("cron service not found")
 		}
-	}*/
+
+		plugins := core.GetPlugins()
+
+		for _, plugin := range plugins {
+			if core.PluginHasCron(plugin) {
+				err := cronSvc.RegisterPluginJobs(ctx.GetContext(), plugin)
+				if err != nil {
+					ctx.Logger().Error("Error registering plugin cron jobs", zap.String("plugin", plugin.ID), zap.Error(err))
+					return err
+				}
+			}
+		}
+
+		return nil
+	}))
 
 	return ctxOpts
 }


### PR DESCRIPTION
Implement initCron() method to register plugin cron jobs during context initialization.
Uses ContextWithStartupFunc pattern to defer registration until after services are available.

Previously, initCron() was entirely commented out and referenced a non-existent API.
Now it properly retrieves cron service and registers plugin cron jobs for all plugins.

---

<!-- kody-pr-summary:start -->
Fixes an issue where plugin-defined cron jobs were not being registered during the portal boot process.

Adds a new registration step to the startup sequence that executes before the cron scheduler starts. This step iterates through all loaded plugins, identifies those with cron job definitions, and registers their jobs with the cron service. This ensures that plugins can properly define cron jobs that will be scheduled and executed by the system.
<!-- kody-pr-summary:end -->