### PR TITLE
fix(migrator): use ActivePortal context for service lookup

### DIFF
--- a/cmd/internal/cli/migrate.go
+++ b/cmd/internal/cli/migrate.go
@@ -69,7 +69,9 @@ func migrateRenterdAction(ctx context.Context, cmd *cli.Command) error {
 	defer portal.Stop()
 
 	// Get the RenterService — the migrator uses it directly for uploads.
-	svc := core.GetServiceOptional[core.RenterService](portalCtx, core.RENTER_SERVICE)
+	// Use ActivePortal().Context() because Init() creates a new context with
+	// registered services — the original portalCtx is stale.
+	svc := core.GetServiceOptional[core.RenterService](portal.ActivePortal().Context(), core.RENTER_SERVICE)
 	if svc == nil {
 		return fmt.Errorf("renter service not found in registry")
 	}


### PR DESCRIPTION
## Problem

The migrate command used the original `portalCtx` (created before `portal.Init()`) to look up the RenterService. But `portal.Init()` creates a **new** context with registered services and stores it via `p.SetContext(ctx)`. The original `portalCtx` is stale — it has no services, so `GetServiceOptional` always returns nil.

This caused: `renter service not found in registry`

## Fix

Use `portal.ActivePortal().Context()` instead of the stale `portalCtx`. This returns the updated context that has all services registered during `Init()`.

## Test Plan

- [x] `go build ./...` succeeds
- [x] `go vet` clean