### PR TITLE
fix(otel): add configurable MaxQueueSize to batch span processor

### DIFF
--- a/config/observability.go
+++ b/config/observability.go
@@ -87,6 +87,7 @@ type TracingConfig struct {
 	SamplerRatio       float64 `config:"sampler_ratio"`         // 0.0-1.0, only for traceidratio
 	BatchTimeout       uint    `config:"batch_timeout"`         // seconds between BSP flushes
 	MaxExportBatchSize uint    `config:"max_export_batch_size"` // max spans per export batch
+	MaxQueueSize       uint    `config:"max_queue_size"`        // max spans queued in memory before export
 }
 
 func (t TracingConfig) Schema() z.ZogSchema {
@@ -101,6 +102,8 @@ func (t TracingConfig) Schema() z.ZogSchema {
 			GT(0, z.Message("batch_timeout must be greater than 0")),
 		"MaxExportBatchSize": z.Uint().
 			GT(0, z.Message("max_export_batch_size must be greater than 0")),
+		"MaxQueueSize": z.Uint().
+			GT(0, z.Message("max_queue_size must be greater than 0")),
 	}).TestFunc(func(data any, ctx z.Ctx) bool {
 		c, ok := data.(*TracingConfig)
 		if !ok {
@@ -124,6 +127,7 @@ func (t TracingConfig) Defaults() map[string]any {
 		"SamplerRatio":       1.0,
 		"BatchTimeout":       uint(5),
 		"MaxExportBatchSize": uint(512),
+		"MaxQueueSize":       uint(8192),
 	}
 }
 

--- a/core/otel_setup.go
+++ b/core/otel_setup.go
@@ -117,6 +117,7 @@ func ContextWithTelemetry() ContextBuilderOption {
 					sdktrace.WithBatcher(traceExporter,
 						sdktrace.WithBatchTimeout(time.Duration(cfg.Tracing.BatchTimeout)*time.Second),
 						sdktrace.WithMaxExportBatchSize(int(cfg.Tracing.MaxExportBatchSize)),
+						sdktrace.WithMaxQueueSize(int(cfg.Tracing.MaxQueueSize)),
 					),
 					sdktrace.WithSampler(buildSampler(cfg.Tracing)),
 				)


### PR DESCRIPTION
## Summary
- Add `MaxQueueSize` field to `TracingConfig` with Zog schema validation (`GT(0)`) and default value of `8192`
- Wire `sdktrace.WithMaxQueueSize()` into the batch span processor in `core/otel_setup.go`
- The OTel SDK default `MaxQueueSize` is `2048`, which overflows during upload operations that generate 700+ error spans in a single trace, silently dropping workflow and indexd spans before they reach the exporter