### PR TITLE
perf(config): cache Config() results with subscription-based invalidation

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -142,6 +142,12 @@ type ManagerDefault struct {
 	configuredProtocols map[string]bool
 	configuredServices  map[string]map[string]bool // plugin -> services
 	lock                sync.RWMutex
+
+	// Cached config — rebuilt lazily on first access after invalidation.
+	// SubscribeCallback in NewManager() sets cachedConfig to nil on any
+	// config change via Set/Load, so the next Config() call rebuilds it.
+	cachedConfig   *Config
+	cachedConfigMu sync.RWMutex
 }
 
 func newManagerDefault(cm configmanager.Manager) *ManagerDefault {
@@ -316,6 +322,10 @@ func NewManager(opts ...ManagerOption) (*ManagerDefault, error) {
 		return nil, fmt.Errorf("failed to register config: %w", err)
 	}
 
+	m.Manager.Subscribe("**", func(_, _ string, _ any) {
+		m.invalidateConfig()
+	})
+
 	return m, nil
 }
 
@@ -386,6 +396,27 @@ func (m *ManagerDefault) EnableSync(opts ...configmanager.ConfigOption) error {
 }
 
 func (m *ManagerDefault) Config() *Config {
+	m.cachedConfigMu.RLock()
+	if m.cachedConfig != nil {
+		cfg := m.cachedConfig
+		m.cachedConfigMu.RUnlock()
+		return cfg
+	}
+	m.cachedConfigMu.RUnlock()
+
+	m.cachedConfigMu.Lock()
+	defer m.cachedConfigMu.Unlock()
+
+	if m.cachedConfig != nil {
+		return m.cachedConfig
+	}
+
+	cfg := m.buildConfig()
+	m.cachedConfig = cfg
+	return cfg
+}
+
+func (m *ManagerDefault) buildConfig() *Config {
 	cfg := &Config{
 		Core:   CoreConfig{},
 		Plugin: make(map[string]PluginEntity),
@@ -456,6 +487,12 @@ func (m *ManagerDefault) Config() *Config {
 	}
 
 	return cfg
+}
+
+func (m *ManagerDefault) invalidateConfig() {
+	m.cachedConfigMu.Lock()
+	m.cachedConfig = nil
+	m.cachedConfigMu.Unlock()
 }
 
 func (m *ManagerDefault) getPluginConfigFile(pluginName, subDir string, configType string) (string, error) {

--- a/config/manager_test.go
+++ b/config/manager_test.go
@@ -817,3 +817,62 @@ func TestDatabaseConfigValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigCaching(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "config_cache_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	configFile := filepath.Join(tempDir, CoreConfigFile)
+	err = os.WriteFile(configFile, []byte(`
+domain: "cached.example.com"
+portal_name: "cache_test"
+port: 8080
+`), 0644)
+	require.NoError(t, err)
+
+	m, err := NewManager(WithConfigPaths([]string{tempDir}))
+	require.NoError(t, err)
+
+	err = m.ConfigureProtocol("test_plugin", newTestProtocolConfig())
+	require.NoError(t, err)
+
+	err = m.Init()
+	require.NoError(t, err)
+
+	cfg1 := m.Config()
+	require.NotNil(t, cfg1)
+	assert.Equal(t, "cached.example.com", cfg1.Core.Domain)
+
+	cfg2 := m.Config()
+	assert.Same(t, cfg1, cfg2, "Config() should return the same cached pointer")
+}
+
+func TestConfigCacheInvalidation(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "config_invalidate_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	configFile := filepath.Join(tempDir, CoreConfigFile)
+	err = os.WriteFile(configFile, []byte(`
+domain: "before.example.com"
+portal_name: "invalidate_test"
+`), 0644)
+	require.NoError(t, err)
+
+	m, err := NewManager(WithConfigPaths([]string{tempDir}))
+	require.NoError(t, err)
+
+	err = m.Init()
+	require.NoError(t, err)
+
+	cfg1 := m.Config()
+	require.NotNil(t, cfg1)
+	assert.Equal(t, "before.example.com", cfg1.Core.Domain)
+
+	m.invalidateConfig()
+
+	cfg2 := m.Config()
+	assert.NotSame(t, cfg1, cfg2, "After invalidation, Config() should return a new pointer")
+	assert.Equal(t, "before.example.com", cfg2.Core.Domain)
+}


### PR DESCRIPTION
Config() was doing full deep-copy + mapstructure decode on every call, called from the HTTP hot path on every request. This caused 83% CPU usage (490% utilization) and ~3,900GB cumulative alloc lifetime.

- Add double-checked locking cache: RLock fast path returns cached pointer, Lock slow path calls buildConfig()
- Extract buildConfig() from original Config() body (no behavior change)
- Add invalidateConfig() called by Subscribe("**") in NewManager()
- Subscribe registered at construction time (not Init) to ensure invalidation works even when Init() is never called (test contexts)
- Add TestConfigCaching and TestConfigCacheInvalidation

---

<!-- kody-pr-summary:start -->
## Summary

This PR adds caching to the `Config()` method in the config manager, avoiding redundant config rebuilds on every call. The cache is automatically invalidated via a subscription-based mechanism whenever the underlying configuration changes.

### Changes

- **Lazy caching of `Config()` results**: The `Config()` method now returns a cached `*Config` pointer on subsequent calls instead of rebuilding the entire config structure each time. Double-checked locking is used for thread safety.
- **Subscription-based invalidation**: A wildcard subscription (`"**"`) is registered during `NewManager()` so that any config change (via `Set`/`Load`) triggers `invalidateConfig()`, which sets the cache to `nil`. The next `Config()` call then rebuilds the cache lazily.
- **Refactored config building**: The original config construction logic was extracted into a new `buildConfig()` method, called only when the cache is empty.
- **New tests**: `TestConfigCaching` verifies that repeated calls return the same cached pointer, and `TestConfigCacheInvalidation` verifies that after invalidation a fresh config object is produced.
<!-- kody-pr-summary:end -->