### PR TITLE
fix(otel): defer exporter attachment so boot spans are captured

### DIFF
--- a/core/deferred_processor.go
+++ b/core/deferred_processor.go
@@ -1,0 +1,102 @@
+package core
+
+import (
+	"context"
+	"sync"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// DeferredSpanProcessor is a SpanProcessor that buffers spans until a real
+// exporter is attached via SetExporter. This allows spans created during early
+// boot (before OTel config is wired) to be captured on a real TracerProvider
+// and exported once the OTLP exporter becomes available.
+//
+// Spans that end before SetExporter is called are buffered. When SetExporter
+// is called, the buffered spans are flushed to the real processor, and all
+// subsequent spans go directly through it.
+type DeferredSpanProcessor struct {
+	mu       sync.Mutex
+	real     sdktrace.SpanProcessor
+	buffered []sdktrace.ReadOnlySpan
+	shutdown bool
+}
+
+// NewDeferredSpanProcessor creates a DeferredSpanProcessor with no exporter
+// attached. Spans will be buffered until SetExporter is called.
+func NewDeferredSpanProcessor() *DeferredSpanProcessor {
+	return &DeferredSpanProcessor{}
+}
+
+// SetExporter attaches a real SpanExporter by creating a BatchSpanProcessor
+// and flushing any buffered spans to it. After this call, all new and
+// buffered spans are exported through the real processor.
+func (d *DeferredSpanProcessor) SetExporter(exp sdktrace.SpanExporter, opts ...sdktrace.BatchSpanProcessorOption) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.shutdown {
+		return
+	}
+
+	d.real = sdktrace.NewBatchSpanProcessor(exp, opts...)
+
+	// Flush buffered spans
+	for _, span := range d.buffered {
+		d.real.OnEnd(span)
+	}
+	d.buffered = nil
+}
+
+// OnStart implements SpanProcessor.OnStart.
+func (d *DeferredSpanProcessor) OnStart(parent context.Context, s sdktrace.ReadWriteSpan) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.real != nil {
+		d.real.OnStart(parent, s)
+	}
+	// If no real processor yet, nothing to do — the span is live and
+	// will be buffered on OnEnd.
+}
+
+// OnEnd implements SpanProcessor.OnEnd.
+func (d *DeferredSpanProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.shutdown {
+		return
+	}
+
+	if d.real != nil {
+		d.real.OnEnd(s)
+	} else {
+		d.buffered = append(d.buffered, s)
+	}
+}
+
+// Shutdown implements SpanProcessor.Shutdown.
+func (d *DeferredSpanProcessor) Shutdown(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.shutdown = true
+	d.buffered = nil
+
+	if d.real != nil {
+		return d.real.Shutdown(ctx)
+	}
+	return nil
+}
+
+// ForceFlush implements SpanProcessor.ForceFlush.
+func (d *DeferredSpanProcessor) ForceFlush(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.real != nil {
+		return d.real.ForceFlush(ctx)
+	}
+	return nil
+}

