### PR TITLE
feat: add workflow trace linking via span links and attributes

### DIFF
--- a/core/otel.go
+++ b/core/otel.go
@@ -169,6 +169,7 @@ type SpanConfig struct {
 	Name       string
 	Attributes []attribute.KeyValue
 	Kind       trace.SpanKind
+	Links      []trace.Link
 }
 
 // SpanOption is a function that configures a SpanConfig
@@ -178,6 +179,14 @@ type SpanOption func(*SpanConfig)
 func WithAttributes(attrs ...attribute.KeyValue) SpanOption {
 	return func(c *SpanConfig) {
 		c.Attributes = append(c.Attributes, attrs...)
+	}
+}
+
+// WithLinks adds trace links to the span. Links connect independent traces
+// (e.g., workflow steps) without forcing them into a single trace tree.
+func WithLinks(links ...trace.Link) SpanOption {
+	return func(c *SpanConfig) {
+		c.Links = append(c.Links, links...)
 	}
 }
 
@@ -205,10 +214,14 @@ func StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Co
 	}
 
 	tracer := getTracer(ctx)
-	return tracer.Start(ctx, config.Name,
+	spanOpts := []trace.SpanStartOption{
 		trace.WithAttributes(config.Attributes...),
 		trace.WithSpanKind(config.Kind),
-	)
+	}
+	if len(config.Links) > 0 {
+		spanOpts = append(spanOpts, trace.WithLinks(config.Links...))
+	}
+	return tracer.Start(ctx, config.Name, spanOpts...)
 }
 
 // TraceMethod starts a new trace span for a method.

--- a/core/trace_context.go
+++ b/core/trace_context.go
@@ -1,0 +1,163 @@
+package core
+
+import (
+	"context"
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// traceParentKey is the carrier key for W3C Trace Context headers.
+// This matches the standard "traceparent" header name used in HTTP and
+// other transport protocols, ensuring compatibility with W3C-compliant
+// tracing backends like Tempo, Jaeger, and Zipkin.
+const traceParentKey = "traceparent"
+
+// traceContextCarrier is a propagation.TextMapCarrier that carries the
+// traceparent header in a single string field. It is used to serialize
+// and deserialize trace context across async boundaries (e.g., workflow
+// steps dispatched via cron, or across nodes in a horizontally-scaled
+// deployment).
+type traceContextCarrier struct {
+	headers map[string]string
+}
+
+func (c *traceContextCarrier) Get(key string) string {
+	return c.headers[key]
+}
+
+func (c *traceContextCarrier) Set(key, value string) {
+	c.headers[key] = value
+}
+
+// Keys returns the set of keys present in the carrier, satisfying the
+// propagation.TextMapCarrier interface.
+func (c *traceContextCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.headers))
+	for k := range c.headers {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// MarshalTraceParent extracts the trace context from ctx and serializes
+// it as a W3C traceparent string. Returns an empty string if no span
+// context is present in ctx.
+//
+// Use this to persist trace context across async boundaries (DB, message
+// queue, etc.). Restore it with ContextWithTraceParent.
+func MarshalTraceParent(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return ""
+	}
+
+	carrier := &traceContextCarrier{headers: make(map[string]string)}
+	propagation.TraceContext{}.Inject(ctx, carrier)
+	return carrier.Get(traceParentKey)
+}
+
+// ContextWithTraceParent creates a new context with the trace context
+// restored from a W3C traceparent string. If the string is empty or
+// invalid, the original context is returned unchanged.
+//
+// The returned context's spans will be children of the original trace,
+// maintaining parent-child trace continuity. For linking independent
+// traces (e.g., workflow steps), use SpanLinksFromTraceParents instead.
+func ContextWithTraceParent(ctx context.Context, traceParent string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	traceParent = strings.TrimSpace(traceParent)
+	if traceParent == "" {
+		return ctx
+	}
+
+	carrier := &traceContextCarrier{headers: map[string]string{traceParentKey: traceParent}}
+	return propagation.TraceContext{}.Extract(ctx, carrier)
+}
+
+// ParseTraceParent parses a W3C traceparent string and returns the
+// embedded SpanContext. Returns false if the string is empty, malformed,
+// or contains an invalid span context.
+func ParseTraceParent(traceParent string) (trace.SpanContext, bool) {
+	traceParent = strings.TrimSpace(traceParent)
+	if traceParent == "" {
+		return trace.SpanContext{}, false
+	}
+
+	carrier := &traceContextCarrier{headers: map[string]string{traceParentKey: traceParent}}
+	ctx := propagation.TraceContext{}.Extract(context.Background(), carrier)
+	sc := trace.SpanContextFromContext(ctx)
+	return sc, sc.IsValid()
+}
+
+// SpanLinksFromTraceParents parses one or more traceparent strings and
+// returns them as trace.Link slice suitable for passing to WithLinks.
+// Empty strings are silently skipped. Returns nil if no valid trace
+// parents are provided.
+//
+// Use this to link independent traces (e.g., a workflow step's trace
+// linking back to the root workflow trace) without forcing them into a
+// single parent-child trace tree.
+func SpanLinksFromTraceParents(traceParents ...string) []trace.Link {
+	var links []trace.Link
+	for _, tp := range traceParents {
+		sc, ok := ParseTraceParent(tp)
+		if !ok {
+			continue
+		}
+		links = append(links, trace.Link{SpanContext: sc})
+	}
+	return links
+}
+
+// HasTraceParent returns true if the traceparent string is non-empty
+// and appears to contain a valid W3C trace context.
+func HasTraceParent(traceParent string) bool {
+	_, ok := ParseTraceParent(traceParent)
+	return ok
+}
+
+// Workflow span attribute keys. These are set on every span within a
+// workflow step, enabling query-based grouping in Tempo/LogQL:
+//
+//	workflow.id="42"       — all spans for workflow request 42
+//	workflow.name="upload"  — all upload workflow spans
+//	workflow.user_id="7"    — all workflows for user 7
+//	workflow.hash="..."     — all operations on a specific storage hash
+const (
+	AttrWorkflowID     = attribute.Key("workflow.id")
+	AttrWorkflowName   = attribute.Key("workflow.name")
+	AttrWorkflowUserID = attribute.Key("workflow.user_id")
+	AttrWorkflowHash   = attribute.Key("workflow.hash")
+)
+
+// WorkflowSpanAttributes returns OTEL attributes for workflow span annotation.
+// These attributes enable querying spans by workflow ID, name, user, or hash
+// across all traces in the workflow, even when steps execute on different nodes.
+//
+// userID may be nil for anonymous/system operations. hash may be empty.
+func WorkflowSpanAttributes(workflowID, workflowName string, userID *uint, hash string) []attribute.KeyValue {
+	var attrs []attribute.KeyValue
+	if workflowID != "" {
+		attrs = append(attrs, AttrWorkflowID.String(workflowID))
+	}
+	if workflowName != "" {
+		attrs = append(attrs, AttrWorkflowName.String(workflowName))
+	}
+	if userID != nil {
+		attrs = append(attrs, AttrWorkflowUserID.Int64(int64(*userID)))
+	}
+	if hash != "" {
+		attrs = append(attrs, AttrWorkflowHash.String(hash))
+	}
+	return attrs
+}

