### PR TITLE
feat: add hash/fileName span attributes to storage and renter services

### DIFF
--- a/service/renter.go
+++ b/service/renter.go
@@ -15,6 +15,7 @@ import (
 	"go.lumeweb.com/portal/db/models"
 	renterInternal "go.lumeweb.com/portal/service/internal/renter"
 	renterMetrics "go.lumeweb.com/portal/service/internal/renter"
+	"go.opentelemetry.io/otel/attribute"
 	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/v2/api"
 	autoPilotClient "go.sia.tech/renterd/v2/autopilot"
@@ -118,7 +119,8 @@ func (r *RenterDefault) CreateBucketIfNotExists(bucket string) error {
 }
 
 func (r *RenterDefault) UploadObject(ctx context.Context, file io.Reader, bucket string, fileName string) error {
-	ctx, span := core.TraceMethod(ctx, "RenterDefault.UploadObject")
+	ctx, span := core.TraceMethod(ctx, "RenterDefault.UploadObject",
+		core.WithAttributes(attribute.String("fileName", fileName)))
 	defer span.End()
 
 	return core.MetricTrack(
@@ -219,7 +221,8 @@ func (r *RenterDefault) getWorkerClient() (*workerClient.Client, error) {
 }
 
 func (r *RenterDefault) GetObject(ctx context.Context, bucket string, fileName string, options api.DownloadObjectOptions) (*api.GetObjectResponse, error) {
-	ctx, span := core.TraceMethod(ctx, "RenterDefault.GetObject")
+	ctx, span := core.TraceMethod(ctx, "RenterDefault.GetObject",
+		core.WithAttributes(attribute.String("fileName", fileName)))
 	defer span.End()
 
 	return core.MetricTrackResult(
@@ -503,7 +506,8 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 }
 
 func (r *RenterDefault) DeleteObject(ctx context.Context, bucket string, fileName string) error {
-	ctx, span := core.TraceMethod(ctx, "RenterDefault.DeleteObject")
+	ctx, span := core.TraceMethod(ctx, "RenterDefault.DeleteObject",
+		core.WithAttributes(attribute.String("fileName", fileName)))
 	defer span.End()
 
 	return core.MetricTrack(

--- a/service/storage.go
+++ b/service/storage.go
@@ -24,6 +24,7 @@ import (
 	"go.lumeweb.com/portal/db"
 	"go.lumeweb.com/portal/db/models"
 	storageMetrics "go.lumeweb.com/portal/service/internal/storage"
+	"go.opentelemetry.io/otel/attribute"
 	"go.sia.tech/renterd/v2/api"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -194,7 +195,8 @@ func (rp *readerPool) Close() {
 }
 
 func (s StorageServiceDefault) UploadObject(ctx context.Context, request core.StorageUploadRequest) (*models.Upload, error) {
-	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.UploadObject")
+	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.UploadObject",
+		core.WithAttributes(attribute.String("hash", request.Hash().String())))
 	defer span.End()
 
 	startTime := time.Now()
@@ -363,14 +365,16 @@ func (s StorageServiceDefault) applyStorageOptions(opts []core.StorageOptionFunc
 }
 
 func (s StorageServiceDefault) DownloadObject(ctx context.Context, protocol core.StorageProtocol, objectHash core.StorageHash, start int64) (io.ReadCloser, error) {
-	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DownloadObject")
+	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DownloadObject",
+		core.WithAttributes(attribute.String("hash", objectHash.String())))
 	defer span.End()
 
 	return s.DownloadObjectWithOptions(ctx, protocol, objectHash, core.StorageDownloadWithStart(start))
 }
 
 func (s StorageServiceDefault) DownloadObjectWithOptions(ctx context.Context, protocol core.StorageProtocol, objectHash core.StorageHash, opts ...core.StorageOptionFunc) (io.ReadCloser, error) {
-	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DownloadObjectWithOptions")
+	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DownloadObjectWithOptions",
+		core.WithAttributes(attribute.String("hash", objectHash.String())))
 	defer span.End()
 
 	startTime := time.Now()
@@ -405,7 +409,8 @@ func (s StorageServiceDefault) DownloadObjectWithOptions(ctx context.Context, pr
 }
 
 func (s StorageServiceDefault) DownloadObjectProof(ctx context.Context, protocol core.StorageProtocol, objectHash core.StorageHash) (io.ReadCloser, error) {
-	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DownloadObjectProof")
+	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DownloadObjectProof",
+		core.WithAttributes(attribute.String("hash", objectHash.String())))
 	defer span.End()
 
 	object, err := s.renter.GetObject(ctx, protocol.Name(), s.getProofPath(protocol, objectHash), api.DownloadObjectOptions{})
@@ -417,7 +422,8 @@ func (s StorageServiceDefault) DownloadObjectProof(ctx context.Context, protocol
 }
 
 func (s StorageServiceDefault) DeleteObject(ctx context.Context, protocol core.StorageProtocol, objectHash core.StorageHash) error {
-	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DeleteObject")
+	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DeleteObject",
+		core.WithAttributes(attribute.String("hash", objectHash.String())))
 	defer span.End()
 
 	return core.MetricTrack(storageMetrics.DeleteDuration, storageMetrics.DeleteErrors, func() error {
@@ -426,7 +432,8 @@ func (s StorageServiceDefault) DeleteObject(ctx context.Context, protocol core.S
 }
 
 func (s StorageServiceDefault) DeleteObjectProof(ctx context.Context, protocol core.StorageProtocol, objectHash core.StorageHash) error {
-	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DeleteObjectProof")
+	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.DeleteObjectProof",
+		core.WithAttributes(attribute.String("hash", objectHash.String())))
 	defer span.End()
 
 	return core.MetricTrack(storageMetrics.DeleteDuration, storageMetrics.DeleteErrors, func() error {

--- a/service/storage.go
+++ b/service/storage.go
@@ -195,8 +195,7 @@ func (rp *readerPool) Close() {
 }
 
 func (s StorageServiceDefault) UploadObject(ctx context.Context, request core.StorageUploadRequest) (*models.Upload, error) {
-	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.UploadObject",
-		core.WithAttributes(attribute.String("hash", request.Hash().String())))
+	ctx, span := core.TraceMethod(ctx, "StorageServiceDefault.UploadObject")
 	defer span.End()
 
 	startTime := time.Now()
@@ -227,6 +226,8 @@ func (s StorageServiceDefault) UploadObject(ctx context.Context, request core.St
 			return nil, err
 		}
 	}
+
+	span.SetAttributes(attribute.String("hash", hash.String()))
 
 	meta, err := s.metadata.GetUpload(ctx, hash)
 	if err == nil {


### PR DESCRIPTION
- Add `hash` attribute to StorageService upload/download/delete spans (storage.go)
- Add `fileName` attribute to RenterDefault upload/get/delete spans (renter.go)
- `UploadObjectProof` skipped (proof can be nil at span creation)

Enables CID/hash correlation across the full trace chain from blockstore through storage service to renterd worker calls. Complements portal-plugin-ipfs PR for full trace tag coverage.

---

<!-- kody-pr-summary:start -->
This PR enhances OpenTelemetry tracing by adding contextual span attributes to the storage and renter services. Specifically, it adds a `fileName` attribute to renter service trace spans for object upload, download, and delete operations, and a `hash` attribute to storage service trace spans for object upload, download, download proof, delete, and delete proof operations. These attributes improve observability by making it easier to correlate traces with the specific files or object hashes being processed.
<!-- kody-pr-summary:end -->