### PR TITLE
feat(db): add PrepareStmt, connection pool tuning, and configurable pool settings

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	z "github.com/Oudwins/zog"
 	"go.lumeweb.com/configmanager"
 )
@@ -11,18 +13,21 @@ var (
 )
 
 type DatabaseConfig struct {
-	Type          string       `config:"type"`
-	File          string       `config:"file"`
-	Charset       string       `config:"charset"`
-	Host          string       `config:"host"`
-	Name          string       `config:"name"`
-	Password      string       `config:"password"`
-	Port          int          `config:"port"`
-	Username      string       `config:"username"`
-	Cache         *CacheConfig `config:"cache"`
-	TLSEnabled    bool         `config:"tls_enabled"`
-	TLSSkipVerify bool         `config:"tls_skip_verify"`
-	MetricsPort   uint         `config:"metrics_port"`
+	Type            string        `config:"type"`
+	File            string        `config:"file"`
+	Charset         string        `config:"charset"`
+	Host            string        `config:"host"`
+	Name            string        `config:"name"`
+	Password        string        `config:"password"`
+	Port            int           `config:"port"`
+	Username        string        `config:"username"`
+	Cache           *CacheConfig  `config:"cache"`
+	TLSEnabled      bool          `config:"tls_enabled"`
+	TLSSkipVerify   bool          `config:"tls_skip_verify"`
+	MetricsPort     uint          `config:"metrics_port"`
+	MaxOpenConns    int           `config:"max_open_conns"`
+	MaxIdleConns    int           `config:"max_idle_conns"`
+	ConnMaxLifetime time.Duration `config:"conn_max_lifetime"`
 }
 
 func (d DatabaseConfig) Schema() z.ZogSchema {
@@ -40,6 +45,8 @@ func (d DatabaseConfig) Schema() z.ZogSchema {
 		"TLSSkipVerify": z.Bool(),
 		"MetricsPort": z.Uint().
 			GT(0, z.Message("metrics_port must be greater than 0")),
+		"MaxOpenConns": z.Int().GT(0, z.Message("max_open_conns must be greater than 0")),
+		"MaxIdleConns": z.Int().GT(0, z.Message("max_idle_conns must be greater than 0")),
 	}).TestFunc(func(data any, ctx z.Ctx) bool {
 		d, ok := data.(*DatabaseConfig)
 		if !ok {
@@ -85,10 +92,13 @@ func (d DatabaseConfig) CacheEnabled() bool {
 
 func (d DatabaseConfig) Defaults() map[string]any {
 	def := map[string]any{
-		"Type":        "sqlite",
-		"File":        "portal.db",
-		"Charset":     "utf8mb4",
-		"MetricsPort": uint(9091),
+		"Type":            "sqlite",
+		"File":            "portal.db",
+		"Charset":         "utf8mb4",
+		"MetricsPort":     uint(9091),
+		"MaxOpenConns":    25,
+		"MaxIdleConns":    10,
+		"ConnMaxLifetime": "5m",
 	}
 
 	if d.Type == "mysql" {

--- a/db/mysql_provider.go
+++ b/db/mysql_provider.go
@@ -35,13 +35,31 @@ func (p *MySQLProvider) Connect(logger *core.Logger) (*gorm.DB, error) {
 
 	logger.Debug("Connecting to MySQL", zap.String("dsn", dsn))
 
+	dbConfig := p.cfg.Config().Core.DB
+
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
-		Logger:  NewLogger(logger.Logger, logger.Level()),
-		NowFunc: func() time.Time { return time.Now().UTC() },
+		Logger:      NewLogger(logger.Logger, logger.Level()),
+		NowFunc:     func() time.Time { return time.Now().UTC() },
+		PrepareStmt: true,
 	})
 
 	if err != nil {
 		return nil, err
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
+
+	if dbConfig.MaxOpenConns > 0 {
+		sqlDB.SetMaxOpenConns(dbConfig.MaxOpenConns)
+	}
+	if dbConfig.MaxIdleConns > 0 {
+		sqlDB.SetMaxIdleConns(dbConfig.MaxIdleConns)
+	}
+	if dbConfig.ConnMaxLifetime > 0 {
+		sqlDB.SetConnMaxLifetime(dbConfig.ConnMaxLifetime)
 	}
 
 	p.sqlDB = db


### PR DESCRIPTION
## Changes

### PrepareStmt
Enables GORM's prepared statement caching. Every INSERT/SELECT/UPDATE now reuses a cached prepared statement instead of issuing a COM_STMT_PREPARE round-trip each time. Expected ~2-5ms savings per query — the `renter_objects` INSERT (11.8ms slowest DB op) should drop to 3-6ms.

### Connection Pool Tuning
Previously no pool settings were configured — Go's MySQL driver defaults to unlimited open connections and 2 idle connections. Now configurable with sensible defaults:

| Setting | Default | Description |
|---------|---------|-------------|
| `max_open_conns` | 25 | Max concurrent DB connections |
| `max_idle_conns` | 10 | Idle connections retained |
| `conn_max_lifetime` | 5m | Max connection age (prevents stale conns) |

All three are set via the `DatabaseConfig` struct and applied in `MySQLProvider.Connect()` via `sql.DB` setters. Operators can override in config.

### Files Changed
- `config/database.go` — added `MaxOpenConns`, `MaxIdleConns`, `ConnMaxLifetime` fields + schema validation + defaults
- `db/mysql_provider.go` — enabled `PrepareStmt: true` + pool tuning via `sql.DB` setters