### PR TITLE
feat(user): add RemoveKeyIdentity and ListKeyIdentities methods

### DIFF
--- a/core/internal/service_tests/user_test.go
+++ b/core/internal/service_tests/user_test.go
@@ -516,7 +516,7 @@ func TestUserService_RemoveKeyIdentity_NotFound(t *testing.T) {
 		assert.Error(tb, err)
 		coreErr, ok := err.(*core.Error)
 		require.True(tb, ok, "expected *core.Error")
-		assert.Equal(tb, core.ErrKeyInvalidLogin, coreErr.Key)
+		assert.Equal(tb, core.ErrKeyKeyIdentityNotFound, coreErr.Key)
 	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
 }
 
@@ -546,7 +546,7 @@ func TestUserService_RemoveKeyIdentity_DoesNotBelongToUser(t *testing.T) {
 		assert.Error(tb, err)
 		coreErr, ok := err.(*core.Error)
 		require.True(tb, ok, "expected *core.Error")
-		assert.Equal(tb, core.ErrKeyInvalidLogin, coreErr.Key)
+		assert.Equal(tb, core.ErrKeyKeyIdentityNotFound, coreErr.Key)
 
 		// Verify the key still exists for user 1
 		var count int64
@@ -570,7 +570,7 @@ func TestUserService_RemoveKeyIdentity_NoHandlerReturnsAccountError(t *testing.T
 		assert.Error(tb, err)
 		coreErr, ok := err.(*core.Error)
 		require.True(tb, ok, "expected *core.Error")
-		assert.Equal(tb, core.ErrKeyAddKeyIdentityFailed, coreErr.Key)
+		assert.Equal(tb, core.ErrKeyKeyIdentityNotFound, coreErr.Key)
 	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
 }
 

--- a/core/internal/service_tests/user_test.go
+++ b/core/internal/service_tests/user_test.go
@@ -357,7 +357,7 @@ func TestUserService_AddKeyIdentity_NilMetadataDefaultsToEmptyJSON(t *testing.T)
 		require.NoError(tb, err)
 
 		// Add key identity with nil metadata
-		err = userService.AddKeyIdentity(context.Background(), *user, "ethereum", "0x1234567890abcdef1234567890abcdef12345678", nil)
+		err = userService.AddKeyIdentity(context.Background(), user.ID, "ethereum", "0x1234567890abcdef1234567890abcdef12345678", nil)
 		require.NoError(tb, err)
 
 		// Verify the stored metadata is {} not NULL
@@ -387,7 +387,7 @@ func TestUserService_AddKeyIdentity_HandlerValidatesMetadata(t *testing.T) {
 		require.NoError(tb, err)
 
 		// Add key identity with valid metadata
-		err = userService.AddKeyIdentity(context.Background(), *user, "ethereum", "0xabcdef1234567890abcdef1234567890abcdef12", json.RawMessage(`{"chain_id":"eip155:1"}`))
+		err = userService.AddKeyIdentity(context.Background(), user.ID, "ethereum", "0xabcdef1234567890abcdef1234567890abcdef12", json.RawMessage(`{"chain_id":"eip155:1"}`))
 		require.NoError(tb, err)
 
 		// Verify stored metadata
@@ -415,11 +415,11 @@ func TestUserService_AddKeyIdentity_DuplicateKey(t *testing.T) {
 		require.NoError(tb, err)
 
 		key := "0x9999999999999999999999999999999999999999"
-		err = userService.AddKeyIdentity(context.Background(), *user, "ethereum", key, nil)
+		err = userService.AddKeyIdentity(context.Background(), user.ID, "ethereum", key, nil)
 		require.NoError(tb, err)
 
 		// Adding same key again should fail with ErrKeyKeyIdentityExists
-		err = userService.AddKeyIdentity(context.Background(), *user, "ethereum", key, nil)
+		err = userService.AddKeyIdentity(context.Background(), user.ID, "ethereum", key, nil)
 		assert.Error(tb, err)
 		coreErr, ok := err.(*core.Error)
 		require.True(tb, ok, "expected *core.Error")
@@ -442,7 +442,7 @@ func TestUserService_AddKeyIdentity_NoHandlerReturnsAccountError(t *testing.T) {
 		err = ctx.DB().Create(user).Error
 		require.NoError(tb, err)
 
-		err = userService.AddKeyIdentity(context.Background(), *user, "ethereum", "0x1234567890abcdef1234567890abcdef12345678", nil)
+		err = userService.AddKeyIdentity(context.Background(), user.ID, "ethereum", "0x1234567890abcdef1234567890abcdef12345678", nil)
 		assert.Error(tb, err)
 		coreErr, ok := err.(*core.Error)
 		require.True(tb, ok, "expected *core.Error")
@@ -461,5 +461,158 @@ func TestUserService_KeyIdentityExists_NoHandlerReturnsAccountError(t *testing.T
 		coreErr, ok := err.(*core.Error)
 		require.True(tb, ok, "expected *core.Error")
 		assert.Equal(tb, core.ErrKeyInvalidLogin, coreErr.Key)
+	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
+}
+
+func TestUserService_RemoveKeyIdentity_Success(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userService := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userService)
+
+		coreTesting.WithKeyIdentityHandler("ethereum", &testKeyIdentityHandler{})(ctx)
+
+		hashedCredential, err := bcrypt.GenerateFromPassword([]byte(testKeyIdentitySecret()), bcrypt.DefaultCost)
+		require.NoError(tb, err)
+		user := &models.User{
+			Email:        "remove-key@example.com",
+			PasswordHash: string(hashedCredential),
+		}
+		err = ctx.DB().Create(user).Error
+		require.NoError(tb, err)
+
+		key := "0xaaaa1111bbbb2222cccc3333dddd4444eeee5555"
+		err = userService.AddKeyIdentity(context.Background(), user.ID, "ethereum", key, nil)
+		require.NoError(tb, err)
+
+		// Remove the key
+		err = userService.RemoveKeyIdentity(context.Background(), user.ID, "ethereum", key)
+		require.NoError(tb, err)
+
+		// Verify it's gone
+		var count int64
+		ctx.DB().Model(&models.KeyIdentity{}).Where("user_id = ? AND type = ? AND key = ?", user.ID, "ethereum", key).Count(&count)
+		assert.Equal(tb, int64(0), count)
+	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
+}
+
+func TestUserService_RemoveKeyIdentity_NotFound(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userService := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userService)
+
+		coreTesting.WithKeyIdentityHandler("ethereum", &testKeyIdentityHandler{})(ctx)
+
+		hashedCredential, err := bcrypt.GenerateFromPassword([]byte(testKeyIdentitySecret()), bcrypt.DefaultCost)
+		require.NoError(tb, err)
+		user := &models.User{
+			Email:        "remove-notfound@example.com",
+			PasswordHash: string(hashedCredential),
+		}
+		err = ctx.DB().Create(user).Error
+		require.NoError(tb, err)
+
+		// Remove a key that doesn't exist
+		err = userService.RemoveKeyIdentity(context.Background(), user.ID, "ethereum", "0x9999888877776666555544443333222211110000")
+		assert.Error(tb, err)
+		coreErr, ok := err.(*core.Error)
+		require.True(tb, ok, "expected *core.Error")
+		assert.Equal(tb, core.ErrKeyInvalidLogin, coreErr.Key)
+	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
+}
+
+func TestUserService_RemoveKeyIdentity_DoesNotBelongToUser(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userService := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userService)
+
+		coreTesting.WithKeyIdentityHandler("ethereum", &testKeyIdentityHandler{})(ctx)
+
+		// Create two users
+		hashedCred, err := bcrypt.GenerateFromPassword([]byte(testKeyIdentitySecret()), bcrypt.DefaultCost)
+		require.NoError(tb, err)
+		user1 := &models.User{Email: "rm-user1@example.com", PasswordHash: string(hashedCred)}
+		user2 := &models.User{Email: "rm-user2@example.com", PasswordHash: string(hashedCred)}
+		err = ctx.DB().Create(user1).Error
+		require.NoError(tb, err)
+		err = ctx.DB().Create(user2).Error
+		require.NoError(tb, err)
+
+		key := "0xbbbb1111cccc2222dddd3333eeee4444ffff5555"
+		err = userService.AddKeyIdentity(context.Background(), user1.ID, "ethereum", key, nil)
+		require.NoError(tb, err)
+
+		// User 2 tries to remove user 1's key — should fail (not found for user 2)
+		err = userService.RemoveKeyIdentity(context.Background(), user2.ID, "ethereum", key)
+		assert.Error(tb, err)
+		coreErr, ok := err.(*core.Error)
+		require.True(tb, ok, "expected *core.Error")
+		assert.Equal(tb, core.ErrKeyInvalidLogin, coreErr.Key)
+
+		// Verify the key still exists for user 1
+		var count int64
+		ctx.DB().Model(&models.KeyIdentity{}).Where("user_id = ? AND key = ?", user1.ID, key).Count(&count)
+		assert.Equal(tb, int64(1), count)
+	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
+}
+
+func TestUserService_RemoveKeyIdentity_NoHandlerReturnsAccountError(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userService := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userService)
+
+		hashedCred, err := bcrypt.GenerateFromPassword([]byte(testKeyIdentitySecret()), bcrypt.DefaultCost)
+		require.NoError(tb, err)
+		user := &models.User{Email: "rm-nohandler@example.com", PasswordHash: string(hashedCred)}
+		err = ctx.DB().Create(user).Error
+		require.NoError(tb, err)
+
+		err = userService.RemoveKeyIdentity(context.Background(), user.ID, "ethereum", "0x1234567890abcdef1234567890abcdef12345678")
+		assert.Error(tb, err)
+		coreErr, ok := err.(*core.Error)
+		require.True(tb, ok, "expected *core.Error")
+		assert.Equal(tb, core.ErrKeyAddKeyIdentityFailed, coreErr.Key)
+	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
+}
+
+func TestUserService_ListKeyIdentities_Success(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userService := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userService)
+
+		coreTesting.WithKeyIdentityHandler("ethereum", &testKeyIdentityHandler{})(ctx)
+
+		hashedCred, err := bcrypt.GenerateFromPassword([]byte(testKeyIdentitySecret()), bcrypt.DefaultCost)
+		require.NoError(tb, err)
+		user := &models.User{Email: "list-keys@example.com", PasswordHash: string(hashedCred)}
+		err = ctx.DB().Create(user).Error
+		require.NoError(tb, err)
+
+		// Add multiple keys
+		err = userService.AddKeyIdentity(context.Background(), user.ID, "ethereum", "0x1111111111111111111111111111111111111111", nil)
+		require.NoError(tb, err)
+		err = userService.AddKeyIdentity(context.Background(), user.ID, "ethereum", "0x2222222222222222222222222222222222222222", nil)
+		require.NoError(tb, err)
+
+		// List identities
+		identities, err := userService.ListKeyIdentities(context.Background(), user.ID)
+		require.NoError(tb, err)
+		assert.Len(tb, identities, 2)
+	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
+}
+
+func TestUserService_ListKeyIdentities_Empty(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		userService := core.GetService[core.UserService](ctx, core.USER_SERVICE)
+		require.NotNil(tb, userService)
+
+		hashedCred, err := bcrypt.GenerateFromPassword([]byte(testKeyIdentitySecret()), bcrypt.DefaultCost)
+		require.NoError(tb, err)
+		user := &models.User{Email: "list-empty@example.com", PasswordHash: string(hashedCred)}
+		err = ctx.DB().Create(user).Error
+		require.NoError(tb, err)
+
+		identities, err := userService.ListKeyIdentities(context.Background(), user.ID)
+		require.NoError(tb, err)
+		assert.Empty(tb, identities)
 	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
 }

