### PR TITLE
fix(testing): apply config values atomically before validation in ApplyConfig

### DIFF
--- a/core/testing/config.go
+++ b/core/testing/config.go
@@ -237,7 +237,8 @@ func flattenConfigMap(cfg config.Defaults) map[string]any {
 	return flattenAndSnakeCase(structMap)
 }
 
-// ApplyConfig flattens a config struct and applies all values to the test context.
+// ApplyConfig flattens a config struct and applies all values to the test context
+// atomically, then validates the complete configuration once.
 // It converts the config struct to a flattened map using flattenConfigMap,
 // then filters out nil values and keys that match defaults (unchanged values).
 // Additionally, it uses a heuristic to filter out empty values where the default is non-empty,
@@ -274,16 +275,29 @@ func ApplyConfig(ctx TestContext, prefix string, cfg config.Defaults) error {
 		return false
 	})
 
+	// Build the full-keyed updates map for atomic application
+	updates := make(map[string]any, len(flatConfig))
 	for key, value := range flatConfig {
 		fullKey := key
 		if prefix != "" {
 			fullKey = strings.TrimSuffix(prefix, configKeySeparator) + configKeySeparator + key
 		}
-		if err := setConfigValue(ctx, fullKey, value); err != nil {
-			return err
-		}
+		updates[fullKey] = value
 	}
-	return nil
+
+	if len(updates) == 0 {
+		return nil
+	}
+
+	tctx, ok := ctx.(*testContext)
+	if !ok {
+		return fmt.Errorf("test context is not a *testContext instance")
+	}
+	if tctx.cfg == nil {
+		return fmt.Errorf("no config manager on test context")
+	}
+
+	return tctx.cfg.BulkSetAtomic(ctx, updates)
 }
 
 // envVarName converts a config key to an environment variable name


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Apply config values atomically before validation in `ApplyConfig`

Previously, `ApplyConfig` set each config value individually via `setConfigValue`, which could leave the configuration in a partially-applied state if an error occurred mid-way, and validation would run incrementally on incomplete configurations. This change collects all config updates into a map first, then applies them in a single atomic operation via `BulkSetAtomic`, ensuring the complete configuration is validated only once all values are set together.
<!-- kody-pr-summary:end -->