### PR TITLE
fix(cron): display structured panic info in error logs

### DIFF
--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -328,10 +328,28 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 
 	// Define the after job runs with error event listener
 	afterJobRunsWithError := func(jobID uuid.UUID, jobName string, err error) {
-		s.logger.Error("Job execution failed",
+		fields := []zap.Field{
 			zap.String("jobID", jobID.String()),
 			zap.String("jobName", jobName),
-			zap.Error(err))
+			zap.Error(err),
+		}
+
+		// Check if this error is from a recovered panic
+		// gocron wraps panics as: "gocron: panic recovered from <panic value>"
+		errStr := err.Error()
+		panicPrefix := "gocron: panic recovered from "
+		if strings.HasPrefix(errStr, panicPrefix) {
+			// Extract the panic value
+			panicValue := strings.TrimPrefix(errStr, panicPrefix)
+			
+			// Capture structured panic info using the panic value
+			panicInfo := captureStructuredPanic(panicValue)
+			
+			// Add structured panic info to the error log
+			fields = append(fields, buildPanicFields(panicInfo)...)
+		}
+		
+		s.logger.Error("Job execution failed", fields...)
 
 		s.failureMu.Lock()
 		// Increment failure count
@@ -352,30 +370,12 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 		// Capture structured panic info
 		panicInfo := captureStructuredPanic(recoverData)
 		
-		// Build custom zap fields for structured output
+		// Build zap fields including job info and panic details
 		fields := []zap.Field{
 			zap.String("jobID", jobID.String()),
 			zap.String("jobName", jobName),
-			zap.Any("panicValue", panicInfo.RecoverVal),
-			zap.String("panicMessage", panicInfo.Message),
 		}
-		
-		// Add stack frames if available
-		if len(panicInfo.Stack) > 0 {
-			// Log first few frames as structured fields
-			for i, frame := range panicInfo.Stack {
-				if i >= 5 { // Limit to top 5 frames to avoid log bloat
-					break
-				}
-				fields = append(fields, 
-					zap.String(fmt.Sprintf("frame%d", i), fmt.Sprintf("%s:%d (%s)", frame.File, frame.Line, frame.Function)))
-			}
-			
-			// If there are more frames, indicate it
-			if len(panicInfo.Stack) > 5 {
-				fields = append(fields, zap.Int("additionalFrames", len(panicInfo.Stack)-5))
-			}
-		}
+		fields = append(fields, buildPanicFields(panicInfo)...)
 		
 		s.logger.Error("Task panicked", fields...)
 
@@ -664,6 +664,32 @@ func isInternalPath(function string) bool {
 		}
 	}
 	return false
+}
+
+// buildPanicFields builds structured zap fields from panic information.
+// Returns fields for panic value, message, and filtered stack frames.
+func buildPanicFields(panicInfo *PanicInfo) []zap.Field {
+	fields := []zap.Field{
+		zap.Any("panicValue", panicInfo.RecoverVal),
+		zap.String("panicMessage", panicInfo.Message),
+	}
+	
+	// Add stack frames if available
+	if len(panicInfo.Stack) > 0 {
+		for i, frame := range panicInfo.Stack {
+			if i >= 5 {
+				break
+			}
+			fields = append(fields,
+				zap.String(fmt.Sprintf("frame%d", i), fmt.Sprintf("%s:%d (%s)", frame.File, frame.Line, frame.Function)))
+		}
+		
+		if len(panicInfo.Stack) > 5 {
+			fields = append(fields, zap.Int("additionalFrames", len(panicInfo.Stack)-5))
+		}
+	}
+	
+	return fields
 }
 
 // captureStructuredPanic captures structured panic information using Go's runtime API.


### PR DESCRIPTION
Add structured panic information to error logs when job panics:
- Create buildPanicFields helper to extract common panic logging logic
- Update afterJobRunsWithError to detect and display panic details from gocron errors
- Refactor afterJobRunsWithPanic to use buildPanicFields helper
- Eliminate duplicate panic field building code

This ensures that when gocron wraps a panic as an error, the error log
includes structured panic details (value, message, stack frames) for
easier debugging and log analysis.


---

<!-- kody-pr-summary:start -->
This PR ensures structured panic information is properly captured and displayed in cron job error logs when the scheduler recovers from panics and wraps them as standard errors.

**Changes:**
- Enhanced the `afterJobRunsWithError` handler to detect panic-recovered errors (identified by the "gocron: panic recovered from" prefix) and extract structured panic details including the panic value, message, and stack trace frames using the existing `captureStructuredPanic` functionality
- Introduced a new `buildPanicFields` helper function to standardize the construction of structured zap log fields from panic information, eliminating code duplication between the panic recovery and error handling code paths
- Maintained existing stack trace filtering logic that limits output to the top 5 most relevant frames while indicating when additional frames exist

**Impact:**
Cron job failures will now consistently include structured panic details (panic value, message, and stack trace) in error logs regardless of whether the panic is captured via the dedicated panic recovery handler or wrapped as an error by the gocron scheduler. This improves observability and debugging capabilities by ensuring panic context is available in a structured, queryable format rather than embedded only in error strings.
<!-- kody-pr-summary:end -->