--- a/core/testing/mock_user.go
+++ b/core/testing/mock_user.go
@@ -182,16 +182,14 @@ func (m *MockUserService) VerifyUserEmailFails(email string) error {
 // AddKeyIdentityForUser adds a key identity to user account with automatic mock setup.
 func (m *MockUserService) AddKeyIdentityForUser(user *models.User, keyType string, key string) error {
 	// Mock of AddKeyIdentity response
-	m.EXPECT().AddKeyIdentity(mock.Anything, *user, keyType, key, mock.Anything).Return(nil)
-
+	m.EXPECT().AddKeyIdentity(mock.Anything, user.ID, keyType, key, mock.Anything).Return(nil)
 	return nil
 }
 
 // AddKeyIdentityForUserFails simulates key identity addition failure with automatic mock setup.
 func (m *MockUserService) AddKeyIdentityForUserFails(user *models.User, keyType string, key string) error {
 	// Mock of AddKeyIdentity response with error
-	m.EXPECT().AddKeyIdentity(mock.Anything, *user, keyType, key, mock.Anything).Return(fmt.Errorf("key already exists"))
-
+	m.EXPECT().AddKeyIdentity(mock.Anything, user.ID, keyType, key, mock.Anything).Return(fmt.Errorf("key already exists"))
 	return fmt.Errorf("key already exists")
 }
 

--- a/core/testing/mocks/UserService.go
+++ b/core/testing/mocks/UserService.go
@@ -117,16 +117,16 @@ func (_c *MockUserService_AccountExists_Call) RunAndReturn(run func(ctx context.
 }
 
 // AddKeyIdentity provides a mock function for the type MockUserService
-func (_mock *MockUserService) AddKeyIdentity(ctx context.Context, user models.User, keyType string, key string, metadata json.RawMessage) error {
-	ret := _mock.Called(ctx, user, keyType, key, metadata)
+func (_mock *MockUserService) AddKeyIdentity(ctx context.Context, userId uint, keyType string, key string, metadata json.RawMessage) error {
+	ret := _mock.Called(ctx, userId, keyType, key, metadata)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddKeyIdentity")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, models.User, string, string, json.RawMessage) error); ok {
-		r0 = returnFunc(ctx, user, keyType, key, metadata)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string, json.RawMessage) error); ok {
+		r0 = returnFunc(ctx, userId, keyType, key, metadata)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -140,23 +140,23 @@ type MockUserService_AddKeyIdentity_Call struct {
 
 // AddKeyIdentity is a helper method to define mock.On call
 //   - ctx context.Context
-//   - user models.User
+//   - userId uint
 //   - keyType string
 //   - key string
 //   - metadata json.RawMessage
-func (_e *MockUserService_Expecter) AddKeyIdentity(ctx interface{}, user interface{}, keyType interface{}, key interface{}, metadata interface{}) *MockUserService_AddKeyIdentity_Call {
-	return &MockUserService_AddKeyIdentity_Call{Call: _e.mock.On("AddKeyIdentity", ctx, user, keyType, key, metadata)}
+func (_e *MockUserService_Expecter) AddKeyIdentity(ctx interface{}, userId interface{}, keyType interface{}, key interface{}, metadata interface{}) *MockUserService_AddKeyIdentity_Call {
+	return &MockUserService_AddKeyIdentity_Call{Call: _e.mock.On("AddKeyIdentity", ctx, userId, keyType, key, metadata)}
 }
 
-func (_c *MockUserService_AddKeyIdentity_Call) Run(run func(ctx context.Context, user models.User, keyType string, key string, metadata json.RawMessage)) *MockUserService_AddKeyIdentity_Call {
+func (_c *MockUserService_AddKeyIdentity_Call) Run(run func(ctx context.Context, userId uint, keyType string, key string, metadata json.RawMessage)) *MockUserService_AddKeyIdentity_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 models.User
+		var arg1 uint
 		if args[1] != nil {
-			arg1 = args[1].(models.User)
+			arg1 = args[1].(uint)
 		}
 		var arg2 string
 		if args[2] != nil {
@@ -186,7 +186,7 @@ func (_c *MockUserService_AddKeyIdentity_Call) Return(err error) *MockUserServic
 	return _c
 }
 
-func (_c *MockUserService_AddKeyIdentity_Call) RunAndReturn(run func(ctx context.Context, user models.User, keyType string, key string, metadata json.RawMessage) error) *MockUserService_AddKeyIdentity_Call {
+func (_c *MockUserService_AddKeyIdentity_Call) RunAndReturn(run func(ctx context.Context, userId uint, keyType string, key string, metadata json.RawMessage) error) *MockUserService_AddKeyIdentity_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/testing/mocks/UserService.go
+++ b/core/testing/mocks/UserService.go
@@ -998,6 +998,74 @@ func (_c *MockUserService_KeyIdentityExists_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
+// ListKeyIdentities provides a mock function for the type MockUserService
+func (_mock *MockUserService) ListKeyIdentities(ctx context.Context, userId uint) ([]models.KeyIdentity, error) {
+	ret := _mock.Called(ctx, userId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListKeyIdentities")
+	}
+
+	var r0 []models.KeyIdentity
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) ([]models.KeyIdentity, error)); ok {
+		return returnFunc(ctx, userId)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) []models.KeyIdentity); ok {
+		r0 = returnFunc(ctx, userId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]models.KeyIdentity)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint) error); ok {
+		r1 = returnFunc(ctx, userId)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockUserService_ListKeyIdentities_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListKeyIdentities'
+type MockUserService_ListKeyIdentities_Call struct {
+	*mock.Call
+}
+
+// ListKeyIdentities is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userId uint
+func (_e *MockUserService_Expecter) ListKeyIdentities(ctx interface{}, userId interface{}) *MockUserService_ListKeyIdentities_Call {
+	return &MockUserService_ListKeyIdentities_Call{Call: _e.mock.On("ListKeyIdentities", ctx, userId)}
+}
+
+func (_c *MockUserService_ListKeyIdentities_Call) Run(run func(ctx context.Context, userId uint)) *MockUserService_ListKeyIdentities_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUserService_ListKeyIdentities_Call) Return(keyIdentitys []models.KeyIdentity, err error) *MockUserService_ListKeyIdentities_Call {
+	_c.Call.Return(keyIdentitys, err)
+	return _c
+}
+
+func (_c *MockUserService_ListKeyIdentities_Call) RunAndReturn(run func(ctx context.Context, userId uint) ([]models.KeyIdentity, error)) *MockUserService_ListKeyIdentities_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Logger provides a mock function for the type MockUserService
 func (_mock *MockUserService) Logger() *core.Logger {
 	ret := _mock.Called()
@@ -1040,6 +1108,75 @@ func (_c *MockUserService_Logger_Call) Return(logger *core.Logger) *MockUserServ
 }
 
 func (_c *MockUserService_Logger_Call) RunAndReturn(run func() *core.Logger) *MockUserService_Logger_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RemoveKeyIdentity provides a mock function for the type MockUserService
+func (_mock *MockUserService) RemoveKeyIdentity(ctx context.Context, userId uint, keyType string, key string) error {
+	ret := _mock.Called(ctx, userId, keyType, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveKeyIdentity")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, string, string) error); ok {
+		r0 = returnFunc(ctx, userId, keyType, key)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockUserService_RemoveKeyIdentity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveKeyIdentity'
+type MockUserService_RemoveKeyIdentity_Call struct {
+	*mock.Call
+}
+
+// RemoveKeyIdentity is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userId uint
+//   - keyType string
+//   - key string
+func (_e *MockUserService_Expecter) RemoveKeyIdentity(ctx interface{}, userId interface{}, keyType interface{}, key interface{}) *MockUserService_RemoveKeyIdentity_Call {
+	return &MockUserService_RemoveKeyIdentity_Call{Call: _e.mock.On("RemoveKeyIdentity", ctx, userId, keyType, key)}
+}
+
+func (_c *MockUserService_RemoveKeyIdentity_Call) Run(run func(ctx context.Context, userId uint, keyType string, key string)) *MockUserService_RemoveKeyIdentity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 uint
+		if args[1] != nil {
+			arg1 = args[1].(uint)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUserService_RemoveKeyIdentity_Call) Return(err error) *MockUserService_RemoveKeyIdentity_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockUserService_RemoveKeyIdentity_Call) RunAndReturn(run func(ctx context.Context, userId uint, keyType string, key string) error) *MockUserService_RemoveKeyIdentity_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/user.go
+++ b/core/user.go
@@ -45,7 +45,7 @@ type UserService interface {
 	// keyType is a registry key (e.g., "ethereum", "solana").
 	// metadata is optional type-specific data (chain_id, relays, etc.).
 	// If metadata is nil, it defaults to empty JSON {}.
-	AddKeyIdentity(ctx context.Context, user models.User, keyType string, key string, metadata json.RawMessage) error
+	AddKeyIdentity(ctx context.Context, userId uint, keyType string, key string, metadata json.RawMessage) error
 
 	// RemoveKeyIdentity unlinks a key identity from a user account.
 	// Only removes the key if it belongs to the given user.

--- a/core/user.go
+++ b/core/user.go
@@ -47,6 +47,14 @@ type UserService interface {
 	// If metadata is nil, it defaults to empty JSON {}.
 	AddKeyIdentity(ctx context.Context, user models.User, keyType string, key string, metadata json.RawMessage) error
 
+	// RemoveKeyIdentity unlinks a key identity from a user account.
+	// Only removes the key if it belongs to the given user.
+	// Returns an error if the key is not found or does not belong to the user.
+	RemoveKeyIdentity(ctx context.Context, userId uint, keyType string, key string) error
+
+	// ListKeyIdentities returns all key identities linked to the given user.
+	ListKeyIdentities(ctx context.Context, userId uint) ([]models.KeyIdentity, error)
+
 	// SendEmailVerification sends an email verification email to the user with the given ID.
 	// It returns an error if any.
 	SendEmailVerification(ctx context.Context, userId uint) error

--- a/service/user.go
+++ b/service/user.go
@@ -506,7 +506,7 @@ func (u UserServiceDefault) RemoveKeyIdentity(ctx context.Context, userId uint, 
 
 	handler, ok := core.GetKeyIdentityHandler(keyType)
 	if !ok {
-		return core.NewAccountError(core.ErrKeyAddKeyIdentityFailed, fmt.Errorf("no handler registered for key type %q", keyType))
+		return core.NewAccountError(core.ErrKeyKeyIdentityNotFound, fmt.Errorf("no handler registered for key type %q", keyType))
 	}
 	normalized, err := handler.NormalizeKey(key)
 	if err != nil {
@@ -526,7 +526,7 @@ func (u UserServiceDefault) RemoveKeyIdentity(ctx context.Context, userId uint, 
 		return core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
 	}
 	if rowsAffected == 0 {
-		return core.NewAccountError(core.ErrKeyInvalidLogin, fmt.Errorf("key identity not found for user %d", userId))
+		return core.NewAccountError(core.ErrKeyKeyIdentityNotFound, fmt.Errorf("key identity not found for user %d", userId))
 	}
 	return nil
 }

--- a/service/user.go
+++ b/service/user.go
@@ -500,6 +500,53 @@ func (u UserServiceDefault) AddKeyIdentity(ctx context.Context, user models.User
 	)
 }
 
+func (u UserServiceDefault) RemoveKeyIdentity(ctx context.Context, userId uint, keyType string, key string) error {
+	ctx, span := core.TraceMethod(ctx, "UserServiceDefault.RemoveKeyIdentity")
+	defer span.End()
+
+	handler, ok := core.GetKeyIdentityHandler(keyType)
+	if !ok {
+		return core.NewAccountError(core.ErrKeyAddKeyIdentityFailed, fmt.Errorf("no handler registered for key type %q", keyType))
+	}
+	normalized, err := handler.NormalizeKey(key)
+	if err != nil {
+		return err
+	}
+	key = normalized
+
+	var rowsAffected int64
+	err = db.RetryableComponentTransaction(u, ctx, func(tx *gorm.DB) *gorm.DB {
+		tx = tx.WithContext(ctx).
+			Where(&models.KeyIdentity{Type: keyType, Key: key, UserID: userId}).
+			Delete(&models.KeyIdentity{})
+		rowsAffected = tx.RowsAffected
+		return tx
+	})
+	if err != nil {
+		return core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+	}
+	if rowsAffected == 0 {
+		return core.NewAccountError(core.ErrKeyInvalidLogin, fmt.Errorf("key identity not found for user %d", userId))
+	}
+	return nil
+}
+
+func (u UserServiceDefault) ListKeyIdentities(ctx context.Context, userId uint) ([]models.KeyIdentity, error) {
+	ctx, span := core.TraceMethod(ctx, "UserServiceDefault.ListKeyIdentities")
+	defer span.End()
+
+	var identities []models.KeyIdentity
+	err := db.RetryableComponentTransaction(u, ctx, func(tx *gorm.DB) *gorm.DB {
+		return tx.WithContext(ctx).
+			Where("user_id = ?", userId).
+			Find(&identities)
+	})
+	if err != nil {
+		return nil, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+	}
+	return identities, nil
+}
+
 func (u UserServiceDefault) Exists(ctx context.Context, model any, conditions map[string]any) (bool, any, error) {
 	ctx, span := core.TraceMethod(ctx, "UserServiceDefault.Exists")
 	defer span.End()

--- a/service/user.go
+++ b/service/user.go
@@ -435,7 +435,7 @@ func (u UserServiceDefault) UpdateAccountInfo(ctx context.Context, userId uint, 
 	)
 }
 
-func (u UserServiceDefault) AddKeyIdentity(ctx context.Context, user models.User, keyType string, key string, metadata json.RawMessage) error {
+func (u UserServiceDefault) AddKeyIdentity(ctx context.Context, userId uint, keyType string, key string, metadata json.RawMessage) error {
 	ctx, span := core.TraceMethod(ctx, "UserServiceDefault.AddKeyIdentity")
 	defer span.End()
 
@@ -475,7 +475,7 @@ func (u UserServiceDefault) AddKeyIdentity(ctx context.Context, user models.User
 			model.Type = keyType
 			model.Key = key
 			model.Metadata = metadata
-			model.UserID = user.ID
+			model.UserID = userId
 
 			if err := db.RetryableComponentTransaction(u, ctx, func(tx *gorm.DB) *gorm.DB {
 				return tx.WithContext(ctx).Create(&model)


### PR DESCRIPTION
## Summary

Add service-layer methods for managing key identities on authenticated accounts, enabling connect/disconnect APIs.

## Changes

- `core/user.go` — `RemoveKeyIdentity` and `ListKeyIdentities` added to `UserService` interface
- `service/user.go` — implementations with key normalization and scoped queries
- `core/testing/mocks/` — regenerated via mockery v3.7.0

## Method Signatures

```go
RemoveKeyIdentity(ctx context.Context, userId uint, keyType string, key string) error
ListKeyIdentities(ctx context.Context, userId uint) ([]models.KeyIdentity, error)
```

`RemoveKeyIdentity` scopes the delete by `user_id + type + key` and returns an error if no rows were affected (key not found or doesn't belong to the user).

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./core/... ./service/... -race` — all packages pass
- [x] Mocks regenerated and compile cleanly

---

<!-- kody-pr-summary:start -->
 This pull request adds user key identity management capabilities to the `UserService` interface and its default implementation.

**Changes:**
- **`RemoveKeyIdentity`**: Allows unlinking a key identity from a user account. The operation validates that the key belongs to the specified user, normalizes the key using the registered key identity handler, and returns an error if the key identity is not found or does not belong to the user.
- **`ListKeyIdentities`**: Allows retrieving all key identities currently linked to a given user.
- **Mock updates**: Adds corresponding mock implementations for both new methods in `MockUserService` to support testing.

These additions enable user-facing key identity lifecycle management alongside the existing `AddKeyIdentity` functionality.
<!-- kody-pr-summary:end -->