### PR TITLE
feat(otel): add trace.id attribute to all spans for orphan span correlation

### DIFF
--- a/core/otel.go
+++ b/core/otel.go
@@ -235,7 +235,9 @@ func StartSpan(ctx context.Context, name string, opts ...SpanOption) (context.Co
 	if len(config.Links) > 0 {
 		spanOpts = append(spanOpts, trace.WithLinks(config.Links...))
 	}
-	return tracer.Start(ctx, config.Name, spanOpts...)
+	ctx, span := tracer.Start(ctx, config.Name, spanOpts...)
+	span.SetAttributes(attribute.String("trace.id", span.SpanContext().TraceID().String()))
+	return ctx, span
 }
 
 // TraceMethod starts a new trace span for a method.


### PR DESCRIPTION
## Summary
- Adds trace.id as a span attribute in StartSpan so every span includes its trace ID as a searchable attribute in Tempo
- Enables correlation of orphan spans whose parent was dropped by tail sampling