### PR TITLE
fix: correct variable name in registerAPIExtensions causing panics

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -581,7 +581,7 @@ func (p *PortalImpl) registerAPIExtensions(ctx core.Context) (ctxOpts []core.Con
 						zap.String("plugin", plugin.ID),
 						zap.String("target", ext.TargetAPI()))
 					core.RegisterAPIExtension(ext)
-					ctxOpts = append(ctxOpts, core.ContextWithStartupComponent(ext))
+					ctxOptions = append(ctxOptions, core.ContextWithStartupComponent(ext))
 
 					return core.ProcessCtxOptions(ctx, ctxOptions...)
 				})


### PR DESCRIPTION
Changed ctxOpts to ctxOptions in the append call to properly register
API extensions as startup components. The incorrect variable name
would have prevented ctxOptions from being updated, leaving the
extension excluded from startup initialization and causing panics
when attempting to use the uninitialized extension.


---

<!-- kody-pr-summary:start -->
 This pull request fixes a critical variable name error in the `registerAPIExtensions` function where `ctxOpts` was incorrectly referenced instead of the properly defined `ctxOptions` variable. This correction resolves runtime panics that occurred during API extension registration, ensuring that startup components are properly collected and applied to the context during portal initialization.
<!-- kody-pr-summary:end -->