### PR TITLE
feat(otel): add container, process, OS, and host resource detection

### DIFF
--- a/core/otel_setup.go
+++ b/core/otel_setup.go
@@ -18,7 +18,7 @@ func detectResourceAttributes(ctx context.Context) []attribute.KeyValue {
 		resource.WithOS(),
 		resource.WithHost(),
 	)
-	if err != nil {
+	if err != nil && res == nil {
 		return nil
 	}
 

--- a/core/otel_setup.go
+++ b/core/otel_setup.go
@@ -1,14 +1,33 @@
 package core
 
 import (
-	"os"
+	"context"
 
 	"github.com/uptrace/uptrace-go/uptrace"
 	"go.lumeweb.com/portal/build"
 	"go.lumeweb.com/portal/config"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 )
+
+func detectResourceAttributes(ctx context.Context) []attribute.KeyValue {
+	res, err := resource.New(ctx,
+		resource.WithContainer(),
+		resource.WithProcess(),
+		resource.WithOS(),
+		resource.WithHost(),
+	)
+	if err != nil {
+		return nil
+	}
+
+	var attrs []attribute.KeyValue
+	for iter := res.Iter(); iter.Next(); {
+		attrs = append(attrs, iter.Attribute())
+	}
+	return attrs
+}
 
 // ContextWithTelemetry sets up the OpenTelemetry pipeline based on observability config.
 func ContextWithTelemetry() ContextBuilderOption {
@@ -33,8 +52,8 @@ func ContextWithTelemetry() ContextBuilderOption {
 				uptrace.WithServiceVersion(build.GetInfo().Version),
 			}
 
-			if hostname, err := os.Hostname(); err == nil {
-				options = append(options, uptrace.WithResourceAttributes(semconv.HostName(hostname)))
+			if extraAttrs := detectResourceAttributes(ctx); len(extraAttrs) > 0 {
+				options = append(options, uptrace.WithResourceAttributes(extraAttrs...))
 			}
 
 			// Configure logging if enabled


### PR DESCRIPTION
Replace manual hostname detection with OTel SDK resource detectors (WithContainer, WithProcess, WithOS, WithHost) that auto-detect environment attributes. Attributes are fed into uptrace-go via WithResourceAttributes without overriding its internal pipeline.

Container detection reads /proc/self/cgroup for container.id. Process detection adds PID, executable, runtime info. OS detection adds os.type and os.description.
Host detection replaces the old manual os.Hostname() + semconv.HostName.

---

<!-- kody-pr-summary:start -->
Add automatic container, process, OS, and host resource detection to OpenTelemetry setup

Replaces the manual hostname-only resource attribute detection with OpenTelemetry's built-in resource detectors (`WithContainer`, `WithProcess`, `WithOS`, `WithHost`). This provides richer and more comprehensive resource attributes in traces, including container-aware metadata, improving observability context in the telemetry backend.
<!-- kody-pr-summary:end -->