### PR TITLE
feat(tus): add io.ReaderAt support to TUSUploadReader

### DIFF
--- a/service/internal/tus/s3_reader.go
+++ b/service/internal/tus/s3_reader.go
@@ -13,8 +13,9 @@ import (
 	"go.lumeweb.com/portal/core"
 )
 
-// TUSUploadReader wraps a TUS upload reader to provide io.ReadSeekCloser functionality
-// using the modern ContentServerDataStore approach for S3-backed uploads
+// TUSUploadReader wraps a TUS upload reader to provide io.ReadSeekCloser and
+// io.ReaderAt functionality using the ContentServerDataStore approach for
+// S3-backed uploads
 type TUSUploadReader struct {
 	mu             sync.RWMutex
 	ctx            context.Context
@@ -72,7 +73,6 @@ func NewTUSUploadReader(
 
 // Read implements io.Reader using the modern ContentServerDataStore approach
 func (r *TUSUploadReader) Read(p []byte) (n int, err error) {
-	// Check for context cancellation
 	select {
 	case <-r.ctx.Done():
 		return 0, r.ctx.Err()
@@ -86,63 +86,136 @@ func (r *TUSUploadReader) Read(p []byte) (n int, err error) {
 		return 0, io.EOF
 	}
 
-	// Calculate remaining bytes from current position to end
 	remainingBytes := r.info.Size - r.position
 	if remainingBytes <= 0 {
 		return 0, io.EOF
 	}
 
-	// Don't read more than we have space for
 	maxRead := int64(len(p))
 	if remainingBytes < maxRead {
 		maxRead = remainingBytes
 	}
 
-	// Calculate range for this read request (maxRead is already constrained by remainingBytes)
 	rangeEnd := r.position + maxRead - 1
 
-	// Create HTTP request for range
+	result, err := r.serveRange(r.position, rangeEnd)
+	if err != nil {
+		return 0, err
+	}
+
+	data := result.data
+	if result.statusCode == http.StatusOK {
+		if r.position >= int64(len(data)) {
+			return 0, io.EOF
+		}
+		end := int64(len(data))
+		if r.position+maxRead < end {
+			end = r.position + maxRead
+		}
+		data = data[r.position:end]
+	}
+
+	copied := min(len(data), len(p))
+	copy(p[:copied], data[:copied])
+	r.position += int64(copied)
+
+	if r.position >= r.info.Size {
+		return copied, io.EOF
+	}
+
+	return copied, nil
+}
+
+// ReadAt implements io.ReaderAt — reads from offset without affecting position.
+// Safe for concurrent use from multiple goroutines.
+func (r *TUSUploadReader) ReadAt(p []byte, off int64) (n int, err error) {
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+	}
+
+	r.mu.RLock()
+	closed := r.closed
+	size := r.info.Size
+	r.mu.RUnlock()
+
+	if closed {
+		return 0, io.EOF
+	}
+
+	if off < 0 {
+		return 0, fmt.Errorf("negative offset: %d", off)
+	}
+
+	if off >= size {
+		return 0, io.EOF
+	}
+
+	remainingBytes := size - off
+	maxRead := int64(len(p))
+	if remainingBytes < maxRead {
+		maxRead = remainingBytes
+	}
+
+	rangeEnd := off + maxRead - 1
+
+	result, err := r.serveRange(off, rangeEnd)
+	if err != nil {
+		return 0, err
+	}
+
+	data := result.data
+	if result.statusCode == http.StatusOK {
+		if off >= int64(len(data)) {
+			return 0, io.EOF
+		}
+		end := int64(len(data))
+		if off+maxRead < end {
+			end = off + maxRead
+		}
+		data = data[off:end]
+	}
+
+	copied := min(len(data), len(p))
+	copy(p[:copied], data[:copied])
+
+	if off+int64(copied) >= size {
+		return copied, io.EOF
+	}
+
+	return copied, nil
+}
+
+// serveRangeResult holds the data and status from a ServeContent call.
+type serveRangeResult struct {
+	data       []byte
+	statusCode int
+}
+
+// serveRange fetches bytes [start, end] via ServeContent. Must not be called
+// while holding r.mu (Read holds the write lock; ReadAt does not hold it).
+func (r *TUSUploadReader) serveRange(start, end int64) (*serveRangeResult, error) {
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
-		return 0, fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	// Set range header
-	rangeHeader := fmt.Sprintf("bytes=%d-%d", r.position, rangeEnd)
-	req.Header.Set("Range", rangeHeader)
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
 
-	// Create response recorder to capture the response
 	recorder := newResponseRecorder()
 
-	// Use ServeContent to get the data
-	err = r.servableUpload.ServeContent(r.ctx, recorder, req)
-	if err != nil {
-		return 0, fmt.Errorf("failed to serve content: %w", err)
+	if err := r.servableUpload.ServeContent(r.ctx, recorder, req); err != nil {
+		return nil, fmt.Errorf("failed to serve content: %w", err)
 	}
 
-	// Handle partial content responses
-	if recorder.statusCode == http.StatusPartialContent || recorder.statusCode == http.StatusOK {
-		data := recorder.buffer.Bytes()
-
-		// Calculate how many bytes will actually be copied
-		copied := min(len(data), len(p))
-		copy(p[:copied], data[:copied])
-
-		// Advance position only by bytes actually copied
-		r.position += int64(copied)
-		n = copied
-
-		// Check for EOF after position update
-		if recorder.statusCode == http.StatusOK && r.position >= r.info.Size {
-			return n, io.EOF
-		}
-
-		return n, nil
-	} else if recorder.statusCode == http.StatusRequestedRangeNotSatisfiable {
-		// Range not satisfiable - this means we tried to read beyond the file
-		return 0, io.EOF
-	} else {
-		return 0, fmt.Errorf("unexpected status code: %d", recorder.statusCode)
+	switch recorder.statusCode {
+	case http.StatusPartialContent, http.StatusOK:
+		return &serveRangeResult{data: recorder.buffer.Bytes(), statusCode: recorder.statusCode}, nil
+	case http.StatusRequestedRangeNotSatisfiable:
+		return nil, io.EOF
+	default:
+		return nil, fmt.Errorf("unexpected status code: %d", recorder.statusCode)
 	}
 }
 

--- a/service/internal/tus/s3_reader_test.go
+++ b/service/internal/tus/s3_reader_test.go
@@ -262,7 +262,7 @@ func TestTUSUploadReader_MultipartRangeHandling(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, int64(len(tc.expected)), n)
 			assert.Equal(t, tc.expected, buf.Bytes())
-			defer require.NoError(t, reader.Close())
+			defer func() { require.NoError(t, reader.Close()) }()
 		})
 	}
 }
