### PR TITLE
fix(cron): fix SetHeartbeat race and handle completed jobs gracefully

### DIFF
--- a/core/internal/service_tests/cron_standalone_coordinator_test.go
+++ b/core/internal/service_tests/cron_standalone_coordinator_test.go
@@ -74,6 +74,62 @@ func TestStandaloneCoordinator_CheckHeartbeat(t *testing.T) {
 	})
 }
 
+func TestStandaloneCoordinator_SetHeartbeat_BypassesFSM(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		require.NotNil(t, db)
+
+		jobID := uuid.New()
+		beforeSet := time.Now().Add(-1 * time.Minute)
+
+		// Create a Running job with a stale heartbeat and known version
+		job := models.CronJob{
+			UUID:          types.FromUUID(jobID),
+			State:         models.CronJobStateRunning,
+			Version:       3,
+			LastHeartbeat: &beforeSet,
+		}
+		result := db.Create(&job)
+		require.NoError(t, result.Error)
+
+		// Create coordinator — the FSM must NOT be called.
+		// No mock state machine is wired; if SetHeartbeat goes through the FSM
+		// path, it would nil-dereference or call an unmocked method.
+		mockCronService := coreMocks.NewMockCronService(t)
+		mockJobFactory := coreMocks.NewMockCronJobFactory(t)
+		mockCronService.EXPECT().JobFactory().Return(mockJobFactory).Maybe()
+
+		coordinator, err := service.NewStandaloneCoordinator(
+			ctx,
+			mockCronService,
+			coreMocks.NewMockCronJobStateMachineRegistry(t),
+			service.NewCoordinatorOptions(),
+		)
+		require.NoError(t, err)
+
+		// Execute
+		err = coordinator.SetHeartbeat(nil, jobID)
+		require.NoError(t, err)
+
+		// Reload from DB and assert:
+		// 1. last_heartbeat was updated
+		// 2. state was NOT changed (still Running, not re-transitioned)
+		// 3. version was NOT bumped (FSM was bypassed)
+		var updated models.CronJob
+		result = db.First(&updated, "uuid = ?", types.FromUUID(jobID))
+		require.NoError(t, result.Error)
+
+		assert.Equal(t, models.CronJobStateRunning, updated.State,
+			"state must not change on heartbeat")
+		assert.Equal(t, int64(3), updated.Version,
+			"version must not be bumped on heartbeat")
+		assert.NotNil(t, updated.LastHeartbeat,
+			"last_heartbeat must be set")
+		assert.True(t, updated.LastHeartbeat.After(beforeSet),
+			"last_heartbeat must be updated to a more recent time")
+	})
+}
+
 func TestStandaloneCoordinator_EnqueueJob(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()

--- a/service/cron.go
+++ b/service/cron.go
@@ -21,15 +21,15 @@ import (
 var _ core.CronService = (*CronServiceDefault)(nil)
 
 var (
-	NewJobFactory            = cron.NewJobFactory
-	NewScheduleRegistry      = cron.NewScheduleRegistry
-	NewCronJobStateMachine   = cron.NewCronJobStateMachine
-	NewStateMachineRegistry  = cron.NewStateMachineRegistry
-	NewDefaultCronMonitor    = cron.NewDefaultCronMonitor
-	NewStandaloneCoordinator = cron.NewStandaloneCoordinator
-	NewCoordinatorOptions    = cron.NewCoordinatorOptions
-	NewCoordinatorFromContext = cron.NewCoordinatorFromContext
-	NewJobCreator             = cron.NewJobCreator
+	NewJobFactory              = cron.NewJobFactory
+	NewScheduleRegistry        = cron.NewScheduleRegistry
+	NewCronJobStateMachine     = cron.NewCronJobStateMachine
+	NewStateMachineRegistry    = cron.NewStateMachineRegistry
+	NewDefaultCronMonitor      = cron.NewDefaultCronMonitor
+	NewStandaloneCoordinator   = cron.NewStandaloneCoordinator
+	NewCoordinatorOptions      = cron.NewCoordinatorOptions
+	NewCoordinatorFromContext  = cron.NewCoordinatorFromContext
+	NewJobCreator              = cron.NewJobCreator
 
 	// ErrCronJobNotFound is returned when a cron job cannot be found.
 	ErrCronJobNotFound = cron.ErrCronJobNotFound

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -136,7 +136,16 @@ func (s *StandaloneCoordinator) SetHeartbeat(ctx context.Context, jobID uuid.UUI
 	ctx, span := core.TraceMethod(ctx, "StandaloneCoordinator.SetHeartbeat")
 	defer span.End()
 
-	return s.stateMachine.Transition(ctx, jobID, models.CronJobStateRunning, core.WithCronHeartbeat())
+	// Heartbeat is not a state transition — it's a timestamp update while remaining
+	// in Running state. Going through the FSM would require Running→Running which
+	// is invalid, and would bump the version on every 30s tick. Direct DB update
+	// of last_heartbeat only.
+	now := time.Now()
+	return db.RetryableTransaction(ctx, s.db, func(tx *gorm.DB) *gorm.DB {
+		return tx.Model(&models.CronJob{}).
+			Where("uuid = ?", types.FromUUID(jobID)).
+			Update("last_heartbeat", now)
+	})
 }
 
 func (s *StandaloneCoordinator) CheckHeartbeat(ctx context.Context, jobID uuid.UUID) (bool, error) {
@@ -502,16 +511,16 @@ func (s *StandaloneCoordinator) SetupJob(ctx context.Context, jobID uuid.UUID) e
 	ctx, span := core.TraceMethod(ctx, "StandaloneCoordinator.SetupJob")
 	defer span.End()
 
-	// Get current job state for defensive logging
+	// Get current job state
 	dbJob, err := s.getJobRecord(ctx, jobID)
 	if err != nil {
 		return fmt.Errorf("failed to get job record: %w", err)
 	}
 
+	// Already completed — nothing to set up. This can happen when the job's
+	// Run() method transitions to Completed before the beforeJobRuns callback fires.
 	if dbJob.State == models.CronJobStateCompleted {
-		s.logger.Debug("SetupJob called on completed job - this should not happen normally",
-			zap.String("jobID", jobID.String()),
-			zap.String("currentState", string(dbJob.State)))
+		return nil
 	}
 
 	// Validate retry policy early to catch configuration errors before job execution
@@ -561,16 +570,16 @@ func (s *StandaloneCoordinator) CleanupJob(ctx context.Context, jobID uuid.UUID)
 	ctx, span := core.TraceMethod(ctx, "StandaloneCoordinator.CleanupJob")
 	defer span.End()
 
-	// Get current job state for defensive logging
+	// Get current job state
 	dbJob, err := s.getJobRecord(ctx, jobID)
 	if err != nil {
 		return fmt.Errorf("failed to get job record: %w", err)
 	}
 
+	// Already completed — nothing to clean up. This can happen when the job's
+	// Run() method transitions to Completed before the afterJobRuns callback fires.
 	if dbJob.State == models.CronJobStateCompleted {
-		s.logger.Debug("CleanupJob called on already completed job - this should not happen normally",
-			zap.String("jobID", jobID.String()),
-			zap.String("currentState", string(dbJob.State)))
+		return nil
 	}
 
 	s.cronService.Monitor().StopHeartbeat(ctx, jobID)

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -576,13 +576,15 @@ func (s *StandaloneCoordinator) CleanupJob(ctx context.Context, jobID uuid.UUID)
 		return fmt.Errorf("failed to get job record: %w", err)
 	}
 
-	// Already completed — nothing to clean up. This can happen when the job's
+	// Always stop the heartbeat first — it may have been started by SetupJob
+	// before the job completed, and the goroutine will leak if not stopped.
+	s.cronService.Monitor().StopHeartbeat(ctx, jobID)
+
+	// Already completed — nothing else to clean up. This can happen when the job's
 	// Run() method transitions to Completed before the afterJobRuns callback fires.
 	if dbJob.State == models.CronJobStateCompleted {
 		return nil
 	}
-
-	s.cronService.Monitor().StopHeartbeat(ctx, jobID)
 	s.cancelJobContext(jobID)
 
 	// Reset failure count on successful completion


### PR DESCRIPTION
SetHeartbeat bypasses the FSM and updates last_heartbeat directly
in the DB. The previous implementation transitioned to Running state
on every heartbeat tick, which is invalid (Running→Running) and
caused version bumps every 30s that could conflict with actual state
transitions.

SetupJob and CleanupJob now return nil immediately when the job is
already Completed, instead of logging a warning and continuing
execution. This happens when the job's Run() method completes before
the beforeJobRuns/afterJobRuns callbacks fire.

---

<!-- kody-pr-summary:start -->
This PR fixes a race condition in `SetHeartbeat` and gracefully handles completed jobs in the `SetupJob` and `CleanupJob` callbacks.

**SetHeartbeat race fix:** Previously, `SetHeartbeat` attempted a state machine transition from Running→Running, which is invalid and would fail (and unnecessarily bump the version on every 30-second tick). Since a heartbeat is not a state transition but merely a timestamp update while remaining in the Running state, the method now directly updates the `last_heartbeat` field in the database via a transaction, bypassing the FSM entirely.

**Completed job handling:** `SetupJob` and `CleanupJob` previously logged debug warnings when encountering a job already in the Completed state, treating it as an unexpected condition. These methods now simply return `nil` (no error) when the job is already completed, as this can legitimately occur when a job's `Run()` method transitions to Completed before the `beforeJobRuns`/`afterJobRuns` callbacks fire.
<!-- kody-pr-summary:end -->