### PR TITLE
fix(otel): register OnExit at builder time to ensure shutdown on all paths

### DIFF
--- a/core/internal/core_tests/context_test.go
+++ b/core/internal/core_tests/context_test.go
@@ -62,7 +62,7 @@ func TestNewContext(t *testing.T) {
 	assert.NotNil(t, ctx.GetContext())
 	assert.Equal(t, 0, ctx.ExitCode())
 	assert.NotEmpty(t, ctx.StartupFuncs()) // Logger and other subsystems may register startup funcs
-	assert.Len(t, ctx.ExitFuncs(), 1) // Default exit func for event manager
+	assert.Len(t, ctx.ExitFuncs(), 2)      // Event manager + telemetry shutdown
 
 	mockConfigManager.AssertExpectations(t)
 }
@@ -126,7 +126,7 @@ func TestContextWithExitFunc(t *testing.T) {
 	assert.NotNil(t, ctx)
 
 	exitFuncs := ctx.ExitFuncs()
-	assert.Len(t, exitFuncs, 2) // Includes default event manager exit func
+	assert.Len(t, exitFuncs, 3) // Custom exit + event manager + telemetry shutdown
 
 	// Manually call all exit functions for testing
 	for _, f := range exitFuncs {
@@ -319,7 +319,7 @@ func TestOnExit(t *testing.T) {
 
 	ctx.OnExit(exitFunc)
 	exitFuncs := ctx.ExitFuncs()
-	assert.Len(t, exitFuncs, 2) // Includes default event manager exit func
+	assert.Len(t, exitFuncs, 3) // Custom exit + event manager + telemetry shutdown
 
 	// Manually call the exit function for testing
 	for _, f := range exitFuncs {

--- a/core/otel_lifecycle_test.go
+++ b/core/otel_lifecycle_test.go
@@ -1,0 +1,206 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal/config"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// newTestConfig creates a config.Config with the given observability settings.
+func newTestConfig(obs config.ObservabilityConfig) *config.Config {
+	return &config.Config{
+		Core: config.CoreConfig{
+			Observability: obs,
+		},
+	}
+}
+
+// runStartupAndExit simulates the portal lifecycle: runs all startup funcs.
+func runStartupAndExit(t *testing.T, ctx Context) {
+	t.Helper()
+	for _, f := range ctx.StartupFuncs() {
+		require.NoError(t, f(ctx))
+	}
+}
+
+// runExit runs all exit funcs in order.
+func runExit(t *testing.T, ctx Context) {
+	t.Helper()
+	for _, f := range ctx.ExitFuncs() {
+		require.NoError(t, f(ctx))
+	}
+}
+
+// newMockConfigManagerSimple creates a minimal config manager for telemetry tests.
+func newMockConfigManagerSimple(t *testing.T, cfg *config.Config) *config.MockManager {
+	mockConfigManager := config.NewMockManager(t)
+	mockConfigManager.On("GetConfig").Maybe().Return(cfg)
+	mockConfigManager.On("Config").Maybe().Return(cfg)
+	mockConfigManager.On("SetLogger", mock.Anything).Maybe().Return()
+	return mockConfigManager
+}
+
+// TestContextWithTelemetry_OnExitAlwaysRegistered is the regression test for
+// a bug where OnExit was registered INSIDE the startup func. If the startup
+// func returned early (tracing disabled, no OTLP endpoint), tp.Shutdown()
+// was never called and all buffered spans in the DeferredSpanProcessor were
+// silently lost. OnExit must be registered at builder time so it always runs.
+func TestContextWithTelemetry_OnExitAlwaysRegistered(t *testing.T) {
+	ResetState()
+
+	// Config: observability enabled, but NO OTLP endpoint.
+	// This causes the startup func to return early at the
+	// `if cfg.OTLP.Endpoint == ""` guard.
+	cfg := newTestConfig(config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-portal",
+		OTLP:        config.OTLPConfig{Endpoint: ""},
+		Tracing: config.TracingConfig{
+			Enabled:            true,
+			Sampler:            config.SamplerAlways,
+			BatchTimeout:       5,
+			MaxExportBatchSize: 512,
+		},
+	})
+
+	mockCfg := newMockConfigManagerSimple(t, cfg)
+	logger := NewLogger(mockCfg, nil)
+
+	ctx, err := NewContext(mockCfg, logger)
+	require.NoError(t, err)
+
+	runStartupAndExit(t, ctx)
+
+	// OnExit should be registered at builder time, giving us >= 2 exit funcs
+	// (event manager close + telemetry shutdown). If OnExit is still inside
+	// the startup func after the early-return guard, this will be 1 and fail.
+	exitFuncs := ctx.ExitFuncs()
+	assert.GreaterOrEqual(t, len(exitFuncs), 2,
+		"OnExit must be registered at builder time — early-return paths in "+
+			"the startup func must not skip tp.Shutdown()")
+
+	runExit(t, ctx)
+}
+
+// TestContextWithTelemetry_TracingDisabled verifies that when tracing is
+// disabled entirely (cfg.Enabled = false), the TracerProvider uses
+// NeverSample and no spans are recorded, and shutdown is clean.
+func TestContextWithTelemetry_TracingDisabled(t *testing.T) {
+	ResetState()
+
+	cfg := newTestConfig(config.ObservabilityConfig{Enabled: false})
+
+	mockCfg := newMockConfigManagerSimple(t, cfg)
+	logger := NewLogger(mockCfg, nil)
+
+	ctx, err := NewContext(mockCfg, logger)
+	require.NoError(t, err)
+
+	runStartupAndExit(t, ctx)
+
+	tracer := otel.Tracer("test")
+	_, span := tracer.Start(context.Background(), "should-not-record")
+	span.End()
+
+	tp := otel.GetTracerProvider()
+	assert.NotNil(t, tp)
+
+	runExit(t, ctx)
+}
+
+// TestContextWithTelemetry_EarlyReturnNoPanic verifies that all early-return
+// paths in the startup func (disabled, no endpoint, tracing subsystem disabled)
+// don't panic when exit funcs run — i.e. tp.Shutdown() is always reachable.
+func TestContextWithTelemetry_EarlyReturnNoPanic(t *testing.T) {
+	t.Run("tracing_disabled", func(t *testing.T) {
+		ResetState()
+		cfg := newTestConfig(config.ObservabilityConfig{Enabled: false})
+		mockCfg := newMockConfigManagerSimple(t, cfg)
+		logger := NewLogger(mockCfg, nil)
+		ctx, err := NewContext(mockCfg, logger)
+		require.NoError(t, err)
+		runStartupAndExit(t, ctx)
+		assert.NotPanics(t, func() { runExit(t, ctx) })
+	})
+
+	t.Run("enabled_no_endpoint", func(t *testing.T) {
+		ResetState()
+		cfg := newTestConfig(config.ObservabilityConfig{
+			Enabled: true,
+			OTLP:    config.OTLPConfig{Endpoint: ""},
+		})
+		mockCfg := newMockConfigManagerSimple(t, cfg)
+		logger := NewLogger(mockCfg, nil)
+		ctx, err := NewContext(mockCfg, logger)
+		require.NoError(t, err)
+		runStartupAndExit(t, ctx)
+		assert.NotPanics(t, func() { runExit(t, ctx) })
+	})
+
+	t.Run("tracing_enabled_no_tracing_subsystem", func(t *testing.T) {
+		ResetState()
+		// Observability enabled, OTLP endpoint set, but Tracing.Enabled = false.
+		// SetExporter is never called, but OnExit should still fire.
+		cfg := newTestConfig(config.ObservabilityConfig{
+			Enabled:     true,
+			ServiceName: "test",
+			OTLP:        config.OTLPConfig{Endpoint: "localhost:4317", Insecure: true},
+			Tracing:     config.TracingConfig{Enabled: false},
+		})
+		mockCfg := newMockConfigManagerSimple(t, cfg)
+		logger := NewLogger(mockCfg, nil)
+		ctx, err := NewContext(mockCfg, logger)
+		require.NoError(t, err)
+		runStartupAndExit(t, ctx)
+		assert.NotPanics(t, func() { runExit(t, ctx) })
+	})
+}
+
+// TestContextWithTelemetry_BootSpansExportedViaDeferredProcessor verifies
+// the end-to-end flow: spans created on a TracerProvider with a
+// DeferredSpanProcessor (before exporter attachment) are buffered and
+// flushed when SetExporter is called. This is the mechanism that allows
+// portal.boot spans to reach Tempo.
+func TestContextWithTelemetry_BootSpansExportedViaDeferredProcessor(t *testing.T) {
+	deferred := NewDeferredSpanProcessor()
+	exporter := tracetest.NewInMemoryExporter()
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(deferred),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	defer tp.Shutdown(context.Background())
+	otel.SetTracerProvider(tp)
+
+	tracer := otel.Tracer("test")
+
+	// Span before exporter attachment — buffered
+	_, bootSpan := tracer.Start(context.Background(), "portal.boot")
+	bootSpan.End()
+	assert.Equal(t, 0, len(exporter.GetSpans()))
+
+	// Attach exporter — buffered span flushes
+	deferred.SetExporter(exporter)
+	deferred.ForceFlush(context.Background())
+
+	spans := exporter.GetSpans()
+	assert.Len(t, spans, 1)
+	assert.Equal(t, "portal.boot", spans[0].Name)
+
+	// Runtime span after attachment — direct
+	_, runtimeSpan := tracer.Start(context.Background(), "runtime.request")
+	runtimeSpan.End()
+	require.NoError(t, tp.ForceFlush(context.Background()))
+
+	spans = exporter.GetSpans()
+	require.Len(t, spans, 2)
+	assert.Equal(t, "portal.boot", spans[0].Name)
+	assert.Equal(t, "runtime.request", spans[1].Name)
+}

--- a/core/otel_setup.go
+++ b/core/otel_setup.go
@@ -115,6 +115,26 @@ func ContextWithTelemetry() ContextBuilderOption {
 		}
 		otel.SetTracerProvider(tp)
 
+		// lp is set by the startup func if logging is enabled. It's declared
+		// here so the OnExit closure (registered at builder time) can reference
+		// it regardless of whether the startup func reaches the assignment.
+		var lp *sdklog.LoggerProvider
+
+		// Register OnExit at builder time, not inside the startup func.
+		// If the startup func returns early (tracing disabled, no OTLP endpoint),
+		// the TracerProvider still needs to be shut down to release resources
+		// and flush any buffered spans in the DeferredSpanProcessor.
+		ctx.OnExit(func(exitCtx Context) error {
+			var errs []error
+			if tp != nil {
+				errs = append(errs, tp.Shutdown(exitCtx.GetContext()))
+			}
+			if lp != nil {
+				errs = append(errs, lp.Shutdown(exitCtx.GetContext()))
+			}
+			return errors.Join(errs...)
+		})
+
 		ctx.OnStartup(func(ctx Context) error {
 			cfg := ctx.Config().Config().Core.Observability
 
@@ -130,8 +150,6 @@ func ContextWithTelemetry() ContextBuilderOption {
 			if err != nil {
 				return err
 			}
-
-			var lp *sdklog.LoggerProvider
 
 			if cfg.IsTracingEnabled() {
 				traceExporter, err := otlptracegrpc.New(ctx.GetContext(), buildTraceExporterOptions(cfg.OTLP)...)
@@ -159,17 +177,6 @@ func ContextWithTelemetry() ContextBuilderOption {
 				)
 				global.SetLoggerProvider(lp)
 			}
-
-			ctx.OnExit(func(exitCtx Context) error {
-				var errs []error
-				if tp != nil {
-					errs = append(errs, tp.Shutdown(exitCtx.GetContext()))
-				}
-				if lp != nil {
-					errs = append(errs, lp.Shutdown(exitCtx.GetContext()))
-				}
-				return errors.Join(errs...)
-			})
 
 			return nil
 		})


### PR DESCRIPTION
## Summary
- Moved `OnExit` registration from inside the startup func to builder time so `tp.Shutdown()` always runs, even when the startup func returns early (tracing disabled, no OTLP endpoint, or tracing subsystem disabled)
- Added `lp` as a closure-scoped variable declared at builder time so the exit handler can shut down the LoggerProvider when set
- Added regression tests verifying OnExit is always registered, early-return paths don't panic, and boot→runtime span export flow works end-to-end