### PR TITLE
feat: add core.WireService for CLI commands to wire individual services

### DIFF
--- a/cmd/internal/cli/migrate.go
+++ b/cmd/internal/cli/migrate.go
@@ -65,22 +65,22 @@ func migrateRenterdAction(ctx context.Context, cmd *cli.Command) error {
 		}
 		return fmt.Errorf("failed to initialize portal: %w", err)
 	}
-
-	// Run startup funcs (wires config/DB into services, runs service init)
-	// without starting HTTP, cron, or mailer.
-	if err := portal.StartComponents(); err != nil {
-		if stopErr := portal.Stop(); stopErr != nil {
-			logger.Error("failed to stop portal after component startup error", zap.Error(stopErr))
-		}
-		return fmt.Errorf("failed to start portal components: %w", err)
-	}
 	defer portal.Stop()
 
-	// Use ActivePortal().Context() — StartComponents updates the portal's
-	// context with wired, initialized services. The original portalCtx is stale.
+	// Wire and initialize just the RenterService, without running all
+	// startup funcs (which would open LevelDB, bind Prometheus, etc. —
+	// resources already held by the running server).
 	svc := core.GetServiceOptional[core.RenterService](portal.ActivePortal().Context(), core.RENTER_SERVICE)
 	if svc == nil {
 		return fmt.Errorf("renter service not found in registry")
+	}
+	if err := core.WireService(portal.ActivePortal().Context(), svc); err != nil {
+		return fmt.Errorf("failed to wire renter service: %w", err)
+	}
+	if initSvc, ok := any(svc).(core.ServiceInit); ok {
+		if err := initSvc.Init(); err != nil {
+			return fmt.Errorf("failed to initialize renter service: %w", err)
+		}
 	}
 
 	// Collect all registered protocols that implement StorageProtocol.

--- a/core/context.go
+++ b/core/context.go
@@ -378,28 +378,39 @@ func findBaseComponentField(componentElem reflect.Value) reflect.Value {
 	return baseComponentField
 }
 
