### PR TITLE
fix(cli): print CLI errors to stderr before exit

### DIFF
--- a/cmd/internal/cli/sia_login.go
+++ b/cmd/internal/cli/sia_login.go
@@ -10,8 +10,8 @@ import (
 	"github.com/urfave/cli/v3"
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
-	"go.uber.org/zap"
 	sdk "go.sia.tech/siastorage"
+	"go.uber.org/zap"
 )
 
 const (
@@ -37,9 +37,9 @@ func newSiaLoginCommand() *cli.Command {
 		Action:    siaLoginAction,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:    "print-env",
-				Usage:   "Print environment variables after successful login",
-				Value:   false,
+				Name:  "print-env",
+				Usage: "Print environment variables after successful login",
+				Value: false,
 			},
 		},
 	}

--- a/cmd/portal/main.go
+++ b/cmd/portal/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"go.lumeweb.com/portal/cmd/internal/cli"
 	_ "go.lumeweb.com/portal/service"
 	"os"
@@ -11,6 +12,7 @@ func main() {
 	command := cli.NewPortalCLI()
 	ctx := context.Background()
 	if err := command.Run(ctx, os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/portal_embed/main.go
+++ b/cmd/portal_embed/main.go
@@ -2,6 +2,7 @@ package portal_embed
 
 import (
 	"context"
+	"fmt"
 	"go.lumeweb.com/portal/cmd/internal/cli"
 	_ "go.lumeweb.com/portal/service"
 	"os"
@@ -11,6 +12,7 @@ func Main() {
 	command := cli.NewPortalCLI()
 	ctx := context.Background()
 	if err := command.Run(ctx, os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary
- Print returned errors to stderr before os.Exit(1) in both portal and portal_embed entry points
- Previously errors were silently swallowed, hiding validation failures and other issues from the user