### PR TITLE
feat: add APIExtensionMetrics interface for extension-served metrics

### DIFF
--- a/core/api_extension.go
+++ b/core/api_extension.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	"go.lumeweb.com/portal-router"
 	"sync"
 )
@@ -15,6 +16,15 @@ type APIExtension interface {
 
 	// Configure is called after the main API routes are registered
 	Configure(router router.Router, accessSvc AccessService) error
+}
+
+// APIExtensionMetrics is an optional interface that API extensions can implement
+// to declare metrics that should be registered on the target API's subdomain.
+// When implemented, these metrics are registered into PluginMetricsRegistry(TargetAPI())
+// and served on that API's /metrics endpoint.
+type APIExtensionMetrics interface {
+	APIExtension
+	Metrics() []prometheus.Collector
 }
 
 var (

--- a/portal.go
+++ b/portal.go
@@ -581,6 +581,24 @@ func (p *PortalImpl) registerAPIExtensions(ctx core.Context) (ctxOpts []core.Con
 						zap.String("plugin", plugin.ID),
 						zap.String("target", ext.TargetAPI()))
 					core.RegisterAPIExtension(ext)
+
+					// If the extension declares metrics, register them into the
+					// target API's plugin registry so they are served on that
+					// API's /metrics endpoint.
+					if metricsExt, ok := ext.(core.APIExtensionMetrics); ok {
+						targetAPI := ext.TargetAPI()
+						if err := core.RegisterPluginMetrics(targetAPI, metricsExt.Metrics()); err != nil {
+							ctx.Logger().Error("Failed to register API extension metrics",
+								zap.String("plugin", plugin.ID),
+								zap.String("target_api", targetAPI),
+								zap.Error(err))
+						} else {
+							ctx.Logger().Info("Registered API extension metrics",
+								zap.String("plugin", plugin.ID),
+								zap.String("target_api", targetAPI))
+						}
+					}
+
 					ctxOptions = append(ctxOptions, core.ContextWithStartupComponent(ext))
 
 					return core.ProcessCtxOptions(ctx, ctxOptions...)


### PR DESCRIPTION
Plugins that only provide API extensions (no own API) have no subdomain to serve metrics on. Add an optional APIExtensionMetrics interface that extensions implement to declare metrics registered into the target API's plugin registry, served on that API's /metrics endpoint.

---

<!-- kody-pr-summary:start -->
## Description

This PR adds support for API extensions to declare Prometheus metrics that are automatically registered and served on their target API's `/metrics` endpoint.

A new optional interface `APIExtensionMetrics` is introduced, which extends `APIExtension` with a `Metrics()` method returning a slice of Prometheus collectors. When an API extension implements this interface, the portal detects it during extension registration and registers the declared metrics into the target API's plugin metrics registry. Appropriate success and error logging is included to aid in debugging registration issues.

This enables plugins to expose custom metrics through the standard metrics endpoint of the API they extend, without requiring manual registration.
<!-- kody-pr-summary:end -->