### PR TITLE
fix(workflow): follow NextRequestID chain in GetWorkflowStatus/Instance/StepInfo

### DIFF
--- a/core/internal/service_tests/workflow_test.go
+++ b/core/internal/service_tests/workflow_test.go
@@ -1366,3 +1366,78 @@ func withTestProtocol(operationNames ...string) coreTesting.TestContextBuilderOp
 		coreTesting.WithCustomProtocolConfig("test", coreTesting.NewConfigBuilder()),
 	)
 }
+
+// Test 21: GetWorkflowStatus follows NextRequestID chain
+func TestGetWorkflowStatusFollowsChain(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		workflowName := "chainTestWorkflow"
+		operationName1 := "test.operation.chain1"
+		operationName2 := "test.operation.chain2"
+		operationName3 := "test.operation.chain3"
+
+		steps := []core.OperationStep{
+			{Operation: operationName1, Foreground: true},
+			{Operation: operationName2, Foreground: true},
+			{Operation: operationName3, Foreground: true},
+		}
+
+		err := workflowService.RegisterWorkflow(workflowName, steps, false)
+		require.NoError(tb, err)
+
+		userID := uint(456)
+		req1, err := workflowService.StartWorkflow(context.Background(), workflowName,
+			core.WithWorkflowUserID(userID),
+			core.WithWorkflowData(map[string]interface{}{"test": "data"}))
+		require.NoError(tb, err)
+		require.NotNil(tb, req1)
+
+		// Execute and complete step 1
+		err = workflowService.ExecuteWorkflowStep(context.Background(), req1.ID)
+		require.NoError(tb, err)
+		err = workflowService.CompleteWorkflowStep(context.Background(), req1.ID)
+		require.NoError(tb, err)
+
+		// Find step 2 request
+		var req2 models.Request
+		err = ctx.DB().Model(&models.Request{}).Where("operation = ? AND status = ?", operationName2, models.RequestStatusProcessing).First(&req2).Error
+		require.NoError(tb, err)
+
+		// BUG FIX TEST: GetWorkflowStatus with the ORIGINAL request ID (step 1)
+		// should follow the chain and return step 2's status, not Completed
+		status, err := workflowService.GetWorkflowStatus(context.Background(), req1.ID)
+		assert.NoError(tb, err)
+		assert.Equal(tb, 1, status.CurrentStep, "should follow chain to step 2 (index 1)")
+		assert.Equal(tb, models.RequestStatusProcessing, status.Status, "should report step 2's status, not Completed")
+		assert.Equal(tb, req2.ID, status.CurrentStepID, "should report step 2's request ID")
+
+		// Execute and complete step 2
+		err = workflowService.ExecuteWorkflowStep(context.Background(), req2.ID)
+		require.NoError(tb, err)
+		err = workflowService.CompleteWorkflowStep(context.Background(), req2.ID)
+		require.NoError(tb, err)
+
+		// Find step 3 request
+		var req3 models.Request
+		err = ctx.DB().Model(&models.Request{}).Where("operation = ? AND status = ?", operationName3, models.RequestStatusProcessing).First(&req3).Error
+		require.NoError(tb, err)
+
+		// GetWorkflowStatus with original request ID should follow chain to step 3
+		status, err = workflowService.GetWorkflowStatus(context.Background(), req1.ID)
+		assert.NoError(tb, err)
+		assert.Equal(tb, 2, status.CurrentStep, "should follow chain to step 3 (index 2)")
+		assert.Equal(tb, req3.ID, status.CurrentStepID, "should report step 3's request ID")
+
+		// GetWorkflowInstance with original request ID should also follow the chain
+		instance, err := workflowService.GetWorkflowInstance(context.Background(), userID, req1.ID)
+		assert.NoError(tb, err)
+		assert.Equal(tb, req3.ID, instance.Request.ID, "instance should reference step 3 request")
+		assert.Equal(tb, 2, instance.Status.CurrentStep, "instance status should be step 3")
+
+	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, service.NewRequestService),
+		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, service.NewWorkflowCoordinator),
+		withTestProtocol("test.operation.chain1", "test.operation.chain2", "test.operation.chain3"),
+	)
+}

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -662,8 +662,11 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStatus(ctx context.Context, requ
 		workflowMetrics.WorkflowDuration.WithLabelValues(workflowMetrics.LabelOperationGetStatus),
 		workflowMetrics.WorkflowsFailed.WithLabelValues(workflowMetrics.LabelWorkflowUnknown, workflowMetrics.LabelWorkflowUnknown, workflowMetrics.LabelFailureBehaviorFail),
 		func() (*core.WorkflowStatus, error) {
-			// Get request
-			req, err := w.requestSvc.GetRequestWithDeleted(ctx, requestID)
+			// Follow NextRequestID chain to find the latest step
+			latestID := w.findLatestRequest(ctx, requestID)
+
+			// Get request for the latest step
+			req, err := w.requestSvc.GetRequestWithDeleted(ctx, latestID)
 			if err != nil {
 				return nil, err
 			}
@@ -674,8 +677,8 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStatus(ctx context.Context, requ
 				return nil, err
 			}
 
-			// Get detailed request status
-			reqStatus, err := w.requestSvc.GetRequestStatus(ctx, requestID, true)
+			// Get detailed request status for the latest step
+			reqStatus, err := w.requestSvc.GetRequestStatus(ctx, latestID, true)
 			if err != nil {
 				return nil, err
 			}
@@ -848,8 +851,11 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStepInfo(ctx context.Context, re
 	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.GetWorkflowStepInfo")
 	defer span.End()
 
+	// Follow NextRequestID chain to find the latest step
+	latestID := w.findLatestRequest(ctx, requestID)
+
 	// Get current request
-	req, err := w.requestSvc.GetRequestWithDeleted(ctx, requestID)
+	req, err := w.requestSvc.GetRequestWithDeleted(ctx, latestID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get request: %w", err)
 	}
@@ -1292,8 +1298,11 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowInstance(ctx context.Context, us
 	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.GetWorkflowInstance")
 	defer span.End()
 
+	// Follow NextRequestID chain to find the latest step
+	latestID := w.findLatestRequest(ctx, requestID)
+
 	// First verify the request exists and belongs to the user
-	req, err := w.requestSvc.GetRequestWithDeleted(ctx, requestID)
+	req, err := w.requestSvc.GetRequestWithDeleted(ctx, latestID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get request: %w", err)
 	}
@@ -1352,6 +1361,31 @@ func (w *WorkflowCoordinatorDefault) getStepIndex(stepID string, workflowName st
 	}
 
 	return -1
+}
+
+// findLatestRequest follows the NextRequestID chain forward to find the latest (current) request ID
+func (w *WorkflowCoordinatorDefault) findLatestRequest(ctx context.Context, requestID uint) uint {
+	latestID := requestID
+
+	for {
+		req, err := w.requestSvc.GetRequestWithDeleted(ctx, latestID)
+		if err != nil || req == nil {
+			break
+		}
+
+		var meta WorkflowMetadata
+		if err := json.Unmarshal(req.Metadata, &meta); err != nil {
+			break
+		}
+
+		if meta.NextRequestID == 0 {
+			break
+		}
+
+		latestID = meta.NextRequestID
+	}
+
+	return latestID
 }
 
 // findWorkflowChainRoot follows the PrevRequestID chain backwards to find the root request ID


### PR DESCRIPTION
GetWorkflowStatus, GetWorkflowInstance, and GetWorkflowStepInfo operated on
the exact requestID passed in, ignoring the NextRequestID chain. For
multi-step workflows, querying with the original step 1 request ID after
advancement would report Completed (step 1's status) instead of following
the chain to the current step.

Add findLatestRequest to follow NextRequestID forward (mirroring existing
findWorkflowChainRoot which follows PrevRequestID backward) and use it in
all three methods to resolve the current step before querying status.

---

<!-- kody-pr-summary:start -->
Fix `GetWorkflowStatus`, `GetWorkflowStepInfo`, and `GetWorkflowInstance` to follow the `NextRequestID` chain when querying workflow progress.

Previously, these methods used the provided request ID directly, which meant querying with an earlier step's ID would return that step's completed status instead of the current active step's status. A new `findLatestRequest` helper method was added to traverse the `NextRequestID` chain forward and find the latest request in the workflow. All three methods now resolve to the latest step before fetching status, ensuring accurate workflow progress is reported regardless of which step's request ID was originally provided.
<!-- kody-pr-summary:end -->