### PR TITLE
refactor(event): change ReservationID type from *uint to *string in upload/download events

### DIFF
--- a/event/download.go
+++ b/event/download.go
@@ -14,14 +14,14 @@ const EVENT_DOWNLOAD_COMPLETED = "download.completed"
 type DownloadCompletedEvent struct {
 	Ctx            context.Context
 	UserID         *uint // Optional user ID; nil means anonymous download
-	ReservationID  *uint // Optional reservation ID; if set, should be committed on success or released on failure
+	ReservationID  *string // Optional reservation ID; if set, should be committed on success or released on failure
 	UploadID       uint
 	Bytes          uint64
 	IP             string
 	Successful     bool  // Indicates if the download completed successfully
 }
 
-func NewDownloadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userID *uint, reservationID *uint, successful bool) *DownloadCompletedEvent {
+func NewDownloadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userID *uint, reservationID *string, successful bool) *DownloadCompletedEvent {
 	return &DownloadCompletedEvent{
 		Ctx:           eventCtx,
 		UserID:        userID,
@@ -35,7 +35,7 @@ func NewDownloadCompletedEvent(eventCtx context.Context, uploadID uint, bytes ui
 
 // OnDownloadCompleted registers a handler to run when a download is completed.
 // This is a convenience wrapper around Listen for the EVENT_DOWNLOAD_COMPLETED event.
-func OnDownloadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint, *uint, bool) error, priority ...int) {
+func OnDownloadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint, *string, bool) error, priority ...int) {
 	core.Listen[DownloadCompletedEvent](ctx, EVENT_DOWNLOAD_COMPLETED, func(e *core.CoreEvent[DownloadCompletedEvent]) error {
 		return handler(e.Data.Ctx, e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID, e.Data.ReservationID, e.Data.Successful)
 	}, priority...)

--- a/event/upload.go
+++ b/event/upload.go
@@ -14,14 +14,14 @@ const EVENT_UPLOAD_COMPLETED = "upload.completed"
 type UploadCompletedEvent struct {
 	Ctx            context.Context
 	UserID         *uint // Optional user ID; nil means anonymous upload
-	ReservationID  *uint // Optional reservation ID; if set, should be committed on success or released on failure
+	ReservationID  *string // Optional reservation ID; if set, should be committed on success or released on failure
 	UploadID       uint
 	Bytes          uint64
 	IP             string
 	Successful     bool  // Indicates if the upload completed successfully
 }
 
-func NewUploadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userId *uint, reservationID *uint, successful bool) *UploadCompletedEvent {
+func NewUploadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint64, ip string, userId *uint, reservationID *string, successful bool) *UploadCompletedEvent {
 	return &UploadCompletedEvent{
 		Ctx:           eventCtx,
 		UserID:        userId,
@@ -35,7 +35,7 @@ func NewUploadCompletedEvent(eventCtx context.Context, uploadID uint, bytes uint
 
 // OnUploadCompleted registers a handler to run when an upload is completed.
 // This is a convenience wrapper around Listen for the EVENT_UPLOAD_COMPLETED event.
-func OnUploadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint, *uint, bool) error, priority ...int) {
+func OnUploadCompleted(ctx core.Context, handler func(context.Context, uint, uint64, string, *uint, *string, bool) error, priority ...int) {
 	core.Listen[UploadCompletedEvent](ctx, EVENT_UPLOAD_COMPLETED, func(e *core.CoreEvent[UploadCompletedEvent]) error {
 		return handler(e.Data.Ctx, e.Data.UploadID, e.Data.Bytes, e.Data.IP, e.Data.UserID, e.Data.ReservationID, e.Data.Successful)
 	}, priority...)


### PR DESCRIPTION
- Update UploadCompletedEvent.ReservationID to *string
- Update DownloadCompletedEvent.ReservationID to *string
- Update NewUploadCompletedEvent() reservationID parameter to *string
- Update NewDownloadCompletedEvent() reservationID parameter to *string
- Update OnUploadCompleted() handler signature for ReservationID
- Update OnDownloadCompleted() handler signature for ReservationID


---

<!-- kody-pr-summary:start -->
This pull request refactors the event system to support string-based reservation identifiers instead of numeric ones.

**Changes Made:**

1. **Upload Events (`event/upload.go`):**
   - Changed `ReservationID` field type in `UploadCompletedEvent` struct from `*uint` to `*string`
   - Updated `NewUploadCompletedEvent` constructor to accept `*string` for the reservation ID parameter
   - Modified `OnUploadCompleted` handler signature to receive `*string` instead of `*uint`

2. **Download Events (`event/download.go`):**
   - Changed `ReservationID` field type in `DownloadCompletedEvent` struct from `*uint` to `*string`
   - Updated `NewDownloadCompletedEvent` constructor to accept `*string` for the reservation ID parameter
   - Modified `OnDownloadCompleted` handler signature to receive `*string` instead of `*uint`

**Functional Impact:**
This change enables the use of alphanumeric reservation identifiers (such as UUIDs or custom formatted IDs) rather than being restricted to numeric values. The reservation ID remains optional in both event types (maintained as pointer types), preserving the existing behavior where nil indicates no reservation is associated with the upload or download operation.
<!-- kody-pr-summary:end -->