### PR TITLE
feat(metrics): add Go runtime and process collectors for CPU/memory observability

### DIFF
--- a/core/metrics.go
+++ b/core/metrics.go
@@ -24,6 +24,8 @@ var (
 
 func init() {
 	coreRegistry = prometheus.NewRegistry()
+	coreRegistry.MustRegister(prometheus.NewGoCollector())
+	coreRegistry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 }
 
 // CoreMetricsRegistry returns the global core prometheus registry


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add Go runtime and process Prometheus collectors to the core metrics registry, enabling CPU and memory observability at both the Go runtime level (e.g., GC stats, goroutines, memory allocation) and the process level (e.g., CPU usage, resident memory, file descriptors).
<!-- kody-pr-summary:end -->