@@ -317,10 +317,10 @@ func TestTUSUploadReader_SeekOperations(t *testing.T) {
 
 	buf = make([]byte, 20)
 	n, err = reader.Read(buf)
-	assert.NoError(t, err)
+	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, 15, n)
 	assert.Equal(t, testData[len(testData)-15:], buf[:n])
-	defer require.NoError(t, reader.Close())
+	defer func() { require.NoError(t, reader.Close()) }()
 }
 
 func TestTUSUploadReader_BufferTruncation(t *testing.T) {
@@ -375,6 +375,135 @@ func TestTUSUploadReader_BufferTruncation(t *testing.T) {
 
 	// Close reader manually at the end
 	require.NoError(t, reader.Close())
+}
+
+func TestTUSUploadReader_ReadAt(t *testing.T) {
+	_, store, _, _, serverURL := setupTUSServer(t)
+	ctx := context.Background()
+
+	testData := []byte("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
+
+	uploadURL := uploadWithTusClient(t, serverURL, testData, store)
+	upload, err := getUploadFromStore(store, uploadURL)
+	require.NoError(t, err)
+
+	info, err := upload.GetInfo(ctx)
+	require.NoError(t, err)
+
+	reader, err := NewTUSUploadReader(ctx, &core.Logger{Logger: zap.NewNop()}, upload, info, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+	buf := make([]byte, 10)
+
+	t.Run("read from beginning", func(t *testing.T) {
+		n, err := reader.ReadAt(buf, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 10, n)
+		assert.Equal(t, []byte("0123456789"), buf)
+	})
+
+	t.Run("read from middle", func(t *testing.T) {
+		n, err := reader.ReadAt(buf, 10)
+		assert.NoError(t, err)
+		assert.Equal(t, 10, n)
+		assert.Equal(t, []byte("ABCDEFGHIJ"), buf)
+	})
+
+	t.Run("read near end with EOF", func(t *testing.T) {
+		off := int64(len(testData) - 5)
+		smallBuf := make([]byte, 10)
+		n, err := reader.ReadAt(smallBuf, off)
+		assert.Equal(t, io.EOF, err)
+		assert.Equal(t, 5, n)
+		assert.Equal(t, testData[off:], smallBuf[:n])
+	})
+
+	t.Run("read at exact end returns EOF", func(t *testing.T) {
+		smallBuf := make([]byte, 1)
+		_, err := reader.ReadAt(smallBuf, int64(len(testData)))
+		assert.Equal(t, io.EOF, err)
+	})
+
+	t.Run("does not affect position", func(t *testing.T) {
+		pos, err := reader.Seek(20, io.SeekStart)
+		require.NoError(t, err)
+		require.Equal(t, int64(20), pos)
+
+		smallBuf := make([]byte, 5)
+		_, _ = reader.ReadAt(smallBuf, 0)
+		assert.Equal(t, []byte("01234"), smallBuf)
+
+		pos, err = reader.Seek(0, io.SeekCurrent)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(20), pos, "ReadAt must not change position")
+	})
+}
+
+func TestTUSUploadReader_ReadAt_Concurrent(t *testing.T) {
+	_, store, _, _, serverURL := setupTUSServer(t)
+	ctx := context.Background()
+
+	testData := []byte("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	uploadURL := uploadWithTusClient(t, serverURL, testData, store)
+	upload, err := getUploadFromStore(store, uploadURL)
+	require.NoError(t, err)
+
+	info, err := upload.GetInfo(ctx)
+	require.NoError(t, err)
+
+	reader, err := NewTUSUploadReader(ctx, &core.Logger{Logger: zap.NewNop()}, upload, info, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+	type result struct {
+		off   int64
+		data  []byte
+		err   error
+		n     int
+	}
+
+	offsets := []int64{0, 10, 26, 50}
+	ch := make(chan result, len(offsets))
+
+	for _, off := range offsets {
+		go func(off int64) {
+			buf := make([]byte, 10)
+			n, err := reader.ReadAt(buf, off)
+			ch <- result{off: off, data: buf[:n], err: err, n: n}
+		}(off)
+	}
+
+	for range offsets {
+		res := <-ch
+		assert.NoError(t, res.err, "offset %d", res.off)
+		assert.Equal(t, 10, res.n, "offset %d", res.off)
+		assert.Equal(t, testData[res.off:res.off+10], res.data, "offset %d", res.off)
+	}
+}
+
+func TestTUSUploadReader_ReadAt_AfterClose(t *testing.T) {
+	_, store, _, _, serverURL := setupTUSServer(t)
+	ctx := context.Background()
+
+	testData := []byte("0123456789ABCDEF")
+
+	uploadURL := uploadWithTusClient(t, serverURL, testData, store)
+	upload, err := getUploadFromStore(store, uploadURL)
+	require.NoError(t, err)
+
+	info, err := upload.GetInfo(ctx)
+	require.NoError(t, err)
+
+	reader, err := NewTUSUploadReader(ctx, &core.Logger{Logger: zap.NewNop()}, upload, info, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, reader.Close())
+
+	buf := make([]byte, 10)
+	_, err = reader.ReadAt(buf, 0)
+	assert.Equal(t, io.EOF, err)
 }
 
 func TestTUSUploadReader_LargeFileRanges(t *testing.T) {
@@ -432,7 +561,7 @@ func TestTUSUploadReader_LargeFileRanges(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, 500, n)
 			assert.Equal(t, tr.expected, buf)
-			defer require.NoError(t, reader.Close())
+			defer func() { require.NoError(t, reader.Close()) }()
 		})
 	}
 }


### PR DESCRIPTION
Add ReadAt method for concurrent random-access reads without affecting
position. Extract serveRange helper to share range-fetch logic between
Read and ReadAt. Fix Read to correctly return io.EOF at end-of-file
regardless of response status code. Fix test deferClose bug where
defer require.NoError(t, reader.Close()) was evaluating Close()
immediately instead of deferring it.

---

<!-- kody-pr-summary:start -->
Add `io.ReaderAt` support to `TUSUploadReader` for concurrent, position-independent reads

This PR extends `TUSUploadReader` to implement `io.ReaderAt`, enabling reads from arbitrary offsets without affecting the reader's current seek position. This is essential for use cases like HTTP range serving and S3-style multipart uploads where concurrent reads at different offsets are needed.

Key changes:
- **New `ReadAt` method**: Reads from a specified offset without modifying the internal position, safe for concurrent use from multiple goroutines (uses `RLock` for shared state access).
- **Refactored `Read` method**: Extracted the common HTTP range-request logic into a shared `serveRange` helper, used by both `Read` and `ReadAt`, reducing duplication.
- **New `serveRangeResult` type**: Encapsulates the response data and status code from `ServeContent` calls.
- **Test fixes**: Corrected `defer` statements in existing tests to properly capture errors at defer-time rather than immediately, and fixed an assertion where `Read` at end-of-file now correctly returns `io.EOF`.
- **New tests**: Added comprehensive tests for `ReadAt` covering basic offset reads, EOF behavior, position independence, concurrent goroutine safety, and behavior after close.
<!-- kody-pr-summary:end -->