### PR TITLE
fix(cron): force root span at ExecuteJob entry point

### DIFF
--- a/core/otel.go
+++ b/core/otel.go
@@ -170,6 +170,7 @@ type SpanConfig struct {
 	Attributes []attribute.KeyValue
 	Kind       trace.SpanKind
 	Links      []trace.Link
+	NewRoot    bool
 }
 
 // SpanOption is a function that configures a SpanConfig
@@ -197,6 +198,16 @@ func WithSpanKind(kind trace.SpanKind) SpanOption {
 	}
 }
 
+// WithNewRoot forces the span to start a new root trace, ignoring any
+// parent span context in ctx. Use for entry points (cron jobs, event
+// handlers) that have no meaningful parent but should have their own
+// trace root.
+func WithNewRoot() SpanOption {
+	return func(c *SpanConfig) {
+		c.NewRoot = true
+	}
+}
+
 // StartSpan creates and starts a new span with the given configuration
 func StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Context, trace.Span) {
 	if ctx == nil {
@@ -217,6 +228,9 @@ func StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Co
 	spanOpts := []trace.SpanStartOption{
 		trace.WithAttributes(config.Attributes...),
 		trace.WithSpanKind(config.Kind),
+	}
+	if config.NewRoot {
+		spanOpts = append(spanOpts, trace.WithNewRoot())
 	}
 	if len(config.Links) > 0 {
 		spanOpts = append(spanOpts, trace.WithLinks(config.Links...))

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -16,6 +16,7 @@ import (
 	"go.lumeweb.com/portal/db"
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/db/types"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
@@ -350,14 +351,14 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 		if strings.HasPrefix(errStr, panicPrefix) {
 			// Extract the panic value
 			panicValue := strings.TrimPrefix(errStr, panicPrefix)
-			
+
 			// Capture structured panic info using the panic value
 			panicInfo := captureStructuredPanic(panicValue)
-			
+
 			// Add structured panic info to the error log
 			fields = append(fields, buildPanicFields(panicInfo)...)
 		}
-		
+
 		s.logger.Error("Job execution failed", fields...)
 
 		s.failureMu.Lock()
@@ -378,14 +379,14 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 	afterJobRunsWithPanic := func(jobID uuid.UUID, jobName string, recoverData any) {
 		// Capture structured panic info
 		panicInfo := captureStructuredPanic(recoverData)
-		
+
 		// Build zap fields including job info and panic details
 		fields := []zap.Field{
 			zap.String("jobID", jobID.String()),
 			zap.String("jobName", jobName),
 		}
 		fields = append(fields, buildPanicFields(panicInfo)...)
-		
+
 		s.logger.Error("Task panicked", fields...)
 
 		s.failureMu.Lock()
@@ -623,13 +624,16 @@ func (s *StandaloneCoordinator) CleanupJob(ctx context.Context, jobID uuid.UUID)
 }
 
 func (s *StandaloneCoordinator) ExecuteJob(ctx context.Context, jobID uuid.UUID) error {
-	// Link to the boot trace so scheduled cron jobs (which have no parent
-	// span after boot completes) can be traced back to the portal instance
-	// that started them.
+	// Start a new root trace for each cron job execution. Cron jobs are
+	// triggered by the scheduler (no HTTP parent), so they need their own
+	// root span to act as the trace root for all downstream work. The boot
+	// traceparent is linked (not parented) so the trace can be correlated
+	// back to the portal instance that started the scheduler.
 	var bootOpts []core.SpanOption
 	if bootTP := core.BootTraceParent(); bootTP != "" {
 		bootOpts = append(bootOpts, core.WithLinks(core.SpanLinksFromTraceParents(bootTP)...))
 	}
+	bootOpts = append(bootOpts, core.WithNewRoot(), core.WithSpanKind(trace.SpanKindServer))
 	ctx, span := core.TraceMethod(ctx, "StandaloneCoordinator.ExecuteJob", bootOpts...)
 	defer span.End()
 
@@ -644,12 +648,9 @@ func (s *StandaloneCoordinator) ExecuteJob(ctx context.Context, jobID uuid.UUID)
 
 	// Create a per-job-type OTel span so each execution is traceable by job type
 	// (e.g. "cron.core.pin-checker") in addition to the generic coordinator span.
-	// Also link to the boot trace for scheduled jobs with no parent span.
-	var jobSpanOpts []core.SpanOption
-	if bootTP := core.BootTraceParent(); bootTP != "" {
-		jobSpanOpts = append(jobSpanOpts, core.WithLinks(core.SpanLinksFromTraceParents(bootTP)...))
-	}
-	jobCtx, jobSpan := core.TraceMethod(ctx, "cron."+job.Type(), jobSpanOpts...)
+	// This is a child of the ExecuteJob root span, so all job work stays in
+	// the same trace.
+	jobCtx, jobSpan := core.TraceMethod(ctx, "cron."+job.Type())
 	defer jobSpan.End()
 
 	return job.Run(s.ctx, jobCtx)
@@ -700,7 +701,7 @@ func buildPanicFields(panicInfo *PanicInfo) []zap.Field {
 		zap.Any("panicValue", panicInfo.RecoverVal),
 		zap.String("panicMessage", panicInfo.Message),
 	}
-	
+
 	// Add stack frames if available
 	if len(panicInfo.Stack) > 0 {
 		for i, frame := range panicInfo.Stack {
@@ -710,12 +711,12 @@ func buildPanicFields(panicInfo *PanicInfo) []zap.Field {
 			fields = append(fields,
 				zap.String(fmt.Sprintf("frame%d", i), fmt.Sprintf("%s:%d (%s)", frame.File, frame.Line, frame.Function)))
 		}
-		
+
 		if len(panicInfo.Stack) > 5 {
 			fields = append(fields, zap.Int("additionalFrames", len(panicInfo.Stack)-5))
 		}
 	}
-	
+
 	return fields
 }
 
@@ -736,17 +737,17 @@ func captureStructuredPanic(recoverData any) *PanicInfo {
 	// Capture up to 64 stack frames
 	pcs := make([]uintptr, 64)
 	n := runtime.Callers(2, pcs) // skip 2 frames: runtime.Callers and this function
-	
+
 	if n == 0 {
 		return info
 	}
 
 	frames := runtime.CallersFrames(pcs[:n])
-	
+
 	// Collect non-internal frames
 	for {
 		frame, more := frames.Next()
-		
+
 		// Skip internal frames
 		if !isInternalPath(frame.Function) {
 			info.Stack = append(info.Stack, StackFrame{
@@ -755,7 +756,7 @@ func captureStructuredPanic(recoverData any) *PanicInfo {
 				Line:     frame.Line,
 			})
 		}
-		
+
 		if !more {
 			break
 		}


### PR DESCRIPTION
## Problem
Cron jobs triggered by the scheduler had no parent trace context. The `ExecuteJob` span was created as a child of a contextless scheduler ctx, causing downstream workflow/upload spans to appear as disconnected orphans in Tempo.

## Fix
- Add `WithNewRoot()` option and `NewRoot` field to `core.SpanConfig`
- Apply `WithNewRoot()` + `SpanKindServer` at `ExecuteJob` to force a clean root span for every cron job execution
- Remove redundant boot traceparent links from the per-job-type span (it's now a child of the ExecuteJob root, not a separate trace)
- Keep boot traceparent as a link on the ExecuteJob root for correlation back to the portal instance

## Result
Every cron job now starts its own trace. All downstream spans (`cron.<job-type>`, `workflowStepExecutorJob.Run`, `ExecuteWorkflowStep`, `ExecuteRequest`, upload handlers, etc.) become children of this root span.

Build: ✅ | Vet: ✅ | Tests: ✅ | gofmt: ✅