### PR TITLE
fix(sia-login): persist app key to config file after BulkSetAtomic

### DIFF
--- a/cmd/internal/cli/sia_login.go
+++ b/cmd/internal/cli/sia_login.go
@@ -172,6 +172,11 @@ func siaLoginAction(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to save app key to config: %w", err)
 	}
 
+	// Persist to the config file so values survive restarts.
+	if err := manager.Persist("core.storage.sia"); err != nil {
+		return fmt.Errorf("failed to persist app key to config file: %w", err)
+	}
+
 	// Step 6: Output env vars for container deployments.
 	pterm.Println()
 	pterm.Success.Println("Login successful! The app key has been saved to config.")


### PR DESCRIPTION
## Problem

The `sia login` command calls `manager.BulkSetAtomic()` to set the app key and indexer URL, but `BulkSetAtomic` only sets values in-memory (koanf). The values are never written to the config file, so they don't survive restarts.

## Fix

Call `manager.Persist("core.storage.sia")` after `BulkSetAtomic` to flush the values to the file source.