### PR TITLE
fix(migrator): correct renterd worker download route and add missing migration

### DIFF
--- a/db/migrations/mysql/20260712042758_object_sync_cursor.sql
+++ b/db/migrations/mysql/20260712042758_object_sync_cursor.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+
+-- Create object_sync_cursor table (stores the sealed-data refresh loop cursor)
+CREATE TABLE IF NOT EXISTS `object_sync_cursor`
+(
+    `id`         bigint unsigned NOT NULL AUTO_INCREMENT,
+    `created_at` datetime(3) DEFAULT NULL,
+    `updated_at` datetime(3) DEFAULT NULL,
+    `deleted_at` datetime(3) DEFAULT NULL,
+    `cursor`     longtext,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+-- +goose Down
+
+DROP TABLE IF EXISTS `object_sync_cursor`;

--- a/db/migrations/sqlite/20260712042758_object_sync_cursor.sql
+++ b/db/migrations/sqlite/20260712042758_object_sync_cursor.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- Create object_sync_cursor table (stores the sealed-data refresh loop cursor)
+CREATE TABLE IF NOT EXISTS `object_sync_cursor`
+(
+    `id`         integer PRIMARY KEY AUTOINCREMENT,
+    `created_at` datetime,
+    `updated_at` datetime,
+    `deleted_at` datetime,
+    `cursor`     text
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS `object_sync_cursor`;

--- a/service/migrator/renterd_client.go
+++ b/service/migrator/renterd_client.go
@@ -125,14 +125,13 @@ func (c *RenterdClient) ListAllObjects(ctx context.Context, bucket string) ([]Re
 // DownloadObject streams an object's data from the renterd worker.
 // The caller must close the returned ReadCloser.
 //
-// The renterd worker route is GET /api/worker/objects/*key where key is
-// a path parameter for the object key. The bucket is passed as a query param.
+// The renterd worker route is GET /api/worker/object/*key (singular "object").
 func (c *RenterdClient) DownloadObject(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
 	values := url.Values{}
 	values.Set("bucket", bucket)
 
 	escapedKey := objectKeyEscape(key)
-	endpoint := fmt.Sprintf("%s/api/worker/objects/%s?%s", c.baseURL, escapedKey, values.Encode())
+	endpoint := fmt.Sprintf("%s/api/worker/object/%s?%s", c.baseURL, escapedKey, values.Encode())
 
 	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {

--- a/service/migrator/renterd_client_test.go
+++ b/service/migrator/renterd_client_test.go
@@ -149,7 +149,7 @@ func TestRenterdClient_ListAllObjects_Pagination(t *testing.T) {
 }
 
 // TestRenterdClient_DownloadObject verifies that the client calls the correct
-// worker endpoint: GET /api/worker/objects/{key}?bucket=...
+// worker endpoint: GET /api/worker/object/{key}?bucket=...
 func TestRenterdClient_DownloadObject(t *testing.T) {
 	var capturedMethod, capturedPath, capturedBucket string
 
@@ -170,7 +170,7 @@ func TestRenterdClient_DownloadObject(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "file contents", string(body))
 	assert.Equal(t, "GET", capturedMethod)
-	assert.Equal(t, "/api/worker/objects/QmTest1", capturedPath)
+	assert.Equal(t, "/api/worker/object/QmTest1", capturedPath)
 	assert.Equal(t, "ipfs", capturedBucket)
 }
 
@@ -192,7 +192,7 @@ func TestRenterdClient_DownloadObject_EscapesKey(t *testing.T) {
 	rc.Close()
 
 	// Leading slash stripped, all slashes and spaces escaped by url.PathEscape
-	assert.Equal(t, "/api/worker/objects/sub%2Fdir%2Ffile%20name.txt", rawPath)
+	assert.Equal(t, "/api/worker/object/sub%2Fdir%2Ffile%20name.txt", rawPath)
 }
 
 // TestRenterdClient_DownloadObject_HTTPError verifies error propagation.


### PR DESCRIPTION
## Problem

Two bugs in the renterd migrator:

1. **404 on download**: The migrator's `DownloadObject` used `/api/worker/objects/{key}` (plural), but renterd v2's worker route is `/api/worker/object/*key` (singular). Every download returned 404.

2. **Missing `object_sync_cursor` table**: The `ObjectSyncCursor` model was registered via `registerModel()` in `db/models/object_sync_cursor.go`, but `GetModels()` is never called for AutoMigrate anywhere in the codebase, and no goose migration was ever created. `RenterService.Init()` queries this table during sealed-data sync → `Error 1146 (42S02): Table 'portal.object_sync_cursor' doesn't exist`.

## Fix

1. Changed download endpoint from `/api/worker/objects/{key}` to `/api/worker/object/{key}`. Confirmed from renterd v2 source (`worker/worker.go:660`):
   ```
   "GET    /object/*key":    w.objectHandlerGET,
   ```

2. Added goose migrations for `object_sync_cursor` in both MySQL and SQLite.

## Test Plan

- [x] `go build ./...` succeeds
- [x] `go test ./service/migrator/...` passes (updated test assertions to match corrected route)