--- a/core/trace_context_test.go
+++ b/core/trace_context_test.go
@@ -1,0 +1,379 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// setupTestTracerProvider creates a real SDK tracer provider with an
+// in-memory exporter for testing, and returns a cleanup function.
+func setupTestTracerProvider() (trace.TracerProvider, *tracetest.InMemoryExporter, func()) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exporter),
+	)
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	cleanup := func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	}
+	return tp, exporter, cleanup
+}
+
+// TestMarshalTraceParent_NoSpanContext tests that MarshalTraceParent returns
+// an empty string when no span context is present in the context.
+func TestMarshalTraceParent_NoSpanContext(t *testing.T) {
+	tp := MarshalTraceParent(context.Background())
+	assert.Empty(t, tp, "should return empty string when no span context")
+}
+
+// TestMarshalTraceParent_WithSpanContext tests that MarshalTraceParent
+// produces a valid W3C traceparent when a span context is present.
+func TestMarshalTraceParent_WithSpanContext(t *testing.T) {
+	tp, _, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "test-span")
+	defer span.End()
+
+	traceParent := MarshalTraceParent(ctx)
+	assert.NotEmpty(t, traceParent, "should return non-empty traceparent")
+	// W3C traceparent format: 00-<32 hex traceID>-<16 hex spanID>-<2 hex flags>
+	assert.Len(t, traceParent, 55, "traceparent should be 55 chars")
+	assert.Equal(t, "00", traceParent[:2], "version should be 00")
+}
+
+// TestContextWithTraceParent_Empty tests that an empty traceparent
+// returns the original context unchanged.
+func TestContextWithTraceParent_Empty(t *testing.T) {
+	ctx := context.Background()
+	result := ContextWithTraceParent(ctx, "")
+	assert.NotNil(t, result)
+}
+
+// TestContextWithTraceParent_Whitespace tests that whitespace-only
+// traceparent is treated as empty.
+func TestContextWithTraceParent_Whitespace(t *testing.T) {
+	ctx := context.Background()
+	result := ContextWithTraceParent(ctx, "   ")
+	assert.NotNil(t, result)
+}
+
+// TestContextWithTraceParent_RoundTrip tests that a traceparent
+// marshaled from a context can be restored and produces a child
+// span context with the same trace ID.
+func TestContextWithTraceParent_RoundTrip(t *testing.T) {
+	tp, _, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+
+	// Create a parent span and extract its traceparent
+	parentCtx, parentSpan := tracer.Start(context.Background(), "parent-span")
+	parentSpan.End()
+
+	traceParent := MarshalTraceParent(parentCtx)
+	assert.NotEmpty(t, traceParent)
+
+	// Restore trace context into a fresh background context
+	restoredCtx := ContextWithTraceParent(context.Background(), traceParent)
+
+	// Create a child span in the restored context
+	_, childSpan := tracer.Start(restoredCtx, "child-span")
+	childSpan.End()
+
+	// Verify the child span has the same trace ID as the parent
+	parentSC := parentSpan.SpanContext()
+	childSC := childSpan.SpanContext()
+
+	assert.True(t, parentSC.TraceID().IsValid(), "parent trace ID should be valid")
+	assert.True(t, childSC.TraceID().IsValid(), "child trace ID should be valid")
+	assert.Equal(t, parentSC.TraceID(), childSC.TraceID(),
+		"child span should have same trace ID as parent")
+	// The child span should be recorded as a child of the parent
+	assert.NotEqual(t, parentSC.SpanID(), childSC.SpanID(),
+		"child span should have different span ID than parent")
+}
+
+// TestContextWithTraceParent_InvalidString tests that an invalid
+// traceparent string is handled gracefully (no panic).
+func TestContextWithTraceParent_InvalidString(t *testing.T) {
+	ctx := context.Background()
+	result := ContextWithTraceParent(ctx, "invalid")
+	assert.NotNil(t, result)
+}
+
+// TestHasTraceParent tests the HasTraceParent helper.
+func TestHasTraceParent(t *testing.T) {
+	assert.False(t, HasTraceParent(""))
+	assert.False(t, HasTraceParent("  "))
+	assert.False(t, HasTraceParent("00-abc-def-01"), "short/invalid traceparent should be false")
+}
+
+// TestMarshalTraceParent_NilContext tests nil context handling.
+func TestMarshalTraceParent_NilContext(t *testing.T) {
+	tp := MarshalTraceParent(nil)
+	assert.Empty(t, tp)
+}
+
+// TestContextWithTraceParent_NilContext tests nil context handling.
+func TestContextWithTraceParent_NilContext(t *testing.T) {
+	result := ContextWithTraceParent(nil, "00-abc-def-01")
+	assert.NotNil(t, result)
+}
+
+// TestRoundTrip_PreservesTraceFlags tests that trace flags (like sampled)
+// are preserved through the round-trip.
+func TestRoundTrip_PreservesTraceFlags(t *testing.T) {
+	tp, _, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+
+	// Create a parent span (sampled by default)
+	parentCtx, parentSpan := tracer.Start(context.Background(), "parent-span")
+	parentSpan.End()
+
+	parentSC := parentSpan.SpanContext()
+	traceParent := MarshalTraceParent(parentCtx)
+
+	// Restore and create child
+	restoredCtx := ContextWithTraceParent(context.Background(), traceParent)
+	_, childSpan := tracer.Start(restoredCtx, "child-span")
+	childSpan.End()
+
+	childSC := childSpan.SpanContext()
+
+	// Trace flags should match
+	assert.Equal(t, parentSC.TraceFlags(), childSC.TraceFlags(),
+		"trace flags should be preserved through round-trip")
+}
+
+// TestContextWithTraceParent_CreatesValidSpanContext tests that
+// restoring a valid traceparent produces a valid span context.
+func TestContextWithTraceParent_CreatesValidSpanContext(t *testing.T) {
+	tp, _, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+
+	// Create parent and extract traceparent
+	parentCtx, parentSpan := tracer.Start(context.Background(), "parent")
+	traceParent := MarshalTraceParent(parentCtx)
+	parentSpan.End()
+
+	// Restore into fresh context
+	restoredCtx := ContextWithTraceParent(context.Background(), traceParent)
+
+	// The restored context should have a valid span context
+	restoredSC := trace.SpanContextFromContext(restoredCtx)
+	assert.True(t, restoredSC.IsValid(), "restored span context should be valid")
+	assert.True(t, restoredSC.IsRemote(), "restored span context should be remote")
+}
+
+// --- ParseTraceParent tests ---
+
+// TestParseTraceParent_ValidRoundTrip tests that ParseTraceParent correctly
+// parses a traceparent produced by MarshalTraceParent.
+func TestParseTraceParent_ValidRoundTrip(t *testing.T) {
+	tp, _, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "test-span")
+	span.End()
+
+	traceParent := MarshalTraceParent(ctx)
+	assert.NotEmpty(t, traceParent)
+
+	sc, ok := ParseTraceParent(traceParent)
+	assert.True(t, ok, "should parse valid traceparent")
+	assert.True(t, sc.IsValid(), "parsed span context should be valid")
+	assert.True(t, sc.IsRemote(), "parsed span context should be remote")
+}
+
+// TestParseTraceParent_Empty tests empty string handling.
+func TestParseTraceParent_Empty(t *testing.T) {
+	_, ok := ParseTraceParent("")
+	assert.False(t, ok, "empty string should not parse")
+}
+
+// TestParseTraceParent_Whitespace tests whitespace-only string.
+func TestParseTraceParent_Whitespace(t *testing.T) {
+	_, ok := ParseTraceParent("   ")
+	assert.False(t, ok, "whitespace should not parse")
+}
+
+// TestParseTraceParent_Invalid tests malformed traceparent.
+func TestParseTraceParent_Invalid(t *testing.T) {
+	_, ok := ParseTraceParent("not-a-traceparent")
+	assert.False(t, ok, "malformed string should not parse")
+}
+
+// --- SpanLinksFromTraceParents tests ---
+
+// TestSpanLinksFromTraceParents_Valid tests that valid traceparents
+// produce trace.Link entries.
+func TestSpanLinksFromTraceParents_Valid(t *testing.T) {
+	tp, _, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "root-span")
+	span.End()
+
+	traceParent := MarshalTraceParent(ctx)
+	assert.NotEmpty(t, traceParent)
+
+	links := SpanLinksFromTraceParents(traceParent)
+	assert.Len(t, links, 1, "should produce one link")
+	assert.True(t, links[0].SpanContext.IsValid(), "link span context should be valid")
+}
+
+// TestSpanLinksFromTraceParents_Multiple tests multiple traceparents.
+func TestSpanLinksFromTraceParents_Multiple(t *testing.T) {
+	tp, _, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+
+	_, span1 := tracer.Start(context.Background(), "span1")
+	span1.End()
+	tp1 := MarshalTraceParent(trace.ContextWithSpanContext(context.Background(), span1.SpanContext()))
+
+	_, span2 := tracer.Start(context.Background(), "span2")
+	span2.End()
+	tp2 := MarshalTraceParent(trace.ContextWithSpanContext(context.Background(), span2.SpanContext()))
+
+	links := SpanLinksFromTraceParents(tp1, tp2)
+	assert.Len(t, links, 2, "should produce two links")
+}
+
+// TestSpanLinksFromTraceParents_SkipsEmpty tests that empty strings
+// are silently skipped.
+func TestSpanLinksFromTraceParents_SkipsEmpty(t *testing.T) {
+	tp, _, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+	ctx, span := tracer.Start(context.Background(), "root")
+	span.End()
+	validTP := MarshalTraceParent(ctx)
+
+	links := SpanLinksFromTraceParents(validTP, "", "  ", "invalid")
+	assert.Len(t, links, 1, "should only produce one link from the valid traceparent")
+}
+
+// TestSpanLinksFromTraceParents_AllEmpty tests no valid input.
+func TestSpanLinksFromTraceParents_AllEmpty(t *testing.T) {
+	links := SpanLinksFromTraceParents("", "  ", "invalid")
+	assert.Nil(t, links, "should return nil when no valid traceparents")
+}
+
+// --- WithLinks / StartSpan integration tests ---
+
+// TestStartSpan_WithLinks tests that links passed via WithLinks are
+// recorded on the span.
+func TestStartSpan_WithLinks(t *testing.T) {
+	tp, exporter, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+
+	// Create a root span to link to
+	_, rootSpan := tracer.Start(context.Background(), "root")
+	rootSpan.End()
+	rootTP := MarshalTraceParent(trace.ContextWithSpanContext(context.Background(), rootSpan.SpanContext()))
+	links := SpanLinksFromTraceParents(rootTP)
+
+	// Create a new span with links — no parent-child relationship, just links
+	_, linkedSpan := StartSpan(context.Background(), "linked",
+		WithLinks(links...),
+	)
+	linkedSpan.End()
+
+	// Verify the span was exported
+	spans := exporter.GetSpans()
+	assert.Len(t, spans, 2, "should have exported root + linked span")
+
+	// The linked span should have the link
+	linkedSpanData := spans[1]
+	assert.NotEmpty(t, linkedSpanData.Links, "linked span should have trace links")
+	assert.Equal(t, rootSpan.SpanContext().TraceID(), linkedSpanData.Links[0].SpanContext.TraceID(),
+		"link should reference root span's trace ID")
+}
+
+// TestStartSpan_WithLinks_Empty tests that no links are set when none provided.
+func TestStartSpan_WithLinks_Empty(t *testing.T) {
+	tp, exporter, cleanup := setupTestTracerProvider()
+	defer cleanup()
+
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(context.Background(), "test")
+	span.End()
+
+	_, linkedSpan := StartSpan(context.Background(), "no-links")
+	linkedSpan.End()
+
+	spans := exporter.GetSpans()
+	assert.Len(t, spans, 2)
+	assert.Empty(t, spans[1].Links, "span should have no links")
+}
+
+// --- WorkflowSpanAttributes tests ---
+
+// TestWorkflowSpanAttributes_AllFields tests attribute generation with all fields.
+func TestWorkflowSpanAttributes_AllFields(t *testing.T) {
+	userID := uint(42)
+	attrs := WorkflowSpanAttributes("req-1", "upload", &userID, "QmHash123")
+
+	assert.Len(t, attrs, 4, "should produce 4 attributes")
+	// Verify keys
+	keys := make(map[string]bool, len(attrs))
+	for _, a := range attrs {
+		keys[string(a.Key)] = true
+	}
+	assert.True(t, keys["workflow.id"])
+	assert.True(t, keys["workflow.name"])
+	assert.True(t, keys["workflow.user_id"])
+	assert.True(t, keys["workflow.hash"])
+}
+
+// TestWorkflowSpanAttributes_NilUser tests nil user ID is omitted.
+func TestWorkflowSpanAttributes_NilUser(t *testing.T) {
+	attrs := WorkflowSpanAttributes("req-1", "upload", nil, "QmHash")
+
+	assert.Len(t, attrs, 3, "should produce 3 attributes (no user_id)")
+	for _, a := range attrs {
+		assert.NotEqual(t, "workflow.user_id", string(a.Key), "should not include user_id")
+	}
+}
+
+// TestWorkflowSpanAttributes_EmptyHash tests empty hash is omitted.
+func TestWorkflowSpanAttributes_EmptyHash(t *testing.T) {
+	userID := uint(1)
+	attrs := WorkflowSpanAttributes("req-1", "upload", &userID, "")
+
+	assert.Len(t, attrs, 3, "should produce 3 attributes (no hash)")
+	for _, a := range attrs {
+		assert.NotEqual(t, "workflow.hash", string(a.Key), "should not include hash")
+	}
+}
+
+// TestWorkflowSpanAttributes_AllEmpty tests minimal attributes.
+func TestWorkflowSpanAttributes_AllEmpty(t *testing.T) {
+	attrs := WorkflowSpanAttributes("", "", nil, "")
+
+	// Should still produce id and name (even if empty), since the condition
+	// checks if either is non-empty — but both empty means no attrs.
+	// Actually the condition is OR, so if both are empty, no attrs are added.
+	assert.Empty(t, attrs, "should produce no attributes when both id and name are empty")
+}

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"sync"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	workflowMetrics "go.lumeweb.com/portal/service/internal/workflow"
 	workflowPkg "go.lumeweb.com/portal/service/internal/workflow"
 	"go.lumeweb.com/queryutil"
+
+	"go.opentelemetry.io/otel/trace"
 
 	kjson "github.com/knadh/koanf/parsers/json"
 	"github.com/knadh/koanf/providers/rawbytes"
@@ -105,6 +108,43 @@ func (w *WorkflowCoordinatorDefault) getRequestWithWorkflowMetadata(ctx context.
 	return req, metadata, nil
 }
 
+// workflowSpanOpts builds OTEL span options for a workflow step. It creates
+// trace links to the root workflow span and the previous step's span (if
+// different), plus sets workflow attributes for query-based grouping.
+//
+// This is the core of the trace linking strategy: each step gets its own
+// trace, linked to the root via span links. This works across process/node
+// boundaries since all data comes from serialized WorkflowMetadata.
+func workflowSpanOpts(req *models.Request, metadata WorkflowMetadata) []core.SpanOption {
+	var links []trace.Link
+	if metadata.RootTraceParent != "" {
+		links = append(links, core.SpanLinksFromTraceParents(metadata.RootTraceParent)...)
+	}
+	// Link to the previous step's trace too, but only if it's different
+	// from the root (first step's TraceParent == RootTraceParent).
+	if metadata.TraceParent != "" && metadata.TraceParent != metadata.RootTraceParent {
+		links = append(links, core.SpanLinksFromTraceParents(metadata.TraceParent)...)
+	}
+
+	opts := []core.SpanOption{
+		core.WithLinks(links...),
+	}
+	if metadata.WorkflowID != "" || metadata.WorkflowName != "" {
+		var hash string
+		if req != nil {
+			hash = req.Hash.String()
+		}
+		var userID *uint
+		if req != nil {
+			userID = req.UserID
+		}
+		opts = append(opts, core.WithAttributes(
+			core.WorkflowSpanAttributes(metadata.WorkflowID, metadata.WorkflowName, userID, hash)...,
+		))
+	}
+	return opts
+}
+
 // processWorkflowOptions handles workflow options and updates metadata accordingly
 // Returns the processed options and marshaled metadata
 func (w *WorkflowCoordinatorDefault) processWorkflowOptions(opts []core.WorkflowOption, metadata *WorkflowMetadata) (core.WorkflowOptions, []byte, error) {
@@ -143,13 +183,23 @@ func (w *WorkflowCoordinatorDefault) processWorkflowOptions(opts []core.Workflow
 
 // WorkflowMetadata stored in request.Metadata JSON field
 type WorkflowMetadata struct {
-	WorkflowName  string         `json:"workflow_name"`
-	CurrentStepID string         `json:"current_step_id"`
-	TotalSteps    int            `json:"total_steps"`
-	NextRequestID uint           `json:"next_request_id,omitempty"`
-	PrevRequestID uint           `json:"prev_request_id,omitempty"`
-	StartedAt     int64          `json:"started_at"`
-	Data          datatypes.JSON `json:"data"`
+	WorkflowName  string `json:"workflow_name"`
+	CurrentStepID string `json:"current_step_id"`
+	TotalSteps    int    `json:"total_steps"`
+	NextRequestID uint   `json:"next_request_id,omitempty"`
+	PrevRequestID uint   `json:"prev_request_id,omitempty"`
+	StartedAt     int64  `json:"started_at"`
+	// TraceParent is the span context of the most recent step. Each step
+	// updates it so the next step links to this step's trace.
+	TraceParent string `json:"trace_parent,omitempty"`
+	// RootTraceParent is the span context of the StartWorkflow call. It
+	// never changes across steps. Every step links to this span context
+	// to form a trace bundle visible in Tempo's linked traces view.
+	RootTraceParent string `json:"root_trace_parent,omitempty"`
+	// WorkflowID is the root request ID as a string. Set once at
+	// StartWorkflow, used as a span attribute for query-based grouping.
+	WorkflowID string         `json:"workflow_id,omitempty"`
+	Data       datatypes.JSON `json:"data"`
 }
 
 // WorkflowCoordinatorDefault implements the WorkflowCoordinator interface
@@ -329,14 +379,22 @@ func (w *WorkflowCoordinatorDefault) StartWorkflow(ctx context.Context, name str
 			// First step
 			firstStep := wf.Steps[0]
 
-			// Create and process metadata for first step
+			// Capture trace context for cross-boundary propagation
+			traceParent := core.MarshalTraceParent(ctx)
+
+			// Create and process metadata for first step.
+			// RootTraceParent is set here so it's persisted in the initial
+			// CreateRequest — WorkflowID (which needs createdReq.ID) is
+			// updated post-create as non-fatal observability data.
 			metadata := WorkflowMetadata{
-				WorkflowName:  wf.Name,
-				CurrentStepID: firstStep.ID,
-				TotalSteps:    len(wf.Steps),
-				StartedAt:     time.Now().Unix(),
-				PrevRequestID: 0, // Explicitly initialize
-				NextRequestID: 0, // Explicitly initialize
+				WorkflowName:    wf.Name,
+				CurrentStepID:   firstStep.ID,
+				TotalSteps:      len(wf.Steps),
+				StartedAt:       time.Now().Unix(),
+				PrevRequestID:   0, // Explicitly initialize
+				NextRequestID:   0, // Explicitly initialize
+				TraceParent:     traceParent,
+				RootTraceParent: traceParent,
 			}
 
 			processedOpts, wfMetadataJSON, err := w.processWorkflowOptions(opts, &metadata)
@@ -369,6 +427,20 @@ func (w *WorkflowCoordinatorDefault) StartWorkflow(ctx context.Context, name str
 			createdReq, err := w.requestSvc.CreateRequest(ctx, req, processedOpts.RequestData())
 			if err != nil {
 				return nil, err
+			}
+
+			// Now that we have the root request ID, set WorkflowID for
+			// span attribute-based querying. This is observability-only —
+			// failure is non-fatal since the workflow is already created.
+			metadata.WorkflowID = strconv.FormatUint(uint64(createdReq.ID), 10)
+			metadataJSON, err = json.Marshal(metadata)
+			if err != nil {
+				w.Logger().Warn("failed to marshal workflow trace metadata", zap.Error(err))
+			} else {
+				createdReq.Metadata = datatypes.JSON(metadataJSON)
+				if err := w.requestSvc.UpdateRequest(ctx, createdReq); err != nil {
+					w.Logger().Warn("failed to set workflow trace metadata", zap.Error(err))
+				}
 			}
 
 			// Record workflow started metric
@@ -434,17 +506,33 @@ func (w *WorkflowCoordinatorDefault) parseWorkflowMetadata(metadataJSON datatype
 }
 
 func (w *WorkflowCoordinatorDefault) CompleteWorkflowStep(ctx context.Context, requestID uint, opts ...core.WorkflowOption) error {
-	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.CompleteWorkflowStep")
+	// Fetch request and metadata once — used for span links/attributes
+	// and reused inside the MetricTrack closure to avoid a second DB round trip.
+	req, metadata, traceErr := w.getRequestWithWorkflowMetadata(ctx, requestID)
+
+	// Create span with links to root + previous step traces, plus workflow
+	// attributes for query-based grouping. Each step is its own trace.
+	var spanOpts []core.SpanOption
+	if traceErr == nil {
+		spanOpts = workflowSpanOpts(req, metadata)
+	}
+	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.CompleteWorkflowStep",
+		spanOpts...,
+	)
 	defer span.End()
 
 	return core.MetricTrack(
 		workflowMetrics.WorkflowDuration.WithLabelValues(workflowMetrics.LabelOperationComplete),
 		workflowMetrics.WorkflowsFailed.WithLabelValues(workflowMetrics.LabelWorkflowUnknown, workflowMetrics.LabelWorkflowUnknown, workflowMetrics.LabelFailureBehaviorFail),
 		func() error {
-			// Get current request and parse metadata
-			req, metadata, err := w.getRequestWithWorkflowMetadata(ctx, requestID)
-			if err != nil {
-				return err
+			if traceErr != nil {
+				// Outer fetch failed (possibly transient) before MetricTrack
+				// timing began; retry once so a transient DB error does not
+				// permanently fail this step.
+				req, metadata, traceErr = w.getRequestWithWorkflowMetadata(ctx, requestID)
+				if traceErr != nil {
+					return traceErr
+				}
 			}
 
 			nextMetadata := metadata
@@ -509,6 +597,9 @@ func (w *WorkflowCoordinatorDefault) CompleteWorkflowStep(ctx context.Context, r
 			// Update metadata with next request ID and workflow data
 			nextMetadata.PrevRequestID = requestID
 			nextMetadata.CurrentStepID = nextStep.ID
+			// Update trace parent so the next step's spans link to the
+			// same trace, even when dispatched via cron or across nodes.
+			nextMetadata.TraceParent = core.MarshalTraceParent(ctx)
 			// Validate and convert JSON data
 			if len(wfMetadataJSON) == 0 {
 				nextMetadata.Data = datatypes.JSON("{}") // Default to empty JSON object
@@ -574,23 +665,33 @@ func (w *WorkflowCoordinatorDefault) CompleteWorkflowStep(ctx context.Context, r
 }
 
 // FailWorkflowStep handles a step failure
-func (w *WorkflowCoordinatorDefault) FailWorkflowStep(ctx context.Context, requestID uint, err error) error {
-	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.FailWorkflowStep")
+func (w *WorkflowCoordinatorDefault) FailWorkflowStep(ctx context.Context, requestID uint, stepErr error) error {
+	// Fetch request+metadata for span links/attributes. Use defensive
+	// error handling since the caller may already be in an error path.
+	currentReq, traceMetadata, err := w.getRequestWithWorkflowMetadata(ctx, requestID)
+	var spanOpts []core.SpanOption
+	if err == nil {
+		spanOpts = workflowSpanOpts(currentReq, traceMetadata)
+	}
+
+	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.FailWorkflowStep",
+		spanOpts...,
+	)
 	defer span.End()
 
 	// Defensively handle nil error parameter
-	if err == nil {
-		err = ErrUnknownError
+	if stepErr == nil {
+		stepErr = ErrUnknownError
 	}
 
 	// Store the original error for later use
-	originalErr := err
+	originalErr := stepErr
 
 	// Get current request and parse metadata
-	currentReq, metadata, err := w.getRequestWithWorkflowMetadata(ctx, requestID)
 	if err != nil {
 		return err
 	}
+	metadata := traceMetadata
 
 	if w.isDisabled(metadata.WorkflowName) {
 		w.Logger().Warn("Attempted to fail step in disabled workflow",
@@ -753,14 +854,19 @@ func (w *WorkflowCoordinatorDefault) GetWorkflowStatus(ctx context.Context, requ
 
 // ExecuteWorkflowStep executes the operation handler for a workflow step
 func (w *WorkflowCoordinatorDefault) ExecuteWorkflowStep(ctx context.Context, requestID uint) error {
-	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.ExecuteWorkflowStep")
-	defer span.End()
-
 	// Get current request and parse metadata first to get workflow info for metrics
-	_, metadata, err := w.getRequestWithWorkflowMetadata(ctx, requestID)
+	req, metadata, err := w.getRequestWithWorkflowMetadata(ctx, requestID)
 	if err != nil {
 		return err
 	}
+
+	// Create span with links to root + previous step traces, plus workflow
+	// attributes for query-based grouping. Each step is its own trace, linked
+	// to the workflow root — the OTEL pattern for fan-out/async workflows.
+	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.ExecuteWorkflowStep",
+		workflowSpanOpts(req, metadata)...,
+	)
+	defer span.End()
 
 	if w.isDisabled(metadata.WorkflowName) {
 		w.Logger().Warn("Attempted to execute step in disabled workflow",
@@ -1016,11 +1122,15 @@ func (w *WorkflowCoordinatorDefault) ConvertRequestToWorkflow(ctx context.Contex
 	}
 
 	// Create initial metadata
+	traceParent := core.MarshalTraceParent(ctx)
 	metadata := WorkflowMetadata{
-		WorkflowName:  wf.Name,
-		CurrentStepID: wf.Steps[startStep].ID,
-		TotalSteps:    len(wf.Steps),
-		StartedAt:     time.Now().Unix(),
+		WorkflowName:    wf.Name,
+		CurrentStepID:   wf.Steps[startStep].ID,
+		TotalSteps:      len(wf.Steps),
+		StartedAt:       time.Now().Unix(),
+		TraceParent:     traceParent,
+		RootTraceParent: traceParent,
+		WorkflowID:      strconv.FormatUint(uint64(requestID), 10),
 	}
 
 	// Process workflow options and get metadata JSON
@@ -1441,14 +1551,18 @@ func (w *WorkflowCoordinatorDefault) getStepByID(wf *core.WorkflowDefinition, st
 
 // DispatchWorkflowStep runs the current step inline when marked foreground, or schedules it via cron otherwise
 func (w *WorkflowCoordinatorDefault) DispatchWorkflowStep(ctx context.Context, requestID uint) error {
-	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.DispatchWorkflowStep")
-	defer span.End()
-
 	// Get current request and parse metadata
-	_, metadata, err := w.getRequestWithWorkflowMetadata(ctx, requestID)
+	req, metadata, err := w.getRequestWithWorkflowMetadata(ctx, requestID)
 	if err != nil {
 		return err
 	}
+
+	// Create span with links to root + previous step traces, plus workflow
+	// attributes for query-based grouping. Each step is its own trace.
+	ctx, span := core.TraceMethod(ctx, "WorkflowCoordinatorDefault.DispatchWorkflowStep",
+		workflowSpanOpts(req, metadata)...,
+	)
+	defer span.End()
 
 	if w.isDisabled(metadata.WorkflowName) {
 		w.Logger().Warn("Attempted to dispatch step in disabled workflow",


### PR DESCRIPTION
## Summary

Add OTEL span links and workflow span attributes to enable grouping all workflow step traces together without forcing them into a single trace tree.

Each workflow step gets its **own trace**, linked to the root workflow span via `trace.WithLinks()`. This is the OTEL-designed pattern for fan-out/async workflows where steps may execute on different nodes via cron dispatch.

## How it works

**Span Links** — Each step trace links to:
- The root workflow span (`RootTraceParent` in metadata)
- The previous step's span (`TraceParent` in metadata, updated per step)

**Span Attributes** — Every workflow span gets:
- `workflow.id` — root request ID
- `workflow.name` — e.g. `"upload"`, `"pin"`
- `workflow.user_id` — the user who initiated it
- `workflow.hash` — storage hash being operated on

Query Tempo: `workflow.id="42"` returns every span across every trace for that workflow.

**Why not a single flat trace tree?**
- Individual steps can be sampled independently
- Each step's trace stays readable (not thousands of spans)
- Trace-level DAG visible in Tempo's linked traces view
- Works across process/node boundaries — all data is serialized in DB metadata

## Changes

- **`core/otel.go`** — Add `Links []trace.Link` to `SpanConfig`, `WithLinks` option, pass `trace.WithLinks` to `tracer.Start`
- **`core/trace_context.go`** — Add `ParseTraceParent`, `SpanLinksFromTraceParents`, `WorkflowSpanAttributes` helpers
- **`service/workflow.go`** — Add `RootTraceParent` + `WorkflowID` to `WorkflowMetadata`; add `workflowSpanOpts` helper; update `StartWorkflow`, `ConvertRequestToWorkflow`, `ExecuteWorkflowStep`, `CompleteWorkflowStep`, `DispatchWorkflowStep`, `FailWorkflowStep` to use span links; eliminate duplicate DB roundtrip in `CompleteWorkflowStep`
- **`core/trace_context_test.go`** — 22 tests covering round-trip, `ParseTraceParent`, `SpanLinksFromTraceParents`, `WithLinks`/`StartSpan` integration, `WorkflowSpanAttributes` edge cases

## Test plan

- [x] `go build ./core/... ./service/...` passes
- [x] `go test -count=1 ./core/...` passes (22 tests)
- [x] `go test -count=1 ./service/internal/workflow/...` passes
- [x] `gofmt` clean on all modified files