### PR TITLE
fix(config): accept bare hostnames in OTLP endpoint validation

### DIFF
--- a/config/observability.go
+++ b/config/observability.go
@@ -50,9 +50,13 @@ func (o OTLPConfig) Schema() z.ZogSchema {
 		}
 
 		if c.Endpoint != "" {
-			if _, _, err := net.SplitHostPort(c.Endpoint); err != nil {
-				ctx.AddIssue(ctx.Issue().SetMessage("endpoint must be in host:port format"))
-				return false
+			endpoint := c.Endpoint
+			if _, _, err := net.SplitHostPort(endpoint); err != nil {
+				endpoint = endpoint + ":4317"
+				if _, _, err2 := net.SplitHostPort(endpoint); err2 != nil {
+					ctx.AddIssue(ctx.Issue().SetMessage("endpoint format is invalid"))
+					return false
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes the OTLP endpoint validation in the observability configuration to accept bare hostnames without requiring an explicit port.

Previously, the validation strictly required the endpoint to be in `host:port` format, rejecting any endpoint that didn't include a port. Now, if no port is specified, the validation automatically appends the default OTLP gRPC port (`:4317`) before re-validating. The endpoint is only rejected if it remains invalid after this fallback, with an updated error message ("endpoint format is invalid" instead of "endpoint must be in host:port format").
<!-- kody-pr-summary:end -->