### PR TITLE
fix: use CamelCase keys in MailConfig.Defaults to match configmanager field lookup

### DIFF
--- a/config/mail.go
+++ b/config/mail.go
@@ -68,13 +68,13 @@ func (m MailConfig) Schema() z.ZogSchema {
 
 func (m MailConfig) Defaults() map[string]interface{} {
 	return map[string]interface{}{
-		"host":       "",
-		"auth_type":  string(mail.SMTPAuthPlain),
-		"port":       25,
-		"ssl":        false,
-		"tls_policy": mail.TLSMandatory.String(),
-		"from":       "",
-		"username":   "",
-		"password":   "",
+		"Host":      "",
+		"AuthType":  string(mail.SMTPAuthPlain),
+		"Port":      25,
+		"SSL":       false,
+		"TLSPolicy": mail.TLSMandatory.String(),
+		"From":      "",
+		"Username":  "",
+		"Password":  "",
 	}
 }


### PR DESCRIPTION
## Summary
- Changed MailConfig.Defaults() map keys from snake_case to CamelCase (e.g. `"auth_type"` -> `"AuthType"`)
- configmanager's DefaultConfigSource.findMatchingField matches defaults keys against Go struct field names case-sensitively, not config tags
- Snake_case keys never matched, so all mail config defaults were silently skipped — AuthType stayed empty, causing SMTP auth to be skipped and MXRoute to reject emails with 550 SMTP AUTH is required
- Audited all other config Defaults() methods — MailConfig was the only one using snake_case keys