### PR TITLE
feat(cron): add per-job-type metrics and OTel tracing

### DIFF
--- a/service/internal/cron/metrics.go
+++ b/service/internal/cron/metrics.go
@@ -5,7 +5,10 @@ import (
 	"go.lumeweb.com/portal/core"
 )
 
-// Metric name constants for cron service metrics
+// LabelJobType is the Prometheus label key used to partition cron metrics by job type.
+const LabelJobType = "job_type"
+
+// Metric name constants for cron service metrics.
 const (
 	MetricJobsCompleted           = "jobs_completed_total"
 	MetricJobsFailed              = "jobs_failed_total"
@@ -18,12 +21,14 @@ const (
 	MetricSchedulerUp             = "up"
 )
 
-// Global metric instances (created once, reused everywhere)
+// Global metric instances (created once, reused everywhere).
+// JobsCompleted, JobsFailed, JobExecutionDuration, and JobSchedulingDelay
+// are partitioned by the job_type label for per-job-type granularity.
 var (
-	JobsCompleted           prometheus.Counter
-	JobsFailed              prometheus.Counter
-	JobExecutionDuration    prometheus.Histogram
-	JobSchedulingDelay      prometheus.Histogram
+	JobsCompleted           *prometheus.CounterVec
+	JobsFailed              *prometheus.CounterVec
+	JobExecutionDuration    *prometheus.HistogramVec
+	JobSchedulingDelay      *prometheus.HistogramVec
 	JobsRunning             prometheus.Gauge
 	JobsRegistered          prometheus.Counter
 	JobsUnregistered        prometheus.Counter
@@ -34,28 +39,28 @@ var (
 // init initializes all cron metrics.
 // Called automatically when the package is imported.
 func init() {
-	JobsCompleted = prometheus.NewCounter(prometheus.CounterOpts{
+	JobsCompleted = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name:      MetricJobsCompleted,
 		Subsystem: core.CRON_SERVICE,
 		Help:      "Total number of cron jobs that completed successfully",
-	})
-	JobsFailed = prometheus.NewCounter(prometheus.CounterOpts{
+	}, []string{LabelJobType})
+	JobsFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name:      MetricJobsFailed,
 		Subsystem: core.CRON_SERVICE,
 		Help:      "Total number of cron job failures",
-	})
-	JobExecutionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	}, []string{LabelJobType})
+	JobExecutionDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:      MetricJobExecutionDuration,
 		Subsystem: core.CRON_SERVICE,
 		Help:      "Time spent executing cron jobs",
 		Buckets:   []float64{0.1, 0.5, 1, 5, 10, 30, 60, 120, 300},
-	})
-	JobSchedulingDelay = prometheus.NewHistogram(prometheus.HistogramOpts{
+	}, []string{LabelJobType})
+	JobSchedulingDelay = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:      MetricJobSchedulingDelay,
 		Subsystem: core.CRON_SERVICE,
 		Help:      "Delay between scheduled and actual start time of cron jobs",
 		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30},
-	})
+	}, []string{LabelJobType})
 	JobsRunning = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      MetricJobsRunning,
 		Subsystem: core.CRON_SERVICE,

