### PR TITLE
fix(migrator): strip leading slash from renterd object keys

### DIFF
--- a/service/migrator/migrator.go
+++ b/service/migrator/migrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"go.lumeweb.com/portal/core"
 	"go.uber.org/zap"
@@ -78,7 +79,10 @@ func (m *Migrator) Migrate(ctx context.Context, protocols []core.StorageProtocol
 			}
 
 			stats.Total++
-			objectKey := obj.Key
+			// Renterd keys may have a leading slash (e.g. /Qm...).
+			// Normal uploads use EncodeFileName which has no leading slash.
+			// Strip it so keys match existing objects and DB lookups.
+			objectKey := strings.TrimPrefix(obj.Key, "/")
 
 			if m.DryRun {
 				m.Logger.Info("[dry-run] would migrate object",

--- a/service/migrator/migrator_test.go
+++ b/service/migrator/migrator_test.go
@@ -257,4 +257,50 @@ func TestMigrationStats_String(t *testing.T) {
 	assert.Equal(t, "total=10 migrated=7 skipped=2 errors=1", s.String())
 }
 
+// TestMigrate_StripsLeadingSlash verifies that object keys from renterd
+// with a leading slash (e.g. /Qm...) are stripped before being used.
+func TestMigrate_StripsLeadingSlash(t *testing.T) {
+	var capturedKey string
+	lister := &mockLister{
+		objects: map[string][]RenterdObjectMetadata{
+			"ipfs": {
+				{Bucket: "ipfs", Key: "/QmTest1", Size: 5},
+			},
+		},
+	}
+	downloader := &mockDownloader{
+		data: map[string][]byte{
+			"ipfs/QmTest1": []byte("hello"),
+		},
+	}
+	renter := mocks.NewMockRenterService(t)
+	renter.EXPECT().UploadExists(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _, fileName string) (bool, *models.RenterObject, error) {
+		capturedKey = fileName
+		return false, nil, nil
+	})
+	renter.EXPECT().UploadObject(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, _ io.Reader, _, fileName string, _ []byte) error {
+		capturedKey = fileName
+		return nil
+	})
+
+	m := &Migrator{
+		Renter:     renter,
+		Lister:     lister,
+		Downloader: downloader,
+		Logger:     testLogger(),
+	}
+
+	proto := mocks.NewMockStorageProtocol(t)
+	proto.EXPECT().Name().Return("ipfs").Maybe()
+	proto.EXPECT().Hash(mock.Anything, mock.Anything).RunAndReturn(func(_ io.Reader, _ uint64) (core.StorageHash, error) {
+		return testHash(), nil
+	})
+
+	stats, err := m.Migrate(context.Background(), []core.StorageProtocol{proto})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Total)
+	assert.Equal(t, 1, stats.Migrated)
+	assert.Equal(t, "QmTest1", capturedKey)
+}
+
 // (helper removed — using mock.Anything for io.Reader args)


### PR DESCRIPTION
## Problem

Renterd returns object keys with a leading slash (e.g. `/QmTest1`), but normal portal uploads use `EncodeFileName(hash)` which produces keys **without** a leading slash (e.g. `QmTest1`).

Without stripping, migrated objects would be stored under a different key (`/QmTest1`) than normal uploads (`QmTest1`), causing:
- `UploadExists` lookups to fail (key mismatch)
- Duplicate uploads of the same object
- DB `object_key` column to have inconsistent values

## Fix

`strings.TrimPrefix(obj.Key, "/")` at the point of use, before the dry-run log and before passing to `UploadExists` / `UploadObject` / `DownloadObject`.

## Test Plan

- [x] `go build ./...` succeeds
- [x] `go vet` clean
- [x] `go test ./service/migrator/...` passes (includes new `TestMigrate_StripsLeadingSlash`)
- [x] New test verifies key passed to `UploadExists` and `UploadObject` is `QmTest1`, not `/QmTest1`