### PR TITLE
fix(cron): guard Stop() against nil BaseComponent

### DIFF
--- a/service/cron.go
+++ b/service/cron.go
@@ -289,6 +289,9 @@ func (c *CronServiceDefault) Monitor() core.CronMonitor {
 }
 
 func (c *CronServiceDefault) Stop(context.Context) error {
+	if c.BaseComponent == nil {
+		return nil
+	}
 	if c.Config().Config().Core.Cron.Enabled && c.coordinator != nil {
 		return c.coordinator.Close()
 	}


### PR DESCRIPTION
## Problem

`CronServiceDefault.Stop()` calls `c.Config()` which dereferences the embedded `*BaseComponent`. When the portal shuts down before the startup sequence has wired the component (e.g. the `migrate-renterd-objects` command), `BaseComponent` is `nil` and causes a SIGSEGV panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 1 [running]:
go.lumeweb.com/portal/core.(*BaseComponent).Config(...)
    core/component.go:70
go.lumeweb.com/portal/service.(*CronServiceDefault).Stop(...)
    service/cron.go:292
```

## Fix

Add a nil guard at the top of `Stop()` — if `BaseComponent` was never initialized, skip cleanup (there's nothing to clean up).