--- a/service/internal/cron/prometheus_monitor.go
+++ b/service/internal/cron/prometheus_monitor.go
@@ -12,7 +12,7 @@ import (
 type PrometheusMonitor struct{}
 
 // NewPrometheusMonitor creates a new PrometheusMonitor.
-// Metrics are initialized and registered externally via InitMetrics() and GetCollectors().
+// Metrics are initialized and registered externally via GetCollectors().
 func NewPrometheusMonitor() *PrometheusMonitor {
 	return &PrometheusMonitor{}
 }
@@ -48,40 +48,38 @@ func (p *PrometheusMonitor) JobStarted(_ gocron.Job) {
 	JobsRunning.Inc()
 }
 
-// JobRunning is called when a job is running.
-// This is called periodically while the job executes.
+// JobRunning is called periodically while a job executes.
 func (p *PrometheusMonitor) JobRunning(_ gocron.Job) {
 }
 
 // JobFailed is called when a job fails to complete successfully.
-func (p *PrometheusMonitor) JobFailed(_ gocron.Job, err error) {
+func (p *PrometheusMonitor) JobFailed(job gocron.Job, _ error) {
 	JobsRunning.Dec()
-	JobsFailed.Inc()
+	JobsFailed.WithLabelValues(job.Name()).Inc()
 }
 
 // JobCompleted is called when a job has completed running successfully.
-func (p *PrometheusMonitor) JobCompleted(_ gocron.Job) {
+func (p *PrometheusMonitor) JobCompleted(job gocron.Job) {
 	JobsRunning.Dec()
-	JobsCompleted.Inc()
+	JobsCompleted.WithLabelValues(job.Name()).Inc()
 }
 
 // JobExecutionTime is called after a job completes (success or failure)
 // with the time it took to execute.
-func (p *PrometheusMonitor) JobExecutionTime(_ gocron.Job, duration time.Duration) {
-	JobExecutionDuration.Observe(duration.Seconds())
+func (p *PrometheusMonitor) JobExecutionTime(job gocron.Job, duration time.Duration) {
+	JobExecutionDuration.WithLabelValues(job.Name()).Observe(duration.Seconds())
 }
 
 // JobSchedulingDelay is called when a job starts running, providing both
 // the scheduled time and actual start time.
-func (p *PrometheusMonitor) JobSchedulingDelay(_ gocron.Job, scheduledTime time.Time, actualStartTime time.Time) {
+func (p *PrometheusMonitor) JobSchedulingDelay(job gocron.Job, scheduledTime time.Time, actualStartTime time.Time) {
 	if delay := actualStartTime.Sub(scheduledTime); delay > 0 {
-		JobSchedulingDelay.Observe(delay.Seconds())
+		JobSchedulingDelay.WithLabelValues(job.Name()).Observe(delay.Seconds())
 	}
 }
 
 // ConcurrencyLimitReached is called when a job cannot start immediately
 // due to concurrency limits (singleton or limit mode).
-// limitType will be "singleton" or "limit".
 func (p *PrometheusMonitor) ConcurrencyLimitReached(_ string, _ gocron.Job) {
 	ConcurrencyLimitReached.Inc()
 }

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -626,17 +626,21 @@ func (s *StandaloneCoordinator) ExecuteJob(ctx context.Context, jobID uuid.UUID)
 	ctx, span := core.TraceMethod(ctx, "StandaloneCoordinator.ExecuteJob")
 	defer span.End()
 
-	// Get job instance
 	job, err := s.CreateJobFromDB(ctx, jobID)
 	if err != nil {
 		return fmt.Errorf("failed to create job instance: %w", err)
 	}
 
-	// Execute the job logic
 	if job == nil {
 		return fmt.Errorf("failed to execute job: job instance is nil")
 	}
-	return job.Run(s.ctx, ctx)
+
+	// Create a per-job-type OTel span so each execution is traceable by job type
+	// (e.g. "cron.core.pin-checker") in addition to the generic coordinator span.
+	jobCtx, jobSpan := core.TraceMethod(ctx, "cron."+job.Type())
+	defer jobSpan.End()
+
+	return job.Run(s.ctx, jobCtx)
 }
 
 func (s *StandaloneCoordinator) Jobs() []gocron.Job {


### PR DESCRIPTION
Switch JobsCompleted, JobsFailed, JobExecutionDuration, and
JobSchedulingDelay to *Vec variants with a job_type label for
per-job-type granularity in Prometheus. Add child OTel span
named cron.<job.Type()> in ExecuteJob for trace-level visibility.

---

<!-- kody-pr-summary:start -->
Add per-job-type granularity to cron Prometheus metrics and OpenTelemetry tracing

This change partitions four key cron metrics (`jobs_completed_total`, `jobs_failed_total`, `job_execution_duration`, `job_scheduling_delay`) by a `job_type` label using Prometheus `*CounterVec`/`*HistogramVec`, and creates a per-job-type OTel span (e.g. `cron.core.pin-checker`) for each job execution so that individual job types are traceable in addition to the generic coordinator span.
<!-- kody-pr-summary:end -->