--- a/core/deferred_processor_test.go
+++ b/core/deferred_processor_test.go
@@ -1,0 +1,155 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestDeferredSpanProcessor_BuffersSpansBeforeExporter(t *testing.T) {
+	deferred := NewDeferredSpanProcessor()
+	exporter := tracetest.NewInMemoryExporter()
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(deferred),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	defer tp.Shutdown(context.Background())
+
+	tracer := tp.Tracer("test")
+
+	// Create and end a span before exporter is attached — should be buffered
+	_, span := tracer.Start(context.Background(), "pre-export-span")
+	span.End()
+
+	// Spans should be buffered, not exported
+	assert.Equal(t, 0, len(exporter.GetSpans()))
+
+	// Attach exporter — buffered spans should flush
+	deferred.SetExporter(exporter)
+	deferred.ForceFlush(context.Background())
+	assert.Equal(t, 1, len(exporter.GetSpans()))
+}
+
+func TestDeferredSpanProcessor_ForwardsAfterExporter(t *testing.T) {
+	deferred := NewDeferredSpanProcessor()
+	exporter := tracetest.NewInMemoryExporter()
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(deferred),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	defer tp.Shutdown(context.Background())
+
+	tracer := tp.Tracer("test")
+
+	// Attach exporter first
+	deferred.SetExporter(exporter)
+
+	// Now create and end a span — should go directly through
+	_, span := tracer.Start(context.Background(), "post-export-span")
+	span.End()
+
+	// Force flush to ensure spans are exported
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	assert.Equal(t, 1, len(exporter.GetSpans()))
+}
+
+func TestDeferredSpanProcessor_ShutdownNoExporter(t *testing.T) {
+	deferred := NewDeferredSpanProcessor()
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(deferred),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	tracer := tp.Tracer("test")
+
+	// Create and end a span with no exporter attached
+	_, span := tracer.Start(context.Background(), "shutdown-span")
+	span.End()
+
+	// Shutdown should not panic or error
+	err := tp.Shutdown(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestDeferredSpanProcessor_SetExporterIdempotent(t *testing.T) {
+	deferred := NewDeferredSpanProcessor()
+	exporter1 := tracetest.NewInMemoryExporter()
+	exporter2 := tracetest.NewInMemoryExporter()
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(deferred),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	defer tp.Shutdown(context.Background())
+
+	tracer := tp.Tracer("test")
+
+	// Create a span before any exporter
+	_, span1 := tracer.Start(context.Background(), "span1")
+	span1.End()
+
+	// Attach first exporter
+	deferred.SetExporter(exporter1)
+	deferred.ForceFlush(context.Background())
+	assert.Equal(t, 1, len(exporter1.GetSpans()))
+
+	// Create another span
+	_, span2 := tracer.Start(context.Background(), "span2")
+	span2.End()
+
+	// Attach second exporter — should NOT re-send span1, only span2 to
+	// exporter2 if SetExporter replaces the processor. But SetExporter creates
+	// a new BSP, so span1 was already flushed to exporter1. span2 should go to
+	// exporter2 via the new BSP.
+	deferred.SetExporter(exporter2)
+
+	// span1 should only be in exporter1 (already flushed)
+	assert.Equal(t, 1, len(exporter1.GetSpans()))
+}
+
+func TestDeferredSpanProcessor_ConcurrentAccess(t *testing.T) {
+	deferred := NewDeferredSpanProcessor()
+	exporter := tracetest.NewInMemoryExporter()
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(deferred),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	defer tp.Shutdown(context.Background())
+
+	tracer := tp.Tracer("test")
+
+	var wg sync.WaitGroup
+	// Spawn multiple goroutines creating and ending spans concurrently
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, span := tracer.Start(context.Background(), "concurrent-span")
+			span.End()
+		}()
+	}
+
+	// Attach exporter while spans are being created
+	time.Sleep(10 * time.Millisecond)
+	deferred.SetExporter(exporter)
+
+	wg.Wait()
+
+	// All spans should eventually be accounted for (either buffered-then-flushed
+	// or sent directly through the real processor)
+	// We need to force flush to ensure all spans are exported
+	tp.ForceFlush(context.Background())
+
+	spans := exporter.GetSpans()
+	assert.GreaterOrEqual(t, len(spans), 1, "should have exported at least some spans")
+}

