### PR TITLE
fix(testing): make StartOperationWorkflow idempotent by reusing registered workflows

### DIFF
--- a/core/testing/workflow.go
+++ b/core/testing/workflow.go
@@ -63,10 +63,15 @@ func (wt *WorkflowTest) AssertMetadataValue(requestID uint, key string, expected
 }
 
 // NewOperationWorkflow creates and registers a simple workflow with a single operation.
+// If the workflow is already registered, it skips registration and reuses the existing one.
 func (wt *WorkflowTest) NewOperationWorkflow(operationName string) string {
-	workflowName := fmt.Sprintf("test-workflow-%s", operationName) // Unique name
+	workflowName := fmt.Sprintf("test-workflow-%s", operationName)
+	_, err := wt.workflowSvc.GetWorkflow(workflowName)
+	if err == nil {
+		return workflowName
+	}
 	steps := []core.OperationStep{{Operation: operationName, FailureBehavior: core.FailWorkflow, Foreground: true}}
-	wt.RegisterWorkflow(workflowName, steps, false) // Don't auto-trigger
+	wt.RegisterWorkflow(workflowName, steps, false)
 	return workflowName
 }
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Make `NewOperationWorkflow` idempotent by reusing already registered workflows

This change modifies the `NewOperationWorkflow` method in the testing package to check if a workflow with the generated name already exists before attempting to register it. If the workflow is already registered, it skips registration and returns the existing workflow name. This prevents errors from duplicate registration attempts when the method is called multiple times with the same operation name, making the workflow creation process idempotent.
<!-- kody-pr-summary:end -->