+// ensureBaseComponent initializes the embedded *BaseComponent field on a
+// component if it is nil. Returns false if the component does not embed a
+// BaseComponent (in which case the caller should skip wiring). Used by both
+// ContextWithStartupComponent (during normal boot) and WireService (for CLI
+// commands that wire a single service).
+func ensureBaseComponent(component Component, ctx Context) bool {
+	componentValue := reflect.ValueOf(component)
+	if componentValue.Kind() != reflect.Ptr || componentValue.IsNil() {
+		return false
+	}
+
+	componentElem := componentValue.Elem()
+	if componentElem.Kind() != reflect.Struct {
+		return false
+	}
+
+	baseComponentField := findBaseComponentField(componentElem)
+	if !baseComponentField.IsValid() || !baseComponentField.Type().AssignableTo(reflect.TypeOf((*BaseComponent)(nil))) {
+		return false
+	}
+
+	if baseComponentField.IsNil() {
+		baseComponentField.Set(reflect.ValueOf(NewBaseComponent(ctx)))
+	}
+
+	return true
+}
+
 func ContextWithStartupComponent(component Component) ContextBuilderOption {
 	return func(ctx Context) (Context, error) {
 		ctx.OnStartup(func(startupCtx Context) error {
-			// Initialize nil BaseComponent field if present
-			componentValue := reflect.ValueOf(component)
-			if componentValue.Kind() != reflect.Ptr || componentValue.IsNil() {
+			if !ensureBaseComponent(component, startupCtx) {
 				return nil
-			}
-
-			componentElem := componentValue.Elem()
-			if componentElem.Kind() != reflect.Struct {
-				return nil
-			}
-
-			baseComponentField := findBaseComponentField(componentElem)
-			if !baseComponentField.IsValid() || !baseComponentField.Type().AssignableTo(reflect.TypeOf((*BaseComponent)(nil))) {
-				return nil
-			}
-
-			if baseComponentField.IsNil() {
-				newBaseComponent := NewBaseComponent(startupCtx)
-				baseComponentField.Set(reflect.ValueOf(newBaseComponent))
 			}
 
 			// Wire up the component with database and config
@@ -437,6 +448,25 @@ func ContextWithStartupComponent(component Component) ContextBuilderOption {
 	}
 }
 
+// WireService manually wires a service component with config, DB, logger,
+// and tracer — the same setup that ContextWithStartupComponent's OnStartup
+// callback performs during startStartupFuncs. CLI commands that need a
+// fully configured service without running all startup funcs call this
+// after Init(), followed by the service's Init() if it implements ServiceInit.
+func WireService(ctx Context, service Service) error {
+	if !ensureBaseComponent(service, ctx) {
+		return fmt.Errorf("service %s does not embed BaseComponent", service.ID())
+	}
+
+	service.SetDB(ctx.DB())
+	service.SetConfig(ctx.Config())
+
+	tracedCtx := ctx.WithServiceTracer(service.ID())
+	service.SetLogger(ctx.ServiceLogger(service))
+	service.SetContext(tracedCtx)
+
+	return nil
+}
 func ContextWithExitFunc(f LifecycleFunc) ContextBuilderOption {
 	return func(ctx Context) (Context, error) {
 		ctx.OnExit(f)

--- a/service/renter.go
+++ b/service/renter.go
@@ -25,7 +25,7 @@ import (
 
 func init() {
 	core.RegisterService(core.ServiceInfo{
-		ID:       core.RENTER_SERVICE,
+		ID: core.RENTER_SERVICE,
 		Factory: func() (core.Service, []core.ContextBuilderOption, error) {
 			return NewRenterService()
 		},
@@ -71,7 +71,7 @@ func NewRenterService() (*RenterService, []core.ContextBuilderOption, error) {
 
 	opts := core.ContextOptions(
 		core.ContextWithStartupFunc(func(ctx core.Context) error {
-			if err := renter.init(ctx); err != nil {
+			if err := renter.Init(); err != nil {
 				return fmt.Errorf("failed to initialize indexd renter service: %w", err)
 			}
 			return nil
@@ -85,7 +85,8 @@ func (r *RenterService) ID() string {
 	return core.RENTER_SERVICE
 }
 
-func (r *RenterService) init(ctx core.Context) error {
+func (r *RenterService) Init() error {
+	ctx := r.Context()
 	if r.slabSize <= 0 {
 		r.slabSize = int64(proto4.SectorSize)
 	}
@@ -146,22 +147,25 @@ func (r *RenterService) init(ctx core.Context) error {
 		}
 	}
 
-	// Start the background packing loop.
-	r.packingLoopCtx, r.packingLoopCancel = context.WithCancel(ctx.GetContext())
-	r.packingLoopDone = make(chan struct{})
-	packingCfg := indexd.PackingLoopCfg{
-		Component:      r,
-		Logger:         r.Logger(),
-		SDK:            r.sdk,
-		StagingBackend: r.stagingBackend,
-		SlabSize:       r.slabSize,
+	// Start the background packing loop (idempotent — skip if already running).
+	if r.packingLoopCancel == nil {
+		r.packingLoopCtx, r.packingLoopCancel = context.WithCancel(ctx.GetContext())
+		r.packingLoopDone = make(chan struct{})
+		packingCfg := indexd.PackingLoopCfg{
+			Component:      r,
+			Logger:         r.Logger(),
+			SDK:            r.sdk,
+			StagingBackend: r.stagingBackend,
+			SlabSize:       r.slabSize,
+		}
+		go indexd.PackingLoop(r.packingLoopCtx, packingCfg, r.packingLoopDone)
 	}
-	go indexd.PackingLoop(r.packingLoopCtx, packingCfg, r.packingLoopDone)
 
 	// Start the sealed-data refresh loop. This periodically syncs object
 	// events from the indexer to keep sealed_data fresh (slab locations
 	// can change as hosts go up/down). Only run if the SDK is configured.
-	if r.sdkConfigured {
+	// Idempotent — skip if already running.
+	if r.sdkConfigured && r.syncLoopCancel == nil {
 		r.syncLoopCtx, r.syncLoopCancel = context.WithCancel(ctx.GetContext())
 		r.syncLoopDone = make(chan struct{})
 		syncCfg := indexd.SyncLoopCfg{


### PR DESCRIPTION
## Problem

The migrate command used `StartComponents()` (from PR #1666) to run startup funcs, but those startup funcs open resources held by the running server:

- GORM Prometheus binds `:9091` → `address already in use`
- IPFS plugin opens LevelDB datastore → `resource temporarily unavailable` (and calls `logger.Fatal` → `os.Exit`)

The migrator only needs `RenterService` — it does not need protocols, LevelDB, or Prometheus.

## Solution

Four changes across three files:

### 1. `core.WireService(ctx, service)` (`core/context.go`)

New framework function that wires a single service with `BaseComponent`, `DB`, `Config`, logger, and tracer — the same setup `ContextWithStartupComponent`'s `OnStartup` does, but callable directly. CLI commands call this after `Init()` to wire one service without running all startup funcs.

### 2. `ensureBaseComponent` helper (`core/context.go`)

Extracted the BaseComponent reflection logic (find field → validate → init if nil) from `ContextWithStartupComponent` into a shared `ensureBaseComponent(component, ctx) bool` helper. Both `ContextWithStartupComponent` and `WireService` call it — no more duplicated reflection.

Returns `bool` so callers preserve the original early-return behavior: if the component doesn't embed a `BaseComponent`, skip wiring.

### 3. `RenterService.init()` → `Init()` (`service/renter.go`)

Renamed to satisfy the existing `ServiceInit` interface (`core/service.go:18`, previously defined but unused). The factory's `ContextWithStartupFunc` calls `Init()` — server path unchanged.

**Idempotency**: `Init()` uses `r.Context()` instead of a passed `ctx` param. The `r.slabSize <= 0` guard makes the slab size assignment idempotent. SDK construction is guarded by `r.sdkConfigured` flag. Safe to call multiple times.

`ensureBaseComponent` is also idempotent — it only sets the `BaseComponent` field when `IsNil()` is true. Calling it twice on an already-wired service is a no-op.

### 4. Migrate command (`cmd/internal/cli/migrate.go`)

Replaced `StartComponents()` with `WireService` + type-assert to `ServiceInit` + call `Init()`. No LevelDB/Prometheus conflicts.

## Design

`WireService` is a framework primitive — not specific to the migrator. Any CLI command that needs a configured service calls `Init()` + `WireService(ctx, svc)` + `svc.Init()` (if `ServiceInit`). The server path is completely unchanged — `Start()` still calls `StartComponents()` → `startStartupFuncs` → all startup funcs run in the same order.

## Test Plan

- [x] `go build ./...` succeeds
- [x] `go vet` clean
- [x] `go test ./core/testing/example_service/...` passes (mock component without BaseComponent)
- [x] `go test ./service/migrator/...` passes