### PR TITLE
refactor(user): ListKeyIdentities with queryhttp list pattern

### DIFF
--- a/core/internal/service_tests/user_test.go
+++ b/core/internal/service_tests/user_test.go
@@ -7,6 +7,7 @@ import (
 	coreTesting "go.lumeweb.com/portal/core/testing"
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/service"
+	"go.lumeweb.com/queryutil"
 	"golang.org/x/crypto/bcrypt"
 	"testing"
 
@@ -594,7 +595,7 @@ func TestUserService_ListKeyIdentities_Success(t *testing.T) {
 		require.NoError(tb, err)
 
 		// List identities
-		identities, err := userService.ListKeyIdentities(context.Background(), user.ID)
+		identities, _, err := userService.ListKeyIdentities(context.Background(), user.ID, nil, nil, queryutil.Pagination{})
 		require.NoError(tb, err)
 		assert.Len(tb, identities, 2)
 	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))
@@ -611,7 +612,7 @@ func TestUserService_ListKeyIdentities_Empty(t *testing.T) {
 		err = ctx.DB().Create(user).Error
 		require.NoError(tb, err)
 
-		identities, err := userService.ListKeyIdentities(context.Background(), user.ID)
+		identities, _, err := userService.ListKeyIdentities(context.Background(), user.ID, nil, nil, queryutil.Pagination{})
 		require.NoError(tb, err)
 		assert.Empty(tb, identities)
 	}, coreTesting.WithServiceFactory(core.USER_SERVICE, service.NewUserService))

--- a/core/testing/mocks/UserService.go
+++ b/core/testing/mocks/UserService.go
@@ -12,6 +12,7 @@ import (
 	"go.lumeweb.com/portal/config"
 	"go.lumeweb.com/portal/core"
 	"go.lumeweb.com/portal/db/models"
+	"go.lumeweb.com/queryutil"
 	"gorm.io/gorm"
 )
 
@@ -999,31 +1000,37 @@ func (_c *MockUserService_KeyIdentityExists_Call) RunAndReturn(run func(ctx cont
 }
 
 // ListKeyIdentities provides a mock function for the type MockUserService
-func (_mock *MockUserService) ListKeyIdentities(ctx context.Context, userId uint) ([]models.KeyIdentity, error) {
-	ret := _mock.Called(ctx, userId)
+func (_mock *MockUserService) ListKeyIdentities(ctx context.Context, userId uint, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*models.KeyIdentity, int64, error) {
+	ret := _mock.Called(ctx, userId, filters, sorts, pagination)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListKeyIdentities")
 	}
 
-	var r0 []models.KeyIdentity
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) ([]models.KeyIdentity, error)); ok {
-		return returnFunc(ctx, userId)
+	var r0 []*models.KeyIdentity
+	var r1 int64
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, []queryutil.CrudFilter, []queryutil.Sort, queryutil.Pagination) ([]*models.KeyIdentity, int64, error)); ok {
+		return returnFunc(ctx, userId, filters, sorts, pagination)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uint) []models.KeyIdentity); ok {
-		r0 = returnFunc(ctx, userId)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uint, []queryutil.CrudFilter, []queryutil.Sort, queryutil.Pagination) []*models.KeyIdentity); ok {
+		r0 = returnFunc(ctx, userId, filters, sorts, pagination)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]models.KeyIdentity)
+			r0 = ret.Get(0).([]*models.KeyIdentity)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uint) error); ok {
-		r1 = returnFunc(ctx, userId)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uint, []queryutil.CrudFilter, []queryutil.Sort, queryutil.Pagination) int64); ok {
+		r1 = returnFunc(ctx, userId, filters, sorts, pagination)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int64)
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, uint, []queryutil.CrudFilter, []queryutil.Sort, queryutil.Pagination) error); ok {
+		r2 = returnFunc(ctx, userId, filters, sorts, pagination)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
 }
 
 // MockUserService_ListKeyIdentities_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListKeyIdentities'
