### PR TITLE
feat(core): add GetAllPinsByHash to PinService

### DIFF
--- a/core/pin.go
+++ b/core/pin.go
@@ -44,6 +44,9 @@ type PinService interface {
 	// UploadPinnedByUser checks if the upload with the given hash is pinned by the specified user.
 	UploadPinnedByUser(ctx context.Context, hash StorageHash, userId uint) (bool, error)
 
+	// GetAllPinsByHash retrieves all pins for a given hash across all users.
+	GetAllPinsByHash(ctx context.Context, hash StorageHash) ([]*models.Pin, error)
+
 	// GetPinsByUploadID retrieves the list of pins for the given upload ID.
 	GetPinsByUploadID(ctx context.Context, uploadID uint) ([]*models.Pin, error)
 

--- a/core/testing/mocks/PinService.go
+++ b/core/testing/mocks/PinService.go
@@ -578,6 +578,74 @@ func (_c *MockPinService_DeletePinByHash_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// GetAllPinsByHash provides a mock function for the type MockPinService
+func (_mock *MockPinService) GetAllPinsByHash(ctx context.Context, hash core.StorageHash) ([]*models.Pin, error) {
+	ret := _mock.Called(ctx, hash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllPinsByHash")
+	}
+
+	var r0 []*models.Pin
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, core.StorageHash) ([]*models.Pin, error)); ok {
+		return returnFunc(ctx, hash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, core.StorageHash) []*models.Pin); ok {
+		r0 = returnFunc(ctx, hash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*models.Pin)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, core.StorageHash) error); ok {
+		r1 = returnFunc(ctx, hash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockPinService_GetAllPinsByHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAllPinsByHash'
+type MockPinService_GetAllPinsByHash_Call struct {
+	*mock.Call
+}
+
+// GetAllPinsByHash is a helper method to define mock.On call
+//   - ctx context.Context
+//   - hash core.StorageHash
+func (_e *MockPinService_Expecter) GetAllPinsByHash(ctx interface{}, hash interface{}) *MockPinService_GetAllPinsByHash_Call {
+	return &MockPinService_GetAllPinsByHash_Call{Call: _e.mock.On("GetAllPinsByHash", ctx, hash)}
+}
+
+func (_c *MockPinService_GetAllPinsByHash_Call) Run(run func(ctx context.Context, hash core.StorageHash)) *MockPinService_GetAllPinsByHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 core.StorageHash
+		if args[1] != nil {
+			arg1 = args[1].(core.StorageHash)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockPinService_GetAllPinsByHash_Call) Return(pins []*models.Pin, err error) *MockPinService_GetAllPinsByHash_Call {
+	_c.Call.Return(pins, err)
+	return _c
+}
+
+func (_c *MockPinService_GetAllPinsByHash_Call) RunAndReturn(run func(ctx context.Context, hash core.StorageHash) ([]*models.Pin, error)) *MockPinService_GetAllPinsByHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetPin provides a mock function for the type MockPinService
 func (_mock *MockPinService) GetPin(ctx context.Context, id uint) (*models.Pin, error) {
 	ret := _mock.Called(ctx, id)

--- a/service/internal/pin/metrics.go
+++ b/service/internal/pin/metrics.go
@@ -33,6 +33,7 @@ const (
 	LabelOpUpdateData    = "update_data"
 	LabelOpListAccount   = "list_account"
 	LabelOpListUpload    = "list_upload"
+	LabelOpListHash      = "list_hash"
 	LabelOpCheckGlobal   = "check_global"
 	LabelOpCheckUser     = "check_user"
 	LabelOpUnknown       = "unknown"

--- a/service/pin.go
+++ b/service/pin.go
@@ -265,6 +265,33 @@ func (p *PinServiceDefault) UploadPinnedByUser(ctx context.Context, hash core.St
 	)
 }
 
+func (p *PinServiceDefault) GetAllPinsByHash(ctx context.Context, hash core.StorageHash) ([]*models.Pin, error) {
+	ctx, span := core.TraceMethod(ctx, "PinServiceDefault.GetAllPinsByHash")
+	defer span.End()
+
+	return core.MetricTrackResult(
+		pinMetrics.PinDuration.WithLabelValues(pinMetrics.LabelOpListHash),
+		pinMetrics.PinFailed.WithLabelValues(pinMetrics.LabelOpListHash),
+		func() ([]*models.Pin, error) {
+			var pins []*models.Pin
+			err := db.RetryableComponentTransaction(p, ctx, func(tx *gorm.DB) *gorm.DB {
+				return tx.WithContext(ctx).Model(&models.Pin{}).
+					Joins("JOIN uploads ON uploads.id = pins.upload_id").
+					Where("uploads.hash = ?", hash.Multihash()).
+					Preload("Upload").
+					Find(&pins)
+			})
+
+			if err != nil {
+				return nil, err
+			}
+
+			pinMetrics.PinsListed.WithLabelValues(pinMetrics.LabelOpListHash).Inc()
+			return pins, nil
+		},
+	)
+}
+
 func (p *PinServiceDefault) GetPinsByUploadID(ctx context.Context, uploadID uint) ([]*models.Pin, error) {
 	ctx, span := core.TraceMethod(ctx, "PinServiceDefault.GetPinsByUploadID")
 	defer span.End()


### PR DESCRIPTION
- Add GetAllPinsByHash method to PinService interface
- Implement in PinServiceDefault querying pins by hash across all users
- Add list_hash metrics label
- Regenerate PinService mock via mockery


---

<!-- kody-pr-summary:start -->
Add `GetAllPinsByHash` method to PinService to retrieve all pins for a given storage hash across all users

This PR introduces a new `GetAllPinsByHash` method to the `PinService` interface and its implementation, enabling retrieval of all pins associated with a specific storage hash regardless of the user. The implementation joins the pins and uploads tables on upload ID, filters by the hash, and preloads the related upload data. A new metric label (`list_hash`) is also added to track this operation's duration, failures, and successful listings.
<!-- kody-pr-summary:end -->