### PR TITLE
fix: continue registering metrics past duplicates, log conflicts at error level

### DIFF
--- a/core/metrics.go
+++ b/core/metrics.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -200,21 +201,27 @@ func RegisterServiceMetrics(serviceID string, metrics []prometheus.Collector) er
 
 	if IsCoreService(serviceID) || pluginID == "" {
 		// Register with core registry
+		var errs []error
 		for _, metric := range metrics {
 			if err := RegisterCoreCollector(metric); err != nil {
-				return fmt.Errorf("failed to register core metric %T: %w", metric, err)
+				if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+					errs = append(errs, fmt.Errorf("failed to register core metric %T: %w", metric, err))
+				}
 			}
 		}
-		return nil
+		return errors.Join(errs...)
 	}
 
 	// Register with plugin registry
+	var errs []error
 	for _, metric := range metrics {
 		if err := RegisterPluginCollector(pluginID, metric); err != nil {
-			return fmt.Errorf("failed to register plugin %s metric %T: %w", pluginID, metric, err)
+			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+				errs = append(errs, fmt.Errorf("failed to register plugin %s metric %T: %w", pluginID, metric, err))
+			}
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // RegisterPluginMetrics registers a plugin's metrics with the plugin's registry
@@ -223,12 +230,18 @@ func RegisterPluginMetrics(pluginID string, metrics []prometheus.Collector) erro
 		return nil
 	}
 
+	var errs []error
 	for _, metric := range metrics {
 		if err := RegisterPluginCollector(pluginID, metric); err != nil {
-			return fmt.Errorf("failed to register plugin %s metric %T: %w", pluginID, metric, err)
+			if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+				// Same metric registered twice - skip silently, this is benign
+				continue
+			}
+			// Real conflict (different help/labels for same name) - collect error but continue
+			errs = append(errs, fmt.Errorf("failed to register plugin %s metric %T: %w", pluginID, metric, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // MetricTrack tracks duration and errors for single-return functions.

--- a/portal.go
+++ b/portal.go
@@ -450,7 +450,7 @@ func (p *PortalImpl) registerMetrics(ctx core.Context) error {
 	// Register metrics for all core and plugin services
 	for _, svcInfo := range core.GetServices() {
 		if err := core.RegisterServiceMetrics(svcInfo.ID, svcInfo.Metrics); err != nil {
-			ctx.Logger().Warn("Failed to register service metrics",
+			ctx.Logger().Error("Failed to register service metrics",
 				zap.String("service", svcInfo.ID),
 				zap.Error(err))
 		}
@@ -459,7 +459,7 @@ func (p *PortalImpl) registerMetrics(ctx core.Context) error {
 	// Register metrics for all plugins
 	for _, plugin := range core.GetPlugins() {
 		if err := core.RegisterPluginMetrics(plugin.ID, plugin.Metrics); err != nil {
-			ctx.Logger().Warn("Failed to register plugin metrics",
+			ctx.Logger().Error("Failed to register plugin metrics",
 				zap.String("plugin", plugin.ID),
 				zap.Error(err))
 		}


### PR DESCRIPTION
RegisterPluginMetrics and RegisterServiceMetrics returned on the
first registration error, skipping all remaining collectors. A single
duplicate metric name in any plugin would drop every metric after it.

AlreadyRegisteredError (same metric registered twice) is now silently
skipped. Real descriptor conflicts (same name, different help/labels)
are collected via errors.Join and logged at Error level instead of
Warn, since benign duplicates no longer surface as errors.

---

<!-- kody-pr-summary:start -->
## Pull Request Description

This PR improves the resilience of Prometheus metrics registration by changing the error handling strategy from fail-fast to continue-and-collect.

### Changes

1. **Continue registration past errors**: Previously, when registering a batch of metrics (for both core services and plugins), the first registration failure would immediately abort the process, leaving remaining metrics unregistered. Now, all metrics are attempted for registration regardless of individual failures, and any errors are aggregated and returned together via `errors.Join()`.

2. **Silently skip duplicate metric registrations**: `prometheus.AlreadyRegisteredError` (which occurs when the same metric is registered more than once) is now treated as benign and silently skipped rather than being reported as an error. Only genuine conflicts (e.g., different help text or labels for the same metric name) are collected as errors.

3. **Escalate log level for real conflicts**: In `portal.go`, the log level for metric registration failures was raised from `Warn` to `Error` for both service and plugin metrics. Since duplicate registrations are now filtered out, any error that surfaces represents a real conflict that warrants higher visibility.
<!-- kody-pr-summary:end -->