@@ -1034,11 +1041,14 @@ type MockUserService_ListKeyIdentities_Call struct {
 // ListKeyIdentities is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userId uint
-func (_e *MockUserService_Expecter) ListKeyIdentities(ctx interface{}, userId interface{}) *MockUserService_ListKeyIdentities_Call {
-	return &MockUserService_ListKeyIdentities_Call{Call: _e.mock.On("ListKeyIdentities", ctx, userId)}
+//   - filters []queryutil.CrudFilter
+//   - sorts []queryutil.Sort
+//   - pagination queryutil.Pagination
+func (_e *MockUserService_Expecter) ListKeyIdentities(ctx interface{}, userId interface{}, filters interface{}, sorts interface{}, pagination interface{}) *MockUserService_ListKeyIdentities_Call {
+	return &MockUserService_ListKeyIdentities_Call{Call: _e.mock.On("ListKeyIdentities", ctx, userId, filters, sorts, pagination)}
 }
 
-func (_c *MockUserService_ListKeyIdentities_Call) Run(run func(ctx context.Context, userId uint)) *MockUserService_ListKeyIdentities_Call {
+func (_c *MockUserService_ListKeyIdentities_Call) Run(run func(ctx context.Context, userId uint, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination)) *MockUserService_ListKeyIdentities_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -1048,20 +1058,35 @@ func (_c *MockUserService_ListKeyIdentities_Call) Run(run func(ctx context.Conte
 		if args[1] != nil {
 			arg1 = args[1].(uint)
 		}
+		var arg2 []queryutil.CrudFilter
+		if args[2] != nil {
+			arg2 = args[2].([]queryutil.CrudFilter)
+		}
+		var arg3 []queryutil.Sort
+		if args[3] != nil {
+			arg3 = args[3].([]queryutil.Sort)
+		}
+		var arg4 queryutil.Pagination
+		if args[4] != nil {
+			arg4 = args[4].(queryutil.Pagination)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
+			arg3,
+			arg4,
 		)
 	})
 	return _c
 }
 
-func (_c *MockUserService_ListKeyIdentities_Call) Return(keyIdentitys []models.KeyIdentity, err error) *MockUserService_ListKeyIdentities_Call {
-	_c.Call.Return(keyIdentitys, err)
+func (_c *MockUserService_ListKeyIdentities_Call) Return(keyIdentitys []*models.KeyIdentity, n int64, err error) *MockUserService_ListKeyIdentities_Call {
+	_c.Call.Return(keyIdentitys, n, err)
 	return _c
 }
 
-func (_c *MockUserService_ListKeyIdentities_Call) RunAndReturn(run func(ctx context.Context, userId uint) ([]models.KeyIdentity, error)) *MockUserService_ListKeyIdentities_Call {
+func (_c *MockUserService_ListKeyIdentities_Call) RunAndReturn(run func(ctx context.Context, userId uint, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*models.KeyIdentity, int64, error)) *MockUserService_ListKeyIdentities_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/user.go
+++ b/core/user.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"go.lumeweb.com/portal/db/models"
+	"go.lumeweb.com/queryutil"
 )
 
 const USER_SERVICE = "user"
@@ -53,7 +54,7 @@ type UserService interface {
 	RemoveKeyIdentity(ctx context.Context, userId uint, keyType string, key string) error
 
 	// ListKeyIdentities returns all key identities linked to the given user.
-	ListKeyIdentities(ctx context.Context, userId uint) ([]models.KeyIdentity, error)
+	ListKeyIdentities(ctx context.Context, userId uint, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*models.KeyIdentity, int64, error)
 
 	// SendEmailVerification sends an email verification email to the user with the given ID.
 	// It returns an error if any.

--- a/service/user.go
+++ b/service/user.go
@@ -13,6 +13,7 @@ import (
 	"go.lumeweb.com/portal/db"
 	"go.lumeweb.com/portal/db/models"
 	"go.lumeweb.com/portal/event"
+	"go.lumeweb.com/queryutil"
 	dbHelper "go.lumeweb.com/portal/service/internal/db"
 	"go.lumeweb.com/portal/service/internal/mailer"
 	"go.lumeweb.com/portal/service/internal/user"
@@ -531,20 +532,29 @@ func (u UserServiceDefault) RemoveKeyIdentity(ctx context.Context, userId uint, 
 	return nil
 }
 
-func (u UserServiceDefault) ListKeyIdentities(ctx context.Context, userId uint) ([]models.KeyIdentity, error) {
+func (u UserServiceDefault) ListKeyIdentities(ctx context.Context, userId uint, filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination) ([]*models.KeyIdentity, int64, error) {
 	ctx, span := core.TraceMethod(ctx, "UserServiceDefault.ListKeyIdentities")
 	defer span.End()
 
-	var identities []models.KeyIdentity
-	err := db.RetryableComponentTransaction(u, ctx, func(tx *gorm.DB) *gorm.DB {
-		return tx.WithContext(ctx).
-			Where("user_id = ?", userId).
-			Find(&identities)
-	})
-	if err != nil {
-		return nil, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+	var identities []*models.KeyIdentity
+	var total int64
+
+	query := u.DB().WithContext(ctx).Model(&models.KeyIdentity{}).Where("user_id = ?", userId)
+
+	query = queryutil.ApplyFilters(query, filters, nil)
+	query = queryutil.ApplySort(query, sorts)
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
 	}
-	return identities, nil
+
+	query = queryutil.ApplyPagination(query, pagination)
+
+	if err := query.Find(&identities).Error; err != nil {
+		return nil, 0, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
+	}
+
+	return identities, total, nil
 }
 
 func (u UserServiceDefault) Exists(ctx context.Context, model any, conditions map[string]any) (bool, any, error) {

--- a/service/user.go
+++ b/service/user.go
@@ -539,15 +539,14 @@ func (u UserServiceDefault) ListKeyIdentities(ctx context.Context, userId uint, 
 	var identities []*models.KeyIdentity
 	var total int64
 
-	query := u.DB().WithContext(ctx).Model(&models.KeyIdentity{}).Where("user_id = ?", userId)
+	baseQuery := u.DB().WithContext(ctx).Model(&models.KeyIdentity{}).Where("user_id = ?", userId)
 
-	query = queryutil.ApplyFilters(query, filters, nil)
-	query = queryutil.ApplySort(query, sorts)
-
-	if err := query.Count(&total).Error; err != nil {
+	if err := queryutil.ApplyFilters(baseQuery, filters, nil).Count(&total).Error; err != nil {
 		return nil, 0, core.NewAccountError(core.ErrKeyDatabaseOperationFailed, err)
 	}
 
+	query := queryutil.ApplyFilters(baseQuery, filters, nil)
+	query = queryutil.ApplySort(query, sorts)
 	query = queryutil.ApplyPagination(query, pagination)
 
 	if err := query.Find(&identities).Error; err != nil {


### PR DESCRIPTION
## Summary

Aligns `ListKeyIdentities` with the `queryutilHttp.ProcessListRequest` pattern used by other list endpoints (e.g. API keys).

## Changes

- **Interface** (`core/user.go`): `ListKeyIdentities` now accepts `filters []queryutil.CrudFilter, sorts []queryutil.Sort, pagination queryutil.Pagination` and returns `([]*models.KeyIdentity, int64, error)`
- **Service** (`service/user.go`): Implements filtering, sorting, pagination via `queryutil.ApplyFilters`/`ApplySort`/`ApplyPagination`, returns total count
- **Tests**: Updated call sites in `user_test.go`; all 11 key identity tests pass

## Why

The dashboard `keyIdentityList` endpoint needs to use the standard `queryutilHttp.ProcessListRequest` pattern for consistent pagination/filtering. That pattern requires the service method to return `([]*T, int64, error)` with filter/sort/pagination params.

Once merged, the dashboard will be updated to use `ProcessListRequest` for the list endpoint.

---

<!-- kody-pr-summary:start -->
 Refactors the `ListKeyIdentities` method on the `UserService` interface and its implementation to follow the standard query/list pattern used elsewhere in the portal codebase.

**What changed:**
- `ListKeyIdentities` now accepts `filters`, `sorts`, and `pagination` parameters via the `queryutil` package.
- The method now returns three values: the list of key identities, a total count, and an error.
- Returned key identities are now pointers (`[]*models.KeyIdentity`) instead of values.
- The implementation applies filters, sorting, and pagination to the database query and returns the total matching record count.
- Generated mocks and existing service tests were updated to match the new signature.

**Functional impact:**
- Consumers can now filter, sort, and paginate key identity listings for a user, enabling more flexible API responses (e.g., query/http-style list endpoints).
- Callers receive the total number of matching records alongside the paginated results.
<!-- kody-pr-summary:end -->