--- a/core/otel_setup.go
+++ b/core/otel_setup.go
@@ -87,6 +87,34 @@ func buildSampler(cfg config.TracingConfig) sdktrace.Sampler {
 
 func ContextWithTelemetry() ContextBuilderOption {
 	return func(ctx Context) (Context, error) {
+		// Create a TracerProvider with a DeferredSpanProcessor immediately so
+		// that spans created during early boot (e.g. portal.boot) are captured
+		// on a real provider. The OTLP exporter is attached later in the
+		// startup func once config is available; until then, ended spans are
+		// buffered in memory and flushed when the exporter is wired up.
+		cfg := ctx.Config().Config().Core.Observability
+
+		deferred := NewDeferredSpanProcessor()
+
+		var tp *sdktrace.TracerProvider
+		if cfg.Enabled {
+			res, err := buildResource(ctx.GetContext(), cfg)
+			if err != nil {
+				return ctx, err
+			}
+			tp = sdktrace.NewTracerProvider(
+				sdktrace.WithSpanProcessor(deferred),
+				sdktrace.WithResource(res),
+				sdktrace.WithSampler(buildSampler(cfg.Tracing)),
+			)
+		} else {
+			tp = sdktrace.NewTracerProvider(
+				sdktrace.WithSpanProcessor(deferred),
+				sdktrace.WithSampler(sdktrace.NeverSample()),
+			)
+		}
+		otel.SetTracerProvider(tp)
+
 		ctx.OnStartup(func(ctx Context) error {
 			cfg := ctx.Config().Config().Core.Observability
 
@@ -103,7 +131,6 @@ func ContextWithTelemetry() ContextBuilderOption {
 				return err
 			}
 
-			var tp *sdktrace.TracerProvider
 			var lp *sdklog.LoggerProvider
 
 			if cfg.IsTracingEnabled() {
@@ -112,18 +139,12 @@ func ContextWithTelemetry() ContextBuilderOption {
 					return err
 				}
 
-				tp = sdktrace.NewTracerProvider(
-					sdktrace.WithResource(res),
-					sdktrace.WithBatcher(traceExporter,
-						sdktrace.WithBatchTimeout(time.Duration(cfg.Tracing.BatchTimeout)*time.Second),
-						sdktrace.WithMaxExportBatchSize(int(cfg.Tracing.MaxExportBatchSize)),
-					),
-					sdktrace.WithSampler(buildSampler(cfg.Tracing)),
+				// Attach the real exporter to the deferred processor. This
+				// flushes any buffered spans (including portal.boot) to Tempo.
+				deferred.SetExporter(traceExporter,
+					sdktrace.WithBatchTimeout(time.Duration(cfg.Tracing.BatchTimeout)*time.Second),
+					sdktrace.WithMaxExportBatchSize(int(cfg.Tracing.MaxExportBatchSize)),
 				)
-				otel.SetTracerProvider(tp)
-			} else {
-				tp = sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.NeverSample()))
-				otel.SetTracerProvider(tp)
 			}
 
 			if cfg.IsLoggingEnabled() {


### PR DESCRIPTION
## Problem
The `TracerProvider` was created inside a startup func that runs AFTER the `portal.boot` span is created. Spans created before the provider was set (during context construction) went to the no-op tracer and were never exported to Tempo.

## Solution
Create the `TracerProvider` with a `DeferredSpanProcessor` immediately during context construction — before the boot span. The provider has the correct resource (service.name, host, process info) and sampler from the start. The OTLP exporter is attached later in the startup func via `SetExporter()`, which flushes any buffered spans (including `portal.boot`) to Tempo.

```
Context construction
  └─ ContextWithTelemetry()           ← TracerProvider created here
       └─ DeferredSpanProcessor        ← buffers spans in memory
            └─ (span created, ends, buffered)
Start()
  └─ portal.boot span created         ← real span on real provider
  └─ startStartupFuncs()
       └─ startup func                ← OTLP exporter attached
            └─ SetExporter()          ← buffered spans flush to Tempo
  └─ defer bootSpan.End()             ← boot span exported
```

## Changes
- `core/deferred_processor.go` — `DeferredSpanProcessor` implements `sdktrace.SpanProcessor`, buffers spans until exporter attached
- `core/otel_setup.go` — `ContextWithTelemetry()` creates provider immediately; startup func attaches exporter via `SetExporter()`
- `core/deferred_processor_test.go` — 5 regression tests: buffering, forwarding, shutdown, idempotency, concurrency