### PR TITLE
refactor(event): add reservation ID to storage pin event

### DIFF
--- a/event/storage_pin.go
+++ b/event/storage_pin.go
@@ -10,23 +10,25 @@ import (
 const EVENT_STORAGE_OBJECT_PINNED = "storage.object.pinned"
 
 type StorageObjectPinnedEvent struct {
-	Ctx context.Context
-	Pin *models.Pin
-	IP  string
+	Ctx            context.Context
+	Pin            *models.Pin
+	IP             string
+	ReservationID  *string // Optional reservation ID; if set, should be committed on success or released on failure
 }
 
-func NewStorageObjectPinnedEvent(eventCtx context.Context, pin *models.Pin, ip string) *StorageObjectPinnedEvent {
+func NewStorageObjectPinnedEvent(eventCtx context.Context, pin *models.Pin, ip string, reservationID *string) *StorageObjectPinnedEvent {
 	return &StorageObjectPinnedEvent{
-		Ctx: eventCtx,
-		Pin: pin,
-		IP:  ip,
+		Ctx:           eventCtx,
+		Pin:           pin,
+		IP:            ip,
+		ReservationID: reservationID,
 	}
 }
 
 // OnStorageObjectPinned registers a handler to run when a storage object is pinned.
 // This is a convenience wrapper around Listen for the EVENT_STORAGE_OBJECT_PINNED event.
-func OnStorageObjectPinned(ctx core.Context, handler func(context.Context, *models.Pin, string) error, priority ...int) {
+func OnStorageObjectPinned(ctx core.Context, handler func(context.Context, *models.Pin, string, *string) error, priority ...int) {
 	core.Listen[StorageObjectPinnedEvent](ctx, EVENT_STORAGE_OBJECT_PINNED, func(e *core.CoreEvent[StorageObjectPinnedEvent]) error {
-		return handler(e.Data.Ctx, e.Data.Pin, e.Data.IP)
+		return handler(e.Data.Ctx, e.Data.Pin, e.Data.IP, e.Data.ReservationID)
 	}, priority...)
 }


### PR DESCRIPTION
- Add ReservationID field to StorageObjectPinnedEvent struct
- Update NewStorageObjectPinnedEvent to accept optional reservationID parameter
- Update OnStorageObjectPinned handler to pass reservationID to callbacks

This aligns StorageObjectPinnedEvent with UploadCompletedEvent and
DownloadCompletedEvent patterns, allowing quota reservation IDs to be
passed through pin operations for proper quota management.


---

<!-- kody-pr-summary:start -->
 Extends the storage object pinned event to include an optional reservation ID, enabling proper resource lifecycle management for pinned content.

When storage objects are pinned, they may be associated with provisional resource reservations (such as quota or storage space). This change adds a `ReservationID` field to the `StorageObjectPinnedEvent`, allowing event handlers to track these reservations and determine whether to commit them upon successful pinning or release them if the operation fails. The reservation identifier is optional and only processed when provided.
<!-- kody-pr-summary:end -->