### PR TITLE
fix(cron): move plugin cron registration to CronService Start()

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -186,9 +186,6 @@ func (p *PortalImpl) Init() error {
 	}
 	ctxOpts = append(ctxOpts, opts...)
 
-	opts = p.initCron(ctx)
-	ctxOpts = append(ctxOpts, opts...)
-
 	ctxOpts = append(ctxOpts, svcOpts...)
 
 	// Finalize context with remaining options (excluding already-applied dbOpts)
@@ -641,32 +638,6 @@ func (p *PortalImpl) initAPIs(ctx core.Context) (ctxOpts []core.ContextBuilderOp
 	}
 
 	return ctxOpts, nil
-}
-
-func (p *PortalImpl) initCron(ctx core.Context) (ctxOpts []core.ContextBuilderOption) {
-	ctxOpts = append(ctxOpts, core.ContextWithStartupFunc(func(ctx core.Context) error {
-		cronSvc := core.GetServiceOptional[core.CronService](ctx, core.CRON_SERVICE)
-		if cronSvc == nil {
-			ctx.Logger().Error("Cron service not found")
-			return errors.New("cron service not found")
-		}
-
-		plugins := core.GetPlugins()
-
-		for _, plugin := range plugins {
-			if core.PluginHasCron(plugin) {
-				err := cronSvc.RegisterPluginJobs(ctx.GetContext(), plugin)
-				if err != nil {
-					ctx.Logger().Error("Error registering plugin cron jobs", zap.String("plugin", plugin.ID), zap.Error(err))
-					return err
-				}
-			}
-		}
-
-		return nil
-	}))
-
-	return ctxOpts
 }
 
 func (p *PortalImpl) startStartupFuncs(ctx core.Context) error {

--- a/service/cron.go
+++ b/service/cron.go
@@ -195,6 +195,19 @@ func (c *CronServiceDefault) Start(ctx context.Context) error {
 		}
 	}
 
+	// Register plugin cron jobs
+	plugins := core.GetPlugins()
+	for _, plugin := range plugins {
+		if core.PluginHasCron(plugin) {
+			err := c.RegisterPluginJobs(ctx, plugin)
+			if err != nil {
+				c.logger.Fatal("Failed to register plugin cron jobs",
+					zap.String("plugin", plugin.ID),
+					zap.Error(err))
+			}
+		}
+	}
+
 	if err := c.loadAndValidateJobs(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
Plugin cron job registration now happens within the CronService's Start()
method, after service entities register their tasks. This ensures all cron
tabs are registered before the service scans the database, avoiding timing
issues.

Removed initCron() from portal.go since registration is now handled by
the cron service itself during its initialization sequence.


---

<!-- kody-pr-summary:start -->
 **Pull Request Description:**

Refactored the plugin cron job registration process by moving the registration logic from the Portal initialization phase into the CronService's `Start()` method.

**Changes:**
- Removed the `initCron()` startup function from `portal.go` that previously handled plugin cron registration during portal initialization
- Added plugin cron job registration directly into `CronServiceDefault.Start()` in `service/cron.go`, ensuring plugin jobs are registered when the cron service starts rather than during general portal startup
- Updated error handling to use fatal logging when plugin cron registration fails within the service context

This change improves separation of concerns by consolidating cron-related plugin registration within the CronService itself, rather than distributing it across the portal initialization logic.
<!-- kody-pr-summary:end -->