### PR TITLE
fix(content_scan): resolve duplicate Prometheus metric registration

### DIFF
--- a/service/internal/content_scan/metrics.go
+++ b/service/internal/content_scan/metrics.go
@@ -13,7 +13,7 @@ const (
 	MetricResultsQueried    = "results_queried_total"
 	MetricScannerRegistered = "scanner_registered_total"
 	MetricDuration          = "duration_seconds"
-	MetricOperationFailed   = "failed_total"
+	MetricOperationFailed   = "operation_failed_total"
 )
 
 // Metric label values


### PR DESCRIPTION
## Summary
- Rename `MetricOperationFailed` from `"failed_total"` to `"operation_failed_total"` to resolve a Prometheus descriptor collision at startup
- `MetricFailed` and `MetricOperationFailed` both resolved to `content_scanner_failed_total` with different label sets (`scanner_id` vs `operation`) and help strings, causing registration to fail