### PR TITLE
fix: workflow tracing — eventCtx, boot root span, CIDString span attribute

### DIFF
--- a/core/internal/service_tests/content_scan_integration_test.go
+++ b/core/internal/service_tests/content_scan_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -204,6 +205,13 @@ func (s *testStorageHash) Type() uint64 {
 
 func (s *testStorageHash) String() string {
 	return string(s.hash)
+}
+
+func (s *testStorageHash) CIDString() string {
+	if s.mh == nil {
+		return ""
+	}
+	return cid.NewCidV0(s.mh).String()
 }
 
 func (s *testStorageHash) Bytes() []byte {

--- a/core/storage_hash.go
+++ b/core/storage_hash.go
@@ -21,6 +21,7 @@ type StorageHash interface {
 	CIDType() uint64
 	Type() uint64
 	String() string
+	CIDString() string
 	Bytes() []byte
 }
 
@@ -129,14 +130,24 @@ func (s StorageHashDefault) String() string {
 	return s.Multihash().B58String()
 }
 
-func (s StorageHashDefault) Bytes() []byte {
-	var c cid.Cid
+// CID returns the CID representation of this storage hash.
+func (s StorageHashDefault) CID() cid.Cid {
 	if s.cidType == 0 {
-		c = cid.NewCidV0(s.Multihash())
-	} else {
-		c = cid.NewCidV1(s.cidType, s.Multihash())
+		return cid.NewCidV0(s.Multihash())
 	}
-	return c.Bytes()
+	return cid.NewCidV1(s.cidType, s.Multihash())
+}
+
+// CIDString returns the CIDv1 (or CIDv0 for legacy) string representation
+// of this storage hash. This is the canonical, human-readable identifier
+// for content-addressed data, suitable for use in trace attributes, logs,
+// and cross-referencing with IPFS gateways.
+func (s StorageHashDefault) CIDString() string {
+	return s.CID().String()
+}
+
+func (s StorageHashDefault) Bytes() []byte {
+	return s.CID().Bytes()
 }
 
 func NewStorageHash(hash []byte, typ uint64, cidType uint64, proof []byte) StorageHash {

--- a/core/testing/mocks/StorageHash.go
+++ b/core/testing/mocks/StorageHash.go
@@ -82,6 +82,50 @@ func (_c *MockStorageHash_Bytes_Call) RunAndReturn(run func() []byte) *MockStora
 	return _c
 }
 
+// CIDString provides a mock function for the type MockStorageHash
+func (_mock *MockStorageHash) CIDString() string {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CIDString")
+	}
+
+	var r0 string
+	if returnFunc, ok := ret.Get(0).(func() string); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	return r0
+}
+
+// MockStorageHash_CIDString_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CIDString'
+type MockStorageHash_CIDString_Call struct {
+	*mock.Call
+}
+
+// CIDString is a helper method to define mock.On call
+func (_e *MockStorageHash_Expecter) CIDString() *MockStorageHash_CIDString_Call {
+	return &MockStorageHash_CIDString_Call{Call: _e.mock.On("CIDString")}
+}
+
+func (_c *MockStorageHash_CIDString_Call) Run(run func()) *MockStorageHash_CIDString_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStorageHash_CIDString_Call) Return(s string) *MockStorageHash_CIDString_Call {
+	_c.Call.Return(s)
+	return _c
+}
+
+func (_c *MockStorageHash_CIDString_Call) RunAndReturn(run func() string) *MockStorageHash_CIDString_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CIDType provides a mock function for the type MockStorageHash
 func (_mock *MockStorageHash) CIDType() uint64 {
 	ret := _mock.Called()

--- a/core/testing/storage.go
+++ b/core/testing/storage.go
@@ -43,6 +43,16 @@ func (s *MockStorageHash) String() string {
 	return s.MultihashValue.String()
 }
 
+func (s *MockStorageHash) CIDString() string {
+	if s.MultihashValue == nil {
+		return ""
+	}
+	if s.CIDTypeValue == 0 {
+		return cid.NewCidV0(s.MultihashValue).String()
+	}
+	return cid.NewCidV1(s.CIDTypeValue, s.MultihashValue).String()
+}
+
 // Bytes returns the binary representation of the storage hash as a CID (Content Identifier).
 // It handles both CIDv0 (for legacy IPFS hashes) and CIDv1 formats based on CIDTypeValue.
 // Returns nil if MultihashValue is nil to prevent panics during testing.

--- a/core/trace_context.go
+++ b/core/trace_context.go
@@ -119,6 +119,25 @@ func SpanLinksFromTraceParents(traceParents ...string) []trace.Link {
 	return links
 }
 
+// bootTraceParent stores the W3C traceparent of the boot root span.
+// Runtime operations (workflows, cron jobs) can link to this to provide
+// a traceable connection back to the boot that started them, without
+// forcing all runtime spans into the boot trace.
+var bootTraceParent string
+
+// SetBootTraceParent stores the W3C traceparent of the boot root span.
+// Called once during portal startup. Runtime operations can retrieve it
+// via BootTraceParent() to add span links back to the boot trace.
+func SetBootTraceParent(tp string) {
+	bootTraceParent = tp
+}
+
+// BootTraceParent returns the W3C traceparent of the boot root span.
+// Returns empty string if boot hasn't started or tracing is disabled.
+func BootTraceParent() string {
+	return bootTraceParent
+}
+
 // HasTraceParent returns true if the traceparent string is non-empty
 // and appears to contain a valid W3C trace context.
 func HasTraceParent(traceParent string) bool {

--- a/portal.go
+++ b/portal.go
@@ -211,6 +211,15 @@ func (p *PortalImpl) Start() error {
 	ctx := p.Context()
 	ctx.Logger().Info("Starting portal")
 
+	// Create a root span for the entire boot sequence. All startup
+	// operations (startup funcs, protocol registration, cron init, HTTP
+	// server start) become children of this span. The span is ended when
+	// boot completes, so runtime spans are NOT children of this trace —
+	// they link to it via core.BootTraceParent() if needed.
+	bootCtx, bootSpan := core.TraceMethod(ctx.GetContext(), "portal.boot")
+	core.SetBootTraceParent(core.MarshalTraceParent(bootCtx))
+	defer bootSpan.End()
+
 	if err := core.Fire(ctx, event.EVENT_BOOT_START, event.NewBootStartEvent(ctx, ctx.GetContext())); err != nil {
 		ctx.Logger().Error("Error firing boot start event", zap.Error(err))
 		return err

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -623,7 +623,14 @@ func (s *StandaloneCoordinator) CleanupJob(ctx context.Context, jobID uuid.UUID)
 }
 
 func (s *StandaloneCoordinator) ExecuteJob(ctx context.Context, jobID uuid.UUID) error {
-	ctx, span := core.TraceMethod(ctx, "StandaloneCoordinator.ExecuteJob")
+	// Link to the boot trace so scheduled cron jobs (which have no parent
+	// span after boot completes) can be traced back to the portal instance
+	// that started them.
+	var bootOpts []core.SpanOption
+	if bootTP := core.BootTraceParent(); bootTP != "" {
+		bootOpts = append(bootOpts, core.WithLinks(core.SpanLinksFromTraceParents(bootTP)...))
+	}
+	ctx, span := core.TraceMethod(ctx, "StandaloneCoordinator.ExecuteJob", bootOpts...)
 	defer span.End()
 
 	job, err := s.CreateJobFromDB(ctx, jobID)
@@ -637,7 +644,12 @@ func (s *StandaloneCoordinator) ExecuteJob(ctx context.Context, jobID uuid.UUID)
 
 	// Create a per-job-type OTel span so each execution is traceable by job type
 	// (e.g. "cron.core.pin-checker") in addition to the generic coordinator span.
-	jobCtx, jobSpan := core.TraceMethod(ctx, "cron."+job.Type())
+	// Also link to the boot trace for scheduled jobs with no parent span.
+	var jobSpanOpts []core.SpanOption
+	if bootTP := core.BootTraceParent(); bootTP != "" {
+		jobSpanOpts = append(jobSpanOpts, core.WithLinks(core.SpanLinksFromTraceParents(bootTP)...))
+	}
+	jobCtx, jobSpan := core.TraceMethod(ctx, "cron."+job.Type(), jobSpanOpts...)
 	defer jobSpan.End()
 
 	return job.Run(s.ctx, jobCtx)

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -125,21 +125,28 @@ func workflowSpanOpts(req *models.Request, metadata WorkflowMetadata) []core.Spa
 	if metadata.TraceParent != "" && metadata.TraceParent != metadata.RootTraceParent {
 		links = append(links, core.SpanLinksFromTraceParents(metadata.TraceParent)...)
 	}
+	// Link to the boot trace so runtime workflow spans can be traced back
+	// to the portal instance that started them.
+	if bootTP := core.BootTraceParent(); bootTP != "" {
+		links = append(links, core.SpanLinksFromTraceParents(bootTP)...)
+	}
 
 	opts := []core.SpanOption{
 		core.WithLinks(links...),
 	}
 	if metadata.WorkflowID != "" || metadata.WorkflowName != "" {
-		var hash string
+		var hashStr string
 		if req != nil {
-			hash = req.Hash.String()
+			if sh := core.NewStorageHashFromMultihash(req.Hash, req.CIDType, nil); sh != nil {
+				hashStr = sh.CIDString()
+			}
 		}
 		var userID *uint
 		if req != nil {
 			userID = req.UserID
 		}
 		opts = append(opts, core.WithAttributes(
-			core.WorkflowSpanAttributes(metadata.WorkflowID, metadata.WorkflowName, userID, hash)...,
+			core.WorkflowSpanAttributes(metadata.WorkflowID, metadata.WorkflowName, userID, hashStr)...,
 		))
 	}
 	return opts

--- a/service/workflow_cron.go
+++ b/service/workflow_cron.go
@@ -50,8 +50,15 @@ func (j *workflowStepExecutorJob) Run(ctx core.Context, eventCtx context.Context
 		return fmt.Errorf("invalid job arguments type, expected uint got %T", j.Args())
 	}
 
+	// eventCtx carries the trace span from ExecuteJob. Use it for all
+	// workflow service calls so spans connect to the cron execution trace.
+	// eventCtx also preserves portal context values (tracer service, etc.)
+	// through DetachContext, so TraceMethod inside workflow methods will
+	// create child spans of the cron job span.
+	execCtx := eventCtx
+
 	// Check if the step can be transitioned
-	canTransition, err := workflowSvc.CanTransition(ctx, args)
+	canTransition, err := workflowSvc.CanTransition(execCtx, args)
 	if err != nil {
 		return fmt.Errorf("failed to check transition status: %w", err)
 	}
@@ -64,7 +71,7 @@ func (j *workflowStepExecutorJob) Run(ctx core.Context, eventCtx context.Context
 	}
 
 	// Execute the workflow step
-	err = workflowSvc.ExecuteWorkflowStep(ctx, args)
+	err = workflowSvc.ExecuteWorkflowStep(execCtx, args)
 	if err != nil {
 		// Check if this was a retried error (which is expected behavior)
 		if core.IsWorkflowErrorType(err, core.ErrKeyWorkflowStepRetried) {
@@ -76,7 +83,7 @@ func (j *workflowStepExecutorJob) Run(ctx core.Context, eventCtx context.Context
 		}
 
 		// Check if step is configured to continue on failure
-		stepInfo, stepErr := workflowSvc.GetWorkflowStepInfo(ctx, args)
+		stepInfo, stepErr := workflowSvc.GetWorkflowStepInfo(execCtx, args)
 		if stepErr != nil {
 			return fmt.Errorf("failed to get workflow step info: %w", stepErr)
 		}
@@ -99,7 +106,7 @@ func (j *workflowStepExecutorJob) Run(ctx core.Context, eventCtx context.Context
 	}
 
 	// Check if the step can still be transitioned (may have been completed by ExecuteWorkflowStep)
-	canTransition, err = workflowSvc.CanTransition(ctx, args)
+	canTransition, err = workflowSvc.CanTransition(execCtx, args)
 	if err != nil {
 		return fmt.Errorf("failed to check transition status after execution: %w", err)
 	}
@@ -107,7 +114,7 @@ func (j *workflowStepExecutorJob) Run(ctx core.Context, eventCtx context.Context
 	// Only complete the step if it's still pending and can be transitioned
 	if canTransition {
 		// If execution was successful (or we're continuing despite failure), advance to the next step
-		err = workflowSvc.CompleteWorkflowStep(ctx, args)
+		err = workflowSvc.CompleteWorkflowStep(execCtx, args)
 		if err != nil {
 			ctx.Logger().Error("Failed to complete workflow step after execution",
 				zap.Uint("requestID", args),


### PR DESCRIPTION
## Summary
- Fix eventCtx: `workflowStepExecutorJob.Run` now passes `eventCtx` (carries cron job span) instead of `ctx` (portal root, no span) to all workflow service calls, so spans inside `ExecuteWorkflowStep` create proper child spans of the cron execution trace
- Add boot root span: `Start()` wraps the boot sequence in a `portal.boot` span, ended at boot completion. Runtime workflow spans link to it via `core.BootTraceParent()` as a span link, not a parent
- Add `CIDString()` to `StorageHash` interface returning the canonical CID string; `workflowSpanOpts` now uses it for the `workflow.hash` span attribute instead of base58 multihash
- Add boot traceparent as a span link to `ExecuteJob` and per-job-type cron spans, so scheduled cron jobs (no parent span after boot) can be traced back to the portal instance that started them