### PR TITLE
fix(cron): fix nil pointer panic by registering jobs after initialization

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -284,6 +284,10 @@ func (p *PortalImpl) Start() error {
 		return err
 	}
 
+	if err := p.registerPluginCron(ctx); err != nil {
+		return err
+	}
+
 	if err := core.Fire(ctx, event.EVENT_BOOT_CRON_COMPLETED, event.NewBootCronCompletedEvent(ctx, ctx.GetContext())); err != nil {
 		ctx.Logger().Error("Error firing boot cron completed event", zap.Error(err))
 		return err
@@ -644,29 +648,30 @@ func (p *PortalImpl) initAPIs(ctx core.Context) (ctxOpts []core.ContextBuilderOp
 }
 
 func (p *PortalImpl) initCron(ctx core.Context) (ctxOpts []core.ContextBuilderOption) {
-	ctxOpts = append(ctxOpts, core.ContextWithStartupFunc(func(ctx core.Context) error {
-		cronSvc := core.GetServiceOptional[core.CronService](ctx, core.CRON_SERVICE)
-		if cronSvc == nil {
-			ctx.Logger().Error("Cron service not found")
-			return errors.New("cron service not found")
-		}
+	return ctxOpts
+}
 
-		plugins := core.GetPlugins()
+func (p *PortalImpl) registerPluginCron(ctx core.Context) error {
+	cronSvc := core.GetServiceOptional[core.CronService](ctx, core.CRON_SERVICE)
 
-		for _, plugin := range plugins {
-			if core.PluginHasCron(plugin) {
-				err := cronSvc.RegisterPluginJobs(ctx.GetContext(), plugin)
-				if err != nil {
-					ctx.Logger().Error("Error registering plugin cron jobs", zap.String("plugin", plugin.ID), zap.Error(err))
-					return err
-				}
+	if cronSvc == nil {
+		ctx.Logger().Error("Cron service not found")
+		return errors.New("cron service not found")
+	}
+
+	plugins := core.GetPlugins()
+
+	for _, plugin := range plugins {
+		if core.PluginHasCron(plugin) {
+			err := cronSvc.RegisterPluginJobs(ctx.GetContext(), plugin)
+			if err != nil {
+				ctx.Logger().Error("Error registering plugin cron jobs", zap.String("plugin", plugin.ID), zap.Error(err))
+				return err
 			}
 		}
+	}
 
-		return nil
-	}))
-
-	return ctxOpts
+	return nil
 }
 
 func (p *PortalImpl) startStartupFuncs(ctx core.Context) error {


### PR DESCRIPTION
The startup func approach caused a nil pointer dereference because it tried to
register jobs before the cron service was initialized. The jobFactory is only
initialized when Start() is called on the cron service.

Changed to register plugin cron jobs via registerPluginCron() which is called
after startCron() completes, ensuring the cron service is fully initialized
before registration occurs.


---

<!-- kody-pr-summary:start -->
 **Fix nil pointer panic by deferring cron job registration until after initialization**

Moves plugin cron job registration from the initialization phase to the application startup phase to prevent nil pointer dereferences.

**Changes:**
- Extracts cron job registration logic from `initCron()` into a new `registerPluginCron()` method
- Invokes `registerPluginCron()` directly within the `Start()` method after all services are initialized
- Removes the startup function wrapper from cron initialization, ensuring the cron service is fully available before attempting to register plugin jobs

This ensures the cron service is properly initialized before any plugin attempts to register scheduled jobs, eliminating race conditions that previously caused nil pointer panics during boot.
<!-- kody-pr-summary:end -->