### PR TITLE
feat: Add operation tracking fields to upload/download events

### DIFF
--- a/event/download.go
+++ b/event/download.go
@@ -10,28 +10,33 @@ const EVENT_DOWNLOAD_COMPLETED = "download.completed"
 
 // DownloadCompletedEvent represents a completed download event.
 // UserID is optional - nil indicates an anonymous download (no associated user).
+// ReservationID is optional - if provided, a quota reservation was created for this download.
 type DownloadCompletedEvent struct {
-	Ctx      context.Context
-	UserID   *uint // Optional user ID; nil means anonymous download
-	UploadID uint
-	Bytes    uint64
-	IP       string
+	Ctx            context.Context
+	UserID         *uint // Optional user ID; nil means anonymous download
+	ReservationID  *uint // Optional reservation ID; if set, should be committed on success or released on failure
+	UploadID       uint
+	Bytes          uint64
+	IP             string
+	Successful     bool  // Indicates if the download completed successfully
 }
 
-func NewDownloadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userID *uint) *DownloadCompletedEvent {
+func NewDownloadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userID *uint, reservationID *uint, successful bool) *DownloadCompletedEvent {
 	return &DownloadCompletedEvent{
-		Ctx:      eventCtx,
-		UserID:   userID,
-		UploadID: uploadID,
-		Bytes:    bytes,
-		IP:       ip,
+		Ctx:           eventCtx,
+		UserID:        userID,
+		ReservationID: reservationID,
+		UploadID:      uploadID,
+		Bytes:         bytes,
+		IP:            ip,
+		Successful:    successful,
 	}
 }
 
 // OnDownloadCompleted registers a handler to run when a download is completed.
 // This is a convenience wrapper around Listen for the EVENT_DOWNLOAD_COMPLETED event.
-func OnDownloadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint) error, priority ...int) {
+func OnDownloadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint, *uint, bool) error, priority ...int) {
 	core.Listen[DownloadCompletedEvent](ctx, EVENT_DOWNLOAD_COMPLETED, func(e *core.CoreEvent[DownloadCompletedEvent]) error {
-		return handler(e.Data.Ctx, e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID)
+		return handler(e.Data.Ctx, e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID, e.Data.ReservationID, e.Data.Successful)
 	}, priority...)
 }

--- a/event/upload.go
+++ b/event/upload.go
@@ -8,28 +8,35 @@ import (
 
 const EVENT_UPLOAD_COMPLETED = "upload.completed"
 
+// UploadCompletedEvent represents a completed upload event.
+// UserID is optional - nil indicates an anonymous upload (no associated user).
+// ReservationID is optional - if provided, a quota reservation was created for this upload.
 type UploadCompletedEvent struct {
-	Ctx      context.Context
-	UserID   *uint
-	UploadID uint
-	Bytes    uint64
-	IP       string
+	Ctx            context.Context
+	UserID         *uint // Optional user ID; nil means anonymous upload
+	ReservationID  *uint // Optional reservation ID; if set, should be committed on success or released on failure
+	UploadID       uint
+	Bytes          uint64
+	IP             string
+	Successful     bool  // Indicates if the upload completed successfully
 }
 
-func NewUploadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userId *uint) *UploadCompletedEvent {
+func NewUploadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userId *uint, reservationID *uint, successful bool) *UploadCompletedEvent {
 	return &UploadCompletedEvent{
-		Ctx:      eventCtx,
-		UserID:   userId,
-		UploadID: uploadID,
-		Bytes:    bytes,
-		IP:       ip,
+		Ctx:           eventCtx,
+		UserID:        userId,
+		ReservationID: reservationID,
+		UploadID:      uploadID,
+		Bytes:         bytes,
+		IP:            ip,
+		Successful:    successful,
 	}
 }
 
 // OnUploadCompleted registers a handler to run when an upload is completed.
 // This is a convenience wrapper around Listen for the EVENT_UPLOAD_COMPLETED event.
-func OnUploadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint) error, priority ...int) {
+func OnUploadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint, *uint, bool) error, priority ...int) {
 	core.Listen[UploadCompletedEvent](ctx, EVENT_UPLOAD_COMPLETED, func(e *core.CoreEvent[UploadCompletedEvent]) error {
-		return handler(e.Data.Ctx, e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID)
+		return handler(e.Data.Ctx, e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID, e.Data.ReservationID, e.Data.Successful)
 	}, priority...)
 }


### PR DESCRIPTION
- Add ReservationID field to UploadCompletedEvent and DownloadCompletedEvent
  to support tracking operation-specific identifiers through the event system

- Add Successful bool field to indicate operation outcome for consumers
  to handle success/failure accordingly

- Update event constructors to accept optional reservation ID and success status
- Update event handlers to pass these additional parameters to registered consumers

This allows event consumers to track and manage operation lifecycles
by correlating operation start events with completion events via identifiers.


---

<!-- kody-pr-summary:start -->
This pull request enhances the upload and download event tracking system by adding operation status and quota reservation fields to completion events.

**Changes Made:**

**Download Events (`event/download.go`):**
- Added `ReservationID` field to track quota reservations associated with downloads (optional - nil when no reservation exists)
- Added `Successful` boolean field to indicate whether the download completed successfully or failed
- Updated event constructor and handler registration to support the new fields

**Upload Events (`event/upload.go`):**
- Added `ReservationID` field to track quota reservations associated with uploads (optional - nil when no reservation exists)  
- Added `Successful` boolean field to indicate whether the upload completed successfully or failed
- Updated event constructor and handler registration to support the new fields

**Functional Impact:**
These changes enable event consumers to:
- Determine if an upload or download operation succeeded or failed
- Properly manage quota reservations by committing them on successful completion or releasing them on failure
- Track anonymous vs. authenticated operations while maintaining reservation context

The `ReservationID` field allows the system to correlate storage quota reservations with their corresponding completion events, supporting proper resource accounting and cleanup workflows.
<!-- kody-pr-summary:end -->