### PR TITLE
fix(migrator): use portal.Stop instead of portal.Shutdown to avoid os.Exit

### DIFF
--- a/cmd/internal/cli/migrate.go
+++ b/cmd/internal/cli/migrate.go
@@ -60,13 +60,13 @@ func migrateRenterdAction(ctx context.Context, cmd *cli.Command) error {
 	portal.NewActivePortal(portalCtx)
 
 	if err := portal.Init(); err != nil {
-		// portal.Shutdown calls os.Exit, which would swallow the error.
-		// Log it, close what we can, then return the error directly.
-		logger.Error("failed to initialize portal", zap.Error(err))
-		portal.Shutdown(portal.ActivePortal(), logger.Logger)
+		// Use Stop (not Shutdown) to avoid os.Exit swallowing the error.
+		if stopErr := portal.Stop(); stopErr != nil {
+			logger.Error("failed to stop portal after init error", zap.Error(stopErr))
+		}
 		return fmt.Errorf("failed to initialize portal: %w", err)
 	}
-	defer portal.Shutdown(portal.ActivePortal(), logger.Logger)
+	defer portal.Stop()
 
 	// Get the RenterService — the migrator uses it directly for uploads.
 	svc := core.GetServiceOptional[core.RenterService](portalCtx, core.RENTER_SERVICE)


### PR DESCRIPTION
## Problem

`portal.Shutdown()` calls `os.Exit()`, which kills the process before the CLI framework (`urfave/cli/v3`) can print the returned error. This was swallowing ALL errors from `migrateRenterdAction`:
- `portal.Init()` failures
- Missing `RenterService`
- Missing storage protocols
- Migration errors

The user saw the command exit silently with only `"Stopping portal"` in the log — no error message.

## Fix

Use `portal.Stop()` (which does NOT call `os.Exit`) for cleanup in the migrate command. This lets the CLI framework receive and print the error normally.

## Test Plan

- [x] `go build ./...` succeeds
- [x] `go vet` clean
- [x] `go test ./service/migrator/...` passes (17 tests)