### PR TITLE
feat(otel): add otelecho HTTP tracing middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	go.lumeweb.com/portal-middleware v0.3.7
 	go.lumeweb.com/portal-router v0.6.16
 	go.opentelemetry.io/contrib/bridges/otelzap v0.19.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/log v0.20.0
 	go.opentelemetry.io/otel/sdk v1.44.0
@@ -234,7 +235,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/arch v0.24.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -886,6 +886,8 @@ go.opentelemetry.io/contrib/bridges/otelzap v0.18.0 h1:EkWTww6Nqs2P29r01NeuNsG7q
 go.opentelemetry.io/contrib/bridges/otelzap v0.18.0/go.mod h1:lj3bgA/c7nJy0NhxqyvWJFC30aTgB+G0RKDdLbvJ4QM=
 go.opentelemetry.io/contrib/bridges/otelzap v0.19.0 h1:48Eq3xxFx2KlL/tF7lnl42kKJBDlhNTLRzv0h154JnM=
 go.opentelemetry.io/contrib/bridges/otelzap v0.19.0/go.mod h1:cQbV77F0u6HmtZPiQD9oxp2esaOEb4uLqIta6OFIKOk=
+go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.69.0 h1:p2oor9jp8aT5uqVuN9p0GCntXn5VX8qXdOH098hgLu4=
+go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.69.0/go.mod h1:NOiuETZRg7aNSNFPWqf4dAszhyFMVdKYXW4V0/DtbNA=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 h1:jhVIQEprwUTV+KfzzliLidclhoTOoHTgdz96kAyR8mU=
 go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0/go.mod h1:4HsdbLUbernaTnA8CNaNE+1g026SciXb3juRYe3l8EY=
 go.opentelemetry.io/contrib/processors/minsev v0.16.0 h1:bjTZkvAKnG1mqWgCjU7RkOkHRTMsGlJO/UlqjRCweeU=
@@ -1096,6 +1098,8 @@ golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/service/http.go
+++ b/service/http.go
@@ -18,6 +18,7 @@ import (
 	"go.lumeweb.com/portal-middleware/cors"
 	"go.lumeweb.com/portal-middleware/swagger"
 	"go.lumeweb.com/portal/build"
+	otelecho "go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
 
 	"io"
 	"net"
@@ -144,6 +145,12 @@ func (h *HTTPServiceDefault) Init() error {
 			return err
 		},
 	}))
+
+	ocfg := h.Config().Config().Core.Observability
+	if ocfg.IsTracingEnabled() {
+		h.router.Use(otelecho.Middleware(ocfg.ServiceName))
+	}
+
 	h.srv.Addr = ":" + strconv.FormatUint(uint64(h.Config().Config().Core.Port), 10)
 	for _, api := range core.GetAPIs() {
 		domain := h.getAPIDomain(api)
@@ -169,6 +176,10 @@ func (h *HTTPServiceDefault) Init() error {
 		hostRouter, err := h.Router().Host(domain)
 		if err != nil {
 			return fmt.Errorf("failed to create host router for API %s: %w", api.Name(), err)
+		}
+
+		if ocfg.IsTracingEnabled() {
+			hostRouter.Use(otelecho.Middleware(ocfg.ServiceName))
 		}
 
 		if apiInfo != nil {
@@ -267,8 +278,6 @@ func (h *HTTPServiceDefault) Init() error {
 	if err != nil {
 		return err
 	}
-
-	ocfg := h.Config().Config().Core.Observability
 
 	// Register metrics endpoints if observability is enabled
 	if ocfg.IsMetricsEnabled() {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Add OpenTelemetry HTTP tracing middleware to the HTTP service using the `otelecho` instrumentation library. When tracing is enabled in the observability configuration, the `otelecho.Middleware` is applied to both the main router and per-API host routers, enabling distributed tracing for incoming HTTP requests. The observability config is now retrieved earlier in the initialization to support this tracing setup alongside the existing metrics registration.
<!-- kody-pr-summary:end -->