### PR TITLE
fix(testing): set subdomain on mockAPI in WithAPIExtension

### DIFF
--- a/core/testing/plugin.go
+++ b/core/testing/plugin.go
@@ -104,7 +104,7 @@ func WithAPIExtension(extFactory core.APIExtensionFactory) TestContextBuilderOpt
 		tb := ctx.T()
 
 		// Create mock API for the target using the testing package's NewMockAPI
-		mockAPI := NewMockAPI(tb, targetAPI)
+		mockAPI := NewMockAPI(tb, targetAPI).WithSubdomain(targetAPI)
 
 		// Register the mock API using existing API registration mechanism
 		apiRegOpt := WithAPI(targetAPI, func() (core.API, []core.ContextBuilderOption, error) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Fixes an issue in the testing framework where mock APIs created for API extension tests were not properly configured with their subdomain. The `WithAPIExtension` function now correctly sets the subdomain on the mock API using the target API's identifier, ensuring accurate test behavior for API extensions that rely on subdomain routing.
<!-- kody-pr-summary:end -->