### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/major_changes.md
+++ b/.changeset/major_changes.md
@@ -1,0 +1,5 @@
+---
+default: major
+---
+
+# Major changes


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add changeset entry for major version bump

This PR introduces a new changeset file (`.changeset/major_changes.md`) that declares a major version change. The changeset is configured with `default: major`, indicating that the upcoming release will include breaking changes requiring a major version increment according to semantic versioning.
<!-- kody-pr-summary:end -->