### PR TITLE
fix(db): migrate RetryableComponentLock callers to RetryableComponentTransaction

### DIFF
--- a/service/renter.go
+++ b/service/renter.go
@@ -317,7 +317,7 @@ func (r *RenterDefault) UploadExists(ctx context.Context, bucket string, fileNam
 	siaUpload.Bucket = bucket
 	siaUpload.Key = fileName
 
-	if err := db.RetryableComponentLock(r, func(db *gorm.DB) *gorm.DB {
+	if err := db.RetryableComponentTransaction(r, ctx, func(db *gorm.DB) *gorm.DB {
 		return db.WithContext(ctx).Model(&models.SiaUpload{}).Where(&siaUpload).First(&siaUpload)
 	}); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -359,7 +359,7 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 			siaUpload.Bucket = bucket
 			siaUpload.Key = fileName
 
-			err = db.RetryableComponentLock(r, func(db *gorm.DB) *gorm.DB {
+			err = db.RetryableComponentTransaction(r, ctx, func(db *gorm.DB) *gorm.DB {
 				return db.WithContext(ctx).Model(&siaUpload).First(&siaUpload)
 
 			})
@@ -390,7 +390,7 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 
 				uploadId = upload.UploadID
 				siaUpload.UploadID = uploadId
-				if err = db.RetryableComponentLock(r, func(db *gorm.DB) *gorm.DB {
+				if err = db.RetryableComponentTransaction(r, ctx, func(db *gorm.DB) *gorm.DB {
 					return db.WithContext(ctx).Create(&siaUpload)
 				}); err != nil {
 					return err
@@ -470,7 +470,7 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 
 				siaUpload.UpdatedAt = time.Now()
 
-				if err = db.RetryableComponentLock(r, func(db *gorm.DB) *gorm.DB {
+				if err = db.RetryableComponentTransaction(r, ctx, func(db *gorm.DB) *gorm.DB {
 					return db.WithContext(ctx).Model(&siaUpload).Save(&siaUpload)
 				}); err != nil {
 					return err
@@ -493,7 +493,7 @@ func (r *RenterDefault) UploadObjectMultipart(ctx context.Context, params *core.
 				return err
 			}
 
-			if err = db.RetryableComponentLock(r, func(db *gorm.DB) *gorm.DB {
+			if err = db.RetryableComponentTransaction(r, ctx, func(db *gorm.DB) *gorm.DB {
 				return db.WithContext(ctx).Delete(&siaUpload)
 			}); err != nil {
 				return err

--- a/service/storage.go
+++ b/service/storage.go
@@ -652,7 +652,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 		var totalUploadDuration time.Duration
 		var currentAverageDuration time.Duration
 
-		if err = db.RetryableComponentLock(s, func(tx *gorm.DB) *gorm.DB {
+		if err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 			return tx.Model(&s3Upload).First(&s3Upload)
 		}); err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -700,7 +700,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			uploadId = *mu.UploadId
 
 			s3Upload.UploadID = uploadId
-			if err = db.RetryableComponentLock(s, func(tx *gorm.DB) *gorm.DB {
+			if err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 				return tx.Create(&s3Upload)
 			}); err != nil {
 				uploadErr = err
@@ -789,7 +789,7 @@ func (s StorageServiceDefault) S3MultipartUpload(ctx context.Context, data io.Re
 			return false, size, err
 		}
 
-		if err = db.RetryableComponentLock(s, func(tx *gorm.DB) *gorm.DB {
+		if err = db.RetryableComponentTransaction(s, ctx, func(tx *gorm.DB) *gorm.DB {
 			return tx.Delete(&s3Upload)
 		}); err != nil {
 			s.Logger().Error("failed to delete S3Upload record after successful upload", zap.Error(err), zap.String("bucket", bucket), zap.String("key", key))


### PR DESCRIPTION
## Problem

`RetryableComponentLock` does not accept a context parameter, so DB queries using it had no context propagation for tracing or cancellation. On retry, the raw `*gorm.DB` was used without `.WithContext(ctx)`, losing the trace span and cancellation chain.

## Fix

Migrated all 8 call sites to `RetryableComponentTransaction(component, ctx, ...)` which passes ctx through to the GORM session via `.WithContext(ctx)`. All call sites already had `ctx context.Context` in scope.

## Files changed

- `service/renter.go` — 5 call sites
- `service/storage.go` — 3 call sites

## Testing

- `go build ./...` — clean
- `go vet ./service/...` — clean
- `go test ./service/... -count=1 -short` — all pass
- Kodos review — clean