### PR TITLE
refactor(core): pass core.Context to KeyIdentityHandler, add IssueChallenge

### DIFF
--- a/core/auth.go
+++ b/core/auth.go
@@ -51,7 +51,14 @@ type AuthService interface {
 	// LoginKeyIdentity authenticates a user with a typed key identity.
 	// keyType is a registry key (e.g., "ethereum").
 	// The key should already be normalized via the type's handler.
+	// The proof must correspond to a challenge previously issued by
+	// the handler's IssueChallenge method.
 	LoginKeyIdentity(ctx context.Context, keyType string, key string, proof []byte, ip string, rememberMe bool) (string, error)
+
+	// LoginKeyIdentityWithContext is the preferred method for key identity
+	// login, as it passes core.Context to the handler for challenge
+	// verification. LoginKeyIdentity delegates to this.
+	LoginKeyIdentityWithContext(ctx Context, keyType string, key string, proof []byte, ip string, rememberMe bool) (string, error)
 
 	// LoginID authenticates a user with the provided user ID.
 	// It returns the generated JWT token if successful.

--- a/core/context.go
+++ b/core/context.go
@@ -41,6 +41,11 @@ type Context interface {
 	SetExitCode(code int)
 	GetContext() context.Context
 
+	// WithRequestContext returns a new Context that wraps the given request
+	// context, preserving request-scoped cancellation, deadlines, and trace
+	// metadata while retaining access to core services, config, DB, and logger.
+	WithRequestContext(ctx context.Context) Context
+
 	// Event helpers
 	Fire(eventName string, payload any) error
 	MustFire(eventName string, payload any)
@@ -256,7 +261,7 @@ func (ctx *DefaultContext) WithLogger(opts ...zap.Field) *Logger {
 
 // Tracer helpers implementation
 func (ctx *DefaultContext) WithTracer(service, subsystem string) Context {
-	return ctx.withNewContext(WithTracerInfo(ctx.Context, service, subsystem))
+	return ctx.WithRequestContext(WithTracerInfo(ctx.Context, service, subsystem))
 }
 
 func (ctx *DefaultContext) WithTracerService(service string) Context {
@@ -271,10 +276,12 @@ func (ctx *DefaultContext) TraceMethod(name string, opts ...SpanOption) (context
 	return TraceMethod(ctx.Context, name, opts...)
 }
 
-// Helper function to create a new DefaultContext with modified context
-func (ctx *DefaultContext) withNewContext(newCtx context.Context) Context {
+// WithRequestContext returns a new Context that wraps the given request
+// context, preserving request-scoped cancellation, deadlines, and trace
+// metadata while retaining access to core services, config, DB, and logger.
+func (ctx *DefaultContext) WithRequestContext(reqCtx context.Context) Context {
 	return &DefaultContext{
-		Context:      newCtx,
+		Context:      reqCtx,
 		services:     ctx.services,
 		cfg:          ctx.cfg,
 		db:           ctx.db,
@@ -289,36 +296,36 @@ func (ctx *DefaultContext) withNewContext(newCtx context.Context) Context {
 
 // Dedicated component tracer helpers implementation
 func (ctx *DefaultContext) WithProtocolTracer(protocolName string) Context {
-	return ctx.withNewContext(WithProtocolTracer(ctx.Context, protocolName))
+	return ctx.WithRequestContext(WithProtocolTracer(ctx.Context, protocolName))
 }
 
 func (ctx *DefaultContext) WithAPITracer(apiName string) Context {
-	return ctx.withNewContext(WithAPITracer(ctx.Context, apiName))
+	return ctx.WithRequestContext(WithAPITracer(ctx.Context, apiName))
 }
 
 func (ctx *DefaultContext) WithAPIExtensionTracer(extensionName string) Context {
-	return ctx.withNewContext(WithAPIExtensionTracer(ctx.Context, extensionName))
+	return ctx.WithRequestContext(WithAPIExtensionTracer(ctx.Context, extensionName))
 }
 
 func (ctx *DefaultContext) WithServiceTracer(serviceName string) Context {
-	return ctx.withNewContext(WithServiceTracer(ctx.Context, serviceName))
+	return ctx.WithRequestContext(WithServiceTracer(ctx.Context, serviceName))
 }
 
 // Subcomponent tracer helpers implementation
 func (ctx *DefaultContext) WithProtocolSubcomponent(protocolName, subcomponentName string) Context {
-	return ctx.withNewContext(WithProtocolSubcomponent(ctx.Context, protocolName, subcomponentName))
+	return ctx.WithRequestContext(WithProtocolSubcomponent(ctx.Context, protocolName, subcomponentName))
 }
 
 func (ctx *DefaultContext) WithAPISubcomponent(apiName, subcomponentName string) Context {
-	return ctx.withNewContext(WithAPISubcomponent(ctx.Context, apiName, subcomponentName))
+	return ctx.WithRequestContext(WithAPISubcomponent(ctx.Context, apiName, subcomponentName))
 }
 
 func (ctx *DefaultContext) WithAPIExtensionSubcomponent(extensionName, subcomponentName string) Context {
-	return ctx.withNewContext(WithAPIExtensionSubcomponent(ctx.Context, extensionName, subcomponentName))
+	return ctx.WithRequestContext(WithAPIExtensionSubcomponent(ctx.Context, extensionName, subcomponentName))
 }
 
 func (ctx *DefaultContext) WithServiceSubcomponent(serviceName, subcomponentName string) Context {
-	return ctx.withNewContext(WithServiceSubcomponent(ctx.Context, serviceName, subcomponentName))
+	return ctx.WithRequestContext(WithServiceSubcomponent(ctx.Context, serviceName, subcomponentName))
 }
 
 // ContextBuilderOption and related functions

--- a/core/internal/service_tests/auth_test.go
+++ b/core/internal/service_tests/auth_test.go
@@ -217,7 +217,10 @@ func (h *testKeyIdentityHandler) NormalizeKey(key string) (string, error) { retu
 func (h *testKeyIdentityHandler) ValidateMetadata(metadata json.RawMessage) (json.RawMessage, error) {
 	return metadata, nil
 }
-func (h *testKeyIdentityHandler) VerifyProof(ctx context.Context, key string, metadata json.RawMessage, proof []byte) error {
+func (h *testKeyIdentityHandler) IssueChallenge(ctx core.Context, key string, metadata json.RawMessage) ([]byte, error) {
+	return []byte("challenge"), nil
+}
+func (h *testKeyIdentityHandler) VerifyProof(ctx core.Context, key string, metadata json.RawMessage, proof []byte) error {
 	return nil
 }
 
@@ -228,7 +231,10 @@ func (h *failingProofHandler) NormalizeKey(key string) (string, error) { return 
 func (h *failingProofHandler) ValidateMetadata(metadata json.RawMessage) (json.RawMessage, error) {
 	return metadata, nil
 }
-func (h *failingProofHandler) VerifyProof(ctx context.Context, key string, metadata json.RawMessage, proof []byte) error {
+func (h *failingProofHandler) IssueChallenge(ctx core.Context, key string, metadata json.RawMessage) ([]byte, error) {
+	return []byte("challenge"), nil
+}
+func (h *failingProofHandler) VerifyProof(ctx core.Context, key string, metadata json.RawMessage, proof []byte) error {
 	return fmt.Errorf("proof verification failed")
 }
 
@@ -242,7 +248,10 @@ func (h *nilMetadataCapturingHandler) NormalizeKey(key string) (string, error) {
 func (h *nilMetadataCapturingHandler) ValidateMetadata(metadata json.RawMessage) (json.RawMessage, error) {
 	return metadata, nil
 }
-func (h *nilMetadataCapturingHandler) VerifyProof(ctx context.Context, key string, metadata json.RawMessage, proof []byte) error {
+func (h *nilMetadataCapturingHandler) IssueChallenge(ctx core.Context, key string, metadata json.RawMessage) ([]byte, error) {
+	return []byte("challenge"), nil
+}
+func (h *nilMetadataCapturingHandler) VerifyProof(ctx core.Context, key string, metadata json.RawMessage, proof []byte) error {
 	h.receivedMetadata = metadata
 	return nil
 }

--- a/core/key_identity.go
+++ b/core/key_identity.go
@@ -9,9 +9,17 @@ import (
 )
 
 // KeyIdentityHandler defines how a specific key type (e.g., "ethereum",
-// "solana") validates and normalizes its keys and metadata.
+// "solana") validates and normalizes its keys and metadata, issues challenges,
+// and verifies proofs of ownership.
+//
 // Handlers are registered by plugins via PluginInfo.KeyIdentityHandlers
-// and looked up by type string.
+// and looked up by type string. All methods that need runtime context
+// receive a core.Context, which embeds context.Context and provides
+// access to config, DB, logger, and registered services.
+//
+// This interface is intentionally minimal so that core can orchestrate
+// a generic challenge → verify → lookup → login flow without knowing
+// the cryptographic details of any specific key type.
 type KeyIdentityHandler interface {
 	// NormalizeKey converts a raw key to its canonical form.
 	// For Ethereum: lowercase the 0x-prefixed address.
@@ -24,10 +32,31 @@ type KeyIdentityHandler interface {
 	// Returns the normalized metadata, or an error if invalid.
 	ValidateMetadata(metadata json.RawMessage) (json.RawMessage, error)
 
+	// IssueChallenge generates a challenge for proving ownership of the
+	// given key. The returned bytes are sent to the client, which must
+	// sign them and return the signature via VerifyProof.
+	//
+	// For Ethereum (CAIP-122/EIP-4361): this generates a nonce and
+	// constructs the SIWE message text for the client to sign.
+	// For WebAuthn: this generates the assertion challenge options.
+	//
+	// The challenge state (nonce, etc.) must be stored by the handler
+	// using ctx (e.g., via ctx.DB() or a registered challenge store service)
+	// so that VerifyProof can validate it.
+	IssueChallenge(ctx Context, key string, metadata json.RawMessage) ([]byte, error)
+
 	// VerifyProof verifies a cryptographic proof of key ownership.
-	// For Ethereum: this is the CAIP-122 signature verification flow.
-	// The proof bytes are protocol-specific (EIP-191 signature, etc.).
-	VerifyProof(ctx context.Context, key string, metadata json.RawMessage, proof []byte) error
+	//
+	// The proof bytes are protocol-specific and must correspond to a
+	// challenge previously issued by IssueChallenge. The handler is
+	// responsible for looking up the stored challenge state via ctx
+	// and performing the cryptographic verification.
+	//
+	// For Ethereum: this is the EIP-191 signature recovery and address
+	// comparison, with nonce/domain validation from the stored challenge.
+	// For WebAuthn: this verifies the assertion signature against the
+	// stored credential.
+	VerifyProof(ctx Context, key string, metadata json.RawMessage, proof []byte) error
 }
 
 var (
@@ -108,3 +137,6 @@ func RegisterKeyIdentityHandlersFromPlugins() {
 		}
 	}
 }
+
+// Ensure context import is used (for godoc examples and future helpers).
+var _ context.Context = (Context)(nil)

--- a/core/key_identity_test.go
+++ b/core/key_identity_test.go
@@ -1,94 +1,113 @@
 package core
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
+
+	"go.lumeweb.com/portal/build"
 )
 
-// mockHandler is a minimal handler for testing the registry.
-type mockHandler struct{}
+// mockHandler is a minimal KeyIdentityHandler for testing.
+type mockHandler struct {
+	challengeFn func(ctx Context, key string, metadata json.RawMessage) ([]byte, error)
+	verifyFn    func(ctx Context, key string, metadata json.RawMessage, proof []byte) error
+}
 
 func (h *mockHandler) NormalizeKey(key string) (string, error) { return key, nil }
 func (h *mockHandler) ValidateMetadata(metadata json.RawMessage) (json.RawMessage, error) {
 	return metadata, nil
 }
-func (h *mockHandler) VerifyProof(ctx context.Context, key string, metadata json.RawMessage, proof []byte) error {
+func (h *mockHandler) IssueChallenge(ctx Context, key string, metadata json.RawMessage) ([]byte, error) {
+	if h.challengeFn != nil {
+		return h.challengeFn(ctx, key, metadata)
+	}
+	return []byte("challenge"), nil
+}
+func (h *mockHandler) VerifyProof(ctx Context, key string, metadata json.RawMessage, proof []byte) error {
+	if h.verifyFn != nil {
+		return h.verifyFn(ctx, key, metadata, proof)
+	}
 	return nil
 }
 
 func TestRegisterAndGetKeyIdentityHandler(t *testing.T) {
-	keyType := "test_type"
+	ResetKeyIdentities()
+	defer ResetKeyIdentities()
 
-	// Register
+	keyType := "test_type"
 	RegisterKeyIdentity(keyType, &mockHandler{})
 
-	// Get -- should exist
 	h, ok := GetKeyIdentityHandler(keyType)
 	if !ok {
-		t.Fatal("expected handler to be registered")
+		t.Fatalf("expected handler for %q", keyType)
 	}
 	if h == nil {
-		t.Fatal("handler should not be nil")
+		t.Fatal("handler is nil")
 	}
 
-	// Get nonexistent
 	_, ok = GetKeyIdentityHandler("nonexistent")
 	if ok {
-		t.Fatal("expected handler to not be registered for nonexistent type")
+		t.Fatal("expected no handler for nonexistent type")
 	}
 }
 
 func TestMustGetKeyIdentityHandler_Panics(t *testing.T) {
+	ResetKeyIdentities()
+	defer ResetKeyIdentities()
+
 	defer func() {
 		if r := recover(); r == nil {
-			t.Fatal("expected panic for unregistered type")
+			t.Fatal("expected panic for unregistered handler")
 		}
 	}()
 	MustGetKeyIdentityHandler("definitely_not_registered")
 }
 
 func TestRegisterKeyIdentityHandlersFromPlugins(t *testing.T) {
-	// Register a plugin with a key identity handler
+	ResetState()
+	defer ResetState()
+
 	RegisterPlugin(PluginInfo{
-		ID: "test-plugin-keyidentity",
+		ID:      "test-plugin",
+		Version: build.New("test-version", "", "", "", "", "", ""),
 		KeyIdentityHandlers: []KeyIdentityHandlerRegistration{
 			{Type: "test_plugin_type", Handler: &mockHandler{}},
 		},
 	})
-	defer UnregisterPlugin("test-plugin-keyidentity")
 
 	RegisterKeyIdentityHandlersFromPlugins()
 
 	h, ok := GetKeyIdentityHandler("test_plugin_type")
-	if !ok {
-		t.Fatal("expected handler to be registered from plugin")
-	}
-	if h == nil {
-		t.Fatal("handler should not be nil")
+	if !ok || h == nil {
+		t.Fatalf("expected handler registered for test_plugin_type")
 	}
 }
 
 func TestRegisterKeyIdentityHandlersFromPlugins_DoesNotOverwriteExistingHandler(t *testing.T) {
-	// Manually register a handler first
+	ResetState()
+	defer ResetState()
+
+	// Register a pre-existing handler
 	RegisterKeyIdentity("preexisting_type", &mockHandler{})
 
-	// Register a plugin with a different type — should not touch preexisting
 	RegisterPlugin(PluginInfo{
-		ID: "test-plugin-no-overwrite",
+		ID:      "test-plugin-2",
+		Version: build.New("test-version", "", "", "", "", "", ""),
 		KeyIdentityHandlers: []KeyIdentityHandlerRegistration{
+			{Type: "preexisting_type", Handler: &mockHandler{}},
 			{Type: "plugin_type", Handler: &mockHandler{}},
 		},
 	})
-	defer UnregisterPlugin("test-plugin-no-overwrite")
 
 	RegisterKeyIdentityHandlersFromPlugins()
 
-	// Both should exist
+	// Should still exist
 	_, ok := GetKeyIdentityHandler("preexisting_type")
 	if !ok {
 		t.Fatal("pre-existing handler should still be registered")
 	}
+
+	// Plugin type should also be registered
 	_, ok = GetKeyIdentityHandler("plugin_type")
 	if !ok {
 		t.Fatal("plugin handler should be registered")
@@ -114,6 +133,9 @@ func TestRegisterKeyIdentity_EmptyTypePanics(t *testing.T) {
 }
 
 func TestRegisterKeyIdentityHandlersFromPlugins_SkipsInvalidEntries(t *testing.T) {
+	ResetState()
+	defer ResetState()
+
 	RegisterPlugin(PluginInfo{
 		ID: "test-plugin-invalid-entries",
 		KeyIdentityHandlers: []KeyIdentityHandlerRegistration{
@@ -122,7 +144,6 @@ func TestRegisterKeyIdentityHandlersFromPlugins_SkipsInvalidEntries(t *testing.T
 			{Type: "valid_plugin_type", Handler: &mockHandler{}}, // valid
 		},
 	})
-	defer UnregisterPlugin("test-plugin-invalid-entries")
 
 	RegisterKeyIdentityHandlersFromPlugins()
 

--- a/core/testing/context.go
+++ b/core/testing/context.go
@@ -58,6 +58,35 @@ type defaultContext struct {
 	router       router.Router
 }
 
+// WithRequestContext returns a new testContext wrapping the given request
+// context, preserving request-scoped cancellation and trace metadata.
+func (ctx *testContext) WithRequestContext(reqCtx context.Context) core.Context {
+	return ctx.withRequestContext(reqCtx)
+}
+
+func (ctx *testContext) withRequestContext(reqCtx context.Context) *testContext {
+	return &testContext{
+		defaultContext: &defaultContext{
+			Context:      reqCtx,
+			services:     ctx.services,
+			cfg:          ctx.cfg,
+			logger:       ctx.logger,
+			exitFuncs:    ctx.exitFuncs,
+			exitCode:     ctx.exitCode,
+			startupFuncs: ctx.startupFuncs,
+			db:           ctx.db,
+			cancel:       ctx.cancel,
+			event:        ctx.event,
+			router:       ctx.router,
+		},
+		tb:               ctx.tb,
+		cleanupFuncs:     ctx.cleanupFuncs,
+		apiID:            ctx.apiID,
+		fireBootComplete: ctx.fireBootComplete,
+		httpDone:         ctx.httpDone,
+	}
+}
+
 // testContext extends the default context for testing
 type testContext struct {
 	*defaultContext

--- a/core/testing/mock_auth.go
+++ b/core/testing/mock_auth.go
@@ -248,6 +248,15 @@ func (m *MockAuthService) LoginKeyIdentity(ctx context.Context, keyType string, 
 	return m.generateTestToken(1), nil
 }
 
+// LoginKeyIdentityWithContext implements core.AuthService.
+// Lazily generates default token if no expectation set.
+func (m *MockAuthService) LoginKeyIdentityWithContext(ctx core.Context, keyType string, key string, proof []byte, ip string, rememberMe bool) (string, error) {
+	if HasExpectationForMethod(&m.MockAuthService.Mock, "LoginKeyIdentityWithContext") {
+		return m.MockAuthService.LoginKeyIdentityWithContext(ctx, keyType, key, proof, ip, rememberMe)
+	}
+	return m.generateTestToken(1), nil
+}
+
 // ValidLoginByUserObj implements core.AuthService.
 func (m *MockAuthService) ValidLoginByUserObj(ctx context.Context, user *models.User, password string) bool {
 	return m.validatePasswordHash(user.PasswordHash, password)

--- a/core/testing/mocks/AuthService.go
+++ b/core/testing/mocks/AuthService.go
@@ -437,6 +437,96 @@ func (_c *MockAuthService_LoginKeyIdentity_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// LoginKeyIdentityWithContext provides a mock function for the type MockAuthService
+func (_mock *MockAuthService) LoginKeyIdentityWithContext(ctx core.Context, keyType string, key string, proof []byte, ip string, rememberMe bool) (string, error) {
+	ret := _mock.Called(ctx, keyType, key, proof, ip, rememberMe)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LoginKeyIdentityWithContext")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(core.Context, string, string, []byte, string, bool) (string, error)); ok {
+		return returnFunc(ctx, keyType, key, proof, ip, rememberMe)
+	}
+	if returnFunc, ok := ret.Get(0).(func(core.Context, string, string, []byte, string, bool) string); ok {
+		r0 = returnFunc(ctx, keyType, key, proof, ip, rememberMe)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(core.Context, string, string, []byte, string, bool) error); ok {
+		r1 = returnFunc(ctx, keyType, key, proof, ip, rememberMe)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockAuthService_LoginKeyIdentityWithContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoginKeyIdentityWithContext'
+type MockAuthService_LoginKeyIdentityWithContext_Call struct {
+	*mock.Call
+}
+
+// LoginKeyIdentityWithContext is a helper method to define mock.On call
+//   - ctx core.Context
+//   - keyType string
+//   - key string
+//   - proof []byte
+//   - ip string
+//   - rememberMe bool
+func (_e *MockAuthService_Expecter) LoginKeyIdentityWithContext(ctx interface{}, keyType interface{}, key interface{}, proof interface{}, ip interface{}, rememberMe interface{}) *MockAuthService_LoginKeyIdentityWithContext_Call {
+	return &MockAuthService_LoginKeyIdentityWithContext_Call{Call: _e.mock.On("LoginKeyIdentityWithContext", ctx, keyType, key, proof, ip, rememberMe)}
+}
+
+func (_c *MockAuthService_LoginKeyIdentityWithContext_Call) Run(run func(ctx core.Context, keyType string, key string, proof []byte, ip string, rememberMe bool)) *MockAuthService_LoginKeyIdentityWithContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 core.Context
+		if args[0] != nil {
+			arg0 = args[0].(core.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 []byte
+		if args[3] != nil {
+			arg3 = args[3].([]byte)
+		}
+		var arg4 string
+		if args[4] != nil {
+			arg4 = args[4].(string)
+		}
+		var arg5 bool
+		if args[5] != nil {
+			arg5 = args[5].(bool)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+		)
+	})
+	return _c
+}
+
+func (_c *MockAuthService_LoginKeyIdentityWithContext_Call) Return(s string, err error) *MockAuthService_LoginKeyIdentityWithContext_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockAuthService_LoginKeyIdentityWithContext_Call) RunAndReturn(run func(ctx core.Context, keyType string, key string, proof []byte, ip string, rememberMe bool) (string, error)) *MockAuthService_LoginKeyIdentityWithContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LoginOTP provides a mock function for the type MockAuthService
 func (_mock *MockAuthService) LoginOTP(ctx context.Context, userId uint, code string, rememberMe bool) (string, error) {
 	ret := _mock.Called(ctx, userId, code, rememberMe)

--- a/core/testing/mocks/Context.go
+++ b/core/testing/mocks/Context.go
@@ -1860,6 +1860,59 @@ func (_c *MockContext_WithProtocolTracer_Call) RunAndReturn(run func(protocolNam
 	return _c
 }
 
+// WithRequestContext provides a mock function for the type MockContext
+func (_mock *MockContext) WithRequestContext(ctx context.Context) core.Context {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithRequestContext")
+	}
+
+	var r0 core.Context
+	if returnFunc, ok := ret.Get(0).(func(context.Context) core.Context); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(core.Context)
+		}
+	}
+	return r0
+}
+
+// MockContext_WithRequestContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithRequestContext'
+type MockContext_WithRequestContext_Call struct {
+	*mock.Call
+}
+
+// WithRequestContext is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockContext_Expecter) WithRequestContext(ctx interface{}) *MockContext_WithRequestContext_Call {
+	return &MockContext_WithRequestContext_Call{Call: _e.mock.On("WithRequestContext", ctx)}
+}
+
+func (_c *MockContext_WithRequestContext_Call) Run(run func(ctx context.Context)) *MockContext_WithRequestContext_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockContext_WithRequestContext_Call) Return(context1 core.Context) *MockContext_WithRequestContext_Call {
+	_c.Call.Return(context1)
+	return _c
+}
+
+func (_c *MockContext_WithRequestContext_Call) RunAndReturn(run func(ctx context.Context) core.Context) *MockContext_WithRequestContext_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WithServiceSubcomponent provides a mock function for the type MockContext
 func (_mock *MockContext) WithServiceSubcomponent(serviceName string, subcomponentName string) core.Context {
 	ret := _mock.Called(serviceName, subcomponentName)

--- a/service/auth.go
+++ b/service/auth.go
@@ -99,7 +99,11 @@ func (a AuthServiceDefault) LoginOTP(ctx context.Context, userId uint, code stri
 }
 
 func (a AuthServiceDefault) LoginKeyIdentity(ctx context.Context, keyType string, key string, proof []byte, ip string, rememberMe bool) (string, error) {
-	ctx, span := core.TraceMethod(ctx, "AuthServiceDefault.LoginKeyIdentity")
+	return a.LoginKeyIdentityWithContext(a.Context().WithRequestContext(ctx), keyType, key, proof, ip, rememberMe)
+}
+
+func (a AuthServiceDefault) LoginKeyIdentityWithContext(ctx core.Context, keyType string, key string, proof []byte, ip string, rememberMe bool) (string, error) {
+	traceCtx, span := core.TraceMethod(ctx, "AuthServiceDefault.LoginKeyIdentityWithContext")
 	defer span.End()
 
 	// Require a registered handler — no handler means we can't normalize or verify
@@ -119,7 +123,7 @@ func (a AuthServiceDefault) LoginKeyIdentity(ctx context.Context, keyType string
 	var rowsAffected int64
 
 	err = db.RetryableComponentTransaction(a, ctx, func(tx *gorm.DB) *gorm.DB {
-		tx = tx.WithContext(ctx).Model(&models.KeyIdentity{}).Preload("User").
+		tx = tx.WithContext(traceCtx).Model(&models.KeyIdentity{}).Preload("User").
 			Where(&models.KeyIdentity{Type: keyType, Key: key}).First(&model)
 		rowsAffected = tx.RowsAffected
 		return tx
@@ -144,7 +148,7 @@ func (a AuthServiceDefault) LoginKeyIdentity(ctx context.Context, keyType string
 
 	user := model.User
 
-	token, err := a.doLogin(ctx, &user, ip, true, rememberMe)
+	token, err := a.doLogin(traceCtx, &user, ip, true, rememberMe)
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary

Refactors the `KeyIdentityHandler` interface to fix a design flaw where handlers needed runtime dependencies (domain, nonce store, config) but were registered statically via `PluginInfo` at boot time before any context existed.

## Changes

### `KeyIdentityHandler` interface (`core/key_identity.go`)
- **Added `IssueChallenge(ctx Context, key, metadata) ([]byte, error)`** — completes the two-step challenge → verify lifecycle. Handlers generate and store challenge state (nonce, etc.) using `ctx`.
- **Changed `VerifyProof` signature** from `context.Context` to `core.Context` — gives handlers access to config, DB, logger, and registered services at call time.
- All handler methods that need runtime context now receive `core.Context` as a parameter — no globals, no construction-time injection.

### `AuthService` interface (`core/auth.go`)
- **Added `LoginKeyIdentityWithContext(ctx Context, ...)`** — the preferred method that passes `core.Context` to the handler.
- `LoginKeyIdentity(ctx context.Context, ...)` is kept for backward compatibility and delegates to `LoginKeyIdentityWithContext` via `a.Context()`.

### Mocks
- Regenerated `AuthService` mock via mockery to include `LoginKeyIdentityWithContext`.
- Updated `mock_auth.go` helper with `LoginKeyIdentityWithContext` delegation.

### Tests
- Updated all test handler implementations (`testKeyIdentityHandler`, `failingProofHandler`, `nilMetadataCapturingHandler`, `mockHandler`) to implement `IssueChallenge` and use `core.Context`.

## Why

The previous design required the `EthereumHandler` to use a package-level `domainHolder string` global to access the portal domain — set during the `Meta` boot callback. This was:
- Not thread-safe
- Not testable in isolation
- Not scalable to other key types needing runtime deps

With `core.Context` passed as a method parameter, handlers can resolve all dependencies at call time via `ctx.Config()`, `ctx.DB()`, `core.GetService()`, etc.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./core/...` passes (all packages)
- [ ] Dashboard plugin compilation (separate PR)
- [ ] Billing plugin adaptation (separate PR)

---

<!-- kody-pr-summary:start -->
 **Title:** refactor(core): pass core.Context to KeyIdentityHandler, add IssueChallenge

**Description:**

This pull request refactors the key identity authentication flow to support a complete challenge-response lifecycle and gives key identity handlers access to the portal runtime context.

**What changed:**

- Added `IssueChallenge` to the `KeyIdentityHandler` interface, allowing handlers to generate protocol-specific challenges (e.g., SIWE messages for Ethereum, assertion options for WebAuthn).
- Changed `VerifyProof` to accept `core.Context` instead of `context.Context`, enabling handlers to access configuration, database, logger, and registered services during proof verification.
- Added `LoginKeyIdentityWithContext` to `AuthService` as the preferred context-aware login path; the existing `LoginKeyIdentity` now delegates to it.
- Updated the default auth service implementation to use `core.Context` for tracing and pass it through to the key identity handler.
- Updated tests and mocks to reflect the new interface signatures.

**Functional impact:**

Key identity handlers can now orchestrate a full challenge → verify → lookup → login flow, including storing and retrieving challenge state via the portal context. This enables robust cryptographic login methods such as SIWE/EIP-4361 and WebAuthn.
<!-- kody-pr-summary:end -->