### PR TITLE
feat(observability): add optional basic auth to metrics endpoint

### DIFF
--- a/config/observability.go
+++ b/config/observability.go
@@ -23,6 +23,8 @@ var (
 	_ Defaults             = (*TracingConfig)(nil)
 	_ ConfigSchemaProvider = (*MetricsConfig)(nil)
 	_ Defaults             = (*MetricsConfig)(nil)
+	_ ConfigSchemaProvider = (*MetricsBasicAuthConfig)(nil)
+	_ Defaults             = (*MetricsBasicAuthConfig)(nil)
 	_ ConfigSchemaProvider = (*LoggingConfig)(nil)
 	_ Defaults             = (*LoggingConfig)(nil)
 )
@@ -78,6 +80,27 @@ type MetricsConfig struct {
 	Enabled         bool   `config:"enabled"`
 	Path            string `config:"path"`
 	RefreshInterval uint   `config:"refresh_interval"`
+	BasicAuth       MetricsBasicAuthConfig `config:"basic_auth"`
+}
+
+type MetricsBasicAuthConfig struct {
+	Password string `config:"password"`
+}
+
+func (m MetricsBasicAuthConfig) Schema() z.ZogSchema {
+	return z.Struct(z.Shape{
+		"Password": z.String(),
+	})
+}
+
+func (m MetricsBasicAuthConfig) Defaults() map[string]any {
+	return map[string]any{
+		"Password": "",
+	}
+}
+
+func (m MetricsBasicAuthConfig) IsEnabled() bool {
+	return m.Password != ""
 }
 
 func (m MetricsConfig) Schema() z.ZogSchema {

--- a/service/http.go
+++ b/service/http.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -781,24 +782,19 @@ func stripPackageName(name string) string {
 
 // registerMetricsEndpoints registers the core metrics endpoint and per-vhost metrics endpoints
 func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string, metricsCfg config.MetricsConfig) error {
-	var metricsMiddleware []echo.MiddlewareFunc
+	metricsAuth := metricsBasicAuthMiddleware(metricsCfg)
 
-	metricsMiddleware = append(metricsMiddleware, echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
-		Registerer: core.CoreMetricsRegistry(),
-	}))
-
-	if metricsCfg.BasicAuth.IsEnabled() {
-		metricsMiddleware = append(metricsMiddleware, echoMiddleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
-			return password == metricsCfg.BasicAuth.Password, nil
-		}))
+	coreMiddleware := []echo.MiddlewareFunc{
+		echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
+			Registerer: core.CoreMetricsRegistry(),
+		}),
 	}
+	coreMiddleware = append(coreMiddleware, metricsAuth...)
 
-	// Register core metrics endpoint on the root router
-	router.GetRouter(h.Router()).GET(metricsPath, echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{Gatherer: core.CoreMetricsRegistry()}), metricsMiddleware...)
+	router.GetRouter(h.Router()).GET(metricsPath, echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{Gatherer: core.CoreMetricsRegistry()}), coreMiddleware...)
 
 	h.Logger().Info("Registered core metrics endpoint", zap.String("path", metricsPath))
 
-	// Register per-vhost metrics endpoints for each API
 	for _, api := range core.GetAPIs() {
 		apiName := api.Name()
 		domain := h.getAPIDomain(api)
@@ -809,20 +805,15 @@ func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string, metric
 			continue
 		}
 
-		var apiMetricsMiddleware []echo.MiddlewareFunc
-
-		apiMetricsMiddleware = append(apiMetricsMiddleware, echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
-			Subsystem:  api.ID(),
-			Registerer: core.PluginMetricsRegistry(apiName),
-		}))
-
-		if metricsCfg.BasicAuth.IsEnabled() {
-			apiMetricsMiddleware = append(apiMetricsMiddleware, echoMiddleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
-				return password == metricsCfg.BasicAuth.Password, nil
-			}))
+		apiMiddleware := []echo.MiddlewareFunc{
+			echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
+				Subsystem:  api.ID(),
+				Registerer: core.PluginMetricsRegistry(apiName),
+			}),
 		}
+		apiMiddleware = append(apiMiddleware, metricsAuth...)
 
