### PR TITLE
fix(core): reorder component type switch cases

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -408,21 +408,21 @@ func ContextWithStartupComponent(component Component) ContextBuilderOption {
 
 			// Wire up the tracer and logger based on component type
 			switch c := component.(type) {
-			case Service:
-				tracedCtx := startupCtx.WithServiceTracer(c.ID())
-				component.SetLogger(startupCtx.ServiceLogger(c))
-				component.SetContext(tracedCtx)
-			case Protocol:
-				tracedCtx := startupCtx.WithProtocolTracer(c.Name())
-				component.SetLogger(startupCtx.ProtocolLogger(c))
+			case APIExtension:
+				tracedCtx := startupCtx.WithAPIExtensionTracer(c.TargetAPI() + "-" + component.ID())
+				component.SetLogger(startupCtx.Logger())
 				component.SetContext(tracedCtx)
 			case API:
 				tracedCtx := startupCtx.WithAPITracer(c.Name())
 				component.SetLogger(startupCtx.APILogger(c))
 				component.SetContext(tracedCtx)
-			case APIExtension:
-				tracedCtx := startupCtx.WithAPIExtensionTracer(c.TargetAPI() + "-" + component.ID())
-				component.SetLogger(startupCtx.Logger())
+			case Protocol:
+				tracedCtx := startupCtx.WithProtocolTracer(c.Name())
+				component.SetLogger(startupCtx.ProtocolLogger(c))
+				component.SetContext(tracedCtx)
+			case Service:
+				tracedCtx := startupCtx.WithServiceTracer(c.ID())
+				component.SetLogger(startupCtx.ServiceLogger(c))
 				component.SetContext(tracedCtx)
 			default:
 				tracedCtx := startupCtx.WithTracerSubsystem(component.ID())


### PR DESCRIPTION
Reorders interface type checks in ContextWithStartupComponent from
most specific (APIExtension) to least specific (Service), ensuring
all cases are reachable and preventing unreachable code.


---

<!-- kody-pr-summary:start -->
 Reorder the component type switch cases in `ContextWithStartupComponent` to ensure correct type resolution priority. The case order is changed from `Service`, `Protocol`, `API`, `APIExtension` to `APIExtension`, `API`, `Protocol`, `Service`, ensuring that `APIExtension` components are matched and configured before general `API` types. This fixes the component type detection logic to properly initialize tracers and loggers based on the specific component type hierarchy.
<!-- kody-pr-summary:end -->