### PR TITLE
feat(otel): configurable BSP batch timeout and export batch size

### DIFF
--- a/config/observability.go
+++ b/config/observability.go
@@ -82,9 +82,11 @@ type ObservabilityConfig struct {
 }
 
 type TracingConfig struct {
-	Enabled      bool    `config:"enabled"`
-	Sampler      string  `config:"sampler"`       // always, never, traceidratio
-	SamplerRatio float64 `config:"sampler_ratio"` // 0.0-1.0, only for traceidratio
+	Enabled            bool    `config:"enabled"`
+	Sampler            string  `config:"sampler"`               // always, never, traceidratio
+	SamplerRatio       float64 `config:"sampler_ratio"`         // 0.0-1.0, only for traceidratio
+	BatchTimeout       uint    `config:"batch_timeout"`         // seconds between BSP flushes
+	MaxExportBatchSize uint    `config:"max_export_batch_size"` // max spans per export batch
 }
 
 func (t TracingConfig) Schema() z.ZogSchema {
@@ -95,6 +97,10 @@ func (t TracingConfig) Schema() z.ZogSchema {
 		"SamplerRatio": z.Float64().
 			GTE(0.0, z.Message("sampler_ratio must be >= 0.0")).
 			LTE(1.0, z.Message("sampler_ratio must be <= 1.0")),
+		"BatchTimeout": z.Uint().
+			GT(0, z.Message("batch_timeout must be greater than 0")),
+		"MaxExportBatchSize": z.Uint().
+			GT(0, z.Message("max_export_batch_size must be greater than 0")),
 	}).TestFunc(func(data any, ctx z.Ctx) bool {
 		c, ok := data.(*TracingConfig)
 		if !ok {
@@ -113,16 +119,18 @@ func (t TracingConfig) Schema() z.ZogSchema {
 
 func (t TracingConfig) Defaults() map[string]any {
 	return map[string]any{
-		"Enabled":      true,
-		"Sampler":      SamplerAlways,
-		"SamplerRatio": 1.0,
+		"Enabled":            true,
+		"Sampler":            SamplerAlways,
+		"SamplerRatio":       1.0,
+		"BatchTimeout":       uint(5),
+		"MaxExportBatchSize": uint(512),
 	}
 }
 
 type MetricsConfig struct {
-	Enabled         bool   `config:"enabled"`
-	Path            string `config:"path"`
-	RefreshInterval uint   `config:"refresh_interval"`
+	Enabled         bool                   `config:"enabled"`
+	Path            string                 `config:"path"`
+	RefreshInterval uint                   `config:"refresh_interval"`
 	BasicAuth       MetricsBasicAuthConfig `config:"basic_auth"`
 }
 

--- a/core/otel_setup.go
+++ b/core/otel_setup.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"time"
 
 	"go.lumeweb.com/portal/build"
 	"go.lumeweb.com/portal/config"
@@ -113,7 +114,10 @@ func ContextWithTelemetry() ContextBuilderOption {
 
 				tp = sdktrace.NewTracerProvider(
 					sdktrace.WithResource(res),
-					sdktrace.WithBatcher(traceExporter),
+					sdktrace.WithBatcher(traceExporter,
+						sdktrace.WithBatchTimeout(time.Duration(cfg.Tracing.BatchTimeout)*time.Second),
+						sdktrace.WithMaxExportBatchSize(int(cfg.Tracing.MaxExportBatchSize)),
+					),
 					sdktrace.WithSampler(buildSampler(cfg.Tracing)),
 				)
 				otel.SetTracerProvider(tp)


### PR DESCRIPTION
## Problem

Root spans created by `core.TraceMethod` are missing from Tempo — 19 out of 20 traces on `portal` show `<root span not yet received>`. Only libp2p root spans survive.

## Root Cause

The OTel BatchSpanProcessor (BSP) defaults to a 5s flush interval. Root spans are ended last (via `defer span.End()`) because they wrap the entire function. For traces longer than 5s, child spans flush in an earlier batch than the root span. Alloy's tail sampling `decision_wait: 10s` can elapse before the root span arrives, so Alloy forwards child spans to Tempo but drops the root.

## Fix

Make the BSP `BatchTimeout` and `MaxExportBatchSize` configurable via `observability.tracing` config:

```yaml
observability:
  tracing:
    batch_timeout: 1        # seconds (default: 5)
    max_export_batch_size: 256  # default: 512
```

Defaults preserve prior behavior (5s / 512). Setting `batch_timeout: 1` flushes root spans fast enough to arrive within Alloy's 10s decision window.

## Changes

- `config/observability.go`: Add `BatchTimeout` and `MaxExportBatchSize` fields to `TracingConfig` with schema validation and defaults
- `core/otel_setup.go`: Pass configured values to `sdktrace.WithBatcher()`