-		router.GetRouter(hostRouter).GET(metricsPath, echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{Gatherer: core.PluginMetricsRegistry(apiName)}), apiMetricsMiddleware...)
+		router.GetRouter(hostRouter).GET(metricsPath, echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{Gatherer: core.PluginMetricsRegistry(apiName)}), apiMiddleware...)
 
 		h.Logger().Info("Registered API metrics endpoint",
 			zap.String("api", apiName),
@@ -831,4 +822,15 @@ func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string, metric
 	}
 
 	return nil
+}
+
+func metricsBasicAuthMiddleware(metricsCfg config.MetricsConfig) []echo.MiddlewareFunc {
+	if !metricsCfg.BasicAuth.IsEnabled() {
+		return nil
+	}
+	return []echo.MiddlewareFunc{
+		echoMiddleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
+			return subtle.ConstantTimeCompare([]byte(password), []byte(metricsCfg.BasicAuth.Password)) == 1, nil
+		}),
+	}
 }

--- a/service/http.go
+++ b/service/http.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	router "go.lumeweb.com/portal-router"
+	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/core/web_manifest"
 	ihttp "go.lumeweb.com/portal/service/internal/http"
@@ -271,7 +272,7 @@ func (h *HTTPServiceDefault) Init() error {
 	// Register metrics endpoints if observability is enabled
 	if ocfg.IsMetricsEnabled() {
 		metricsPath := ocfg.Metrics.Path
-		if err := h.registerMetricsEndpoints(metricsPath); err != nil {
+		if err := h.registerMetricsEndpoints(metricsPath, ocfg.Metrics); err != nil {
 			return fmt.Errorf("failed to register metrics endpoints: %w", err)
 		}
 	}
@@ -779,12 +780,21 @@ func stripPackageName(name string) string {
 }
 
 // registerMetricsEndpoints registers the core metrics endpoint and per-vhost metrics endpoints
-func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string) error {
+func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string, metricsCfg config.MetricsConfig) error {
+	var metricsMiddleware []echo.MiddlewareFunc
 
-	// Register core metrics endpoint on the root router
-	router.GetRouter(h.Router()).GET(metricsPath, echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{Gatherer: core.CoreMetricsRegistry()}), echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
+	metricsMiddleware = append(metricsMiddleware, echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
 		Registerer: core.CoreMetricsRegistry(),
 	}))
+
+	if metricsCfg.BasicAuth.IsEnabled() {
+		metricsMiddleware = append(metricsMiddleware, echoMiddleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
+			return password == metricsCfg.BasicAuth.Password, nil
+		}))
+	}
+
+	// Register core metrics endpoint on the root router
+	router.GetRouter(h.Router()).GET(metricsPath, echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{Gatherer: core.CoreMetricsRegistry()}), metricsMiddleware...)
 
 	h.Logger().Info("Registered core metrics endpoint", zap.String("path", metricsPath))
 
@@ -799,10 +809,20 @@ func (h *HTTPServiceDefault) registerMetricsEndpoints(metricsPath string) error 
 			continue
 		}
 
-		router.GetRouter(hostRouter).GET(metricsPath, echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{Gatherer: core.PluginMetricsRegistry(apiName)}), echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
+		var apiMetricsMiddleware []echo.MiddlewareFunc
+
+		apiMetricsMiddleware = append(apiMetricsMiddleware, echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
 			Subsystem:  api.ID(),
 			Registerer: core.PluginMetricsRegistry(apiName),
 		}))
+
+		if metricsCfg.BasicAuth.IsEnabled() {
+			apiMetricsMiddleware = append(apiMetricsMiddleware, echoMiddleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
+				return password == metricsCfg.BasicAuth.Password, nil
+			}))
+		}
+
+		router.GetRouter(hostRouter).GET(metricsPath, echoprometheus.NewHandlerWithConfig(echoprometheus.HandlerConfig{Gatherer: core.PluginMetricsRegistry(apiName)}), apiMetricsMiddleware...)
 
 		h.Logger().Info("Registered API metrics endpoint",
 			zap.String("api", apiName),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adds optional HTTP Basic Authentication to the metrics endpoint. When a password is configured in the observability settings, all metrics endpoints (both the core metrics endpoint and per-vhost/API metrics endpoints) will require basic authentication to access. The authentication only validates the password — any username is accepted. By default, the password is empty, which disables basic auth and preserves existing behavior.
<!-- kody-pr-summary:end -->