### PR TITLE
feat: enable h2c (unencrypted HTTP/2) on portal HTTP server

### DIFF
--- a/service/http.go
+++ b/service/http.go
@@ -89,7 +89,13 @@ type HTTPServiceDefault struct {
 func NewHTTPService() (core.Service, []core.ContextBuilderOption, error) {
 	_http := &HTTPServiceDefault{}
 
-	srv := &http.Server{}
+	protocols := &http.Protocols{}
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+
+	srv := &http.Server{
+		Protocols: protocols,
+	}
 
 	opts := core.ContextOptions(
 		core.ContextWithStartupFunc(func(ctx core.Context) error {


### PR DESCRIPTION
## Summary
- Configure `http.Server` with `Protocols` allowing both HTTP/1.1 and unencrypted HTTP/2 (h2c)
- Enables reverse proxies (Caddy) to use h2c upstream via `transport http { versions h2c }` or `h2c://` scheme
- HTTP/2 multiplexing means all requests to the same upstream share a single TCP connection, eliminating dial storms and connection pool churn

## Details
Go 1.26 provides native h2c support via `http.Protocols` — no `golang.org/x/net/http2/h2c` wrapper needed. The server accepts both HTTP/1.1 and h2c on the same port, so existing HTTP/1.1 clients are unaffected.