### PR TITLE
feat(db): add composite index on uploads(protocol, mime_type, deleted_at)

### DIFF
--- a/db/migrations/mysql/20260730000000_uploads_stats_index.sql
+++ b/db/migrations/mysql/20260730000000_uploads_stats_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Composite index to optimize queries filtering uploads by protocol + mime_type.
+-- Primarily benefits ProtocolStorageStatsProvider implementations (e.g. Sia plugin's
+-- StorageStats) which filter on protocol, mime_type, and deleted_at to distinguish
+-- slab pins from virtual object pins.
+CREATE INDEX `idx_uploads_protocol_mime_deleted` ON `uploads` (`protocol`(255), `mime_type`(255), `deleted_at`);
+
+-- +goose Down
+DROP INDEX `idx_uploads_protocol_mime_deleted` ON `uploads`;

--- a/db/migrations/sqlite/20260730000000_uploads_stats_index.sql
+++ b/db/migrations/sqlite/20260730000000_uploads_stats_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Composite index to optimize queries filtering uploads by protocol + mime_type.
+-- Primarily benefits ProtocolStorageStatsProvider implementations (e.g. Sia plugin's
+-- StorageStats) which filter on protocol, mime_type, and deleted_at to distinguish
+-- slab pins from virtual object pins.
+CREATE INDEX IF NOT EXISTS idx_uploads_protocol_mime_deleted ON uploads(protocol, mime_type, deleted_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_uploads_protocol_mime_deleted;


### PR DESCRIPTION
## Summary

Adds composite index `idx_uploads_protocol_mime_deleted` on `uploads(protocol, mime_type, deleted_at)` to optimize queries from `ProtocolStorageStatsProvider` implementations.

## Problem

The Sia plugin PR [#53](https://github.com/LumeWeb/portal-plugin-sia/pull/53) implements `StorageStats` which queries `uploads` filtered by `protocol`, `mime_type`, and `deleted_at` to distinguish slab pins from virtual object pins. Without this index, the aggregation does a full table scan as uploads grow.

## What this adds

- SQLite: `CREATE INDEX IF NOT EXISTS idx_uploads_protocol_mime_deleted ON uploads(protocol, mime_type, deleted_at)`
- MySQL: same index with backtick syntax

The existing `idx_uploads_deleted_at` index only covers `deleted_at`. This composite index covers the full WHERE clause filter.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./core/...` passes
- [x] Sia plugin tests pass with this migration applied

---

<!-- kody-pr-summary:start -->
 This pull request adds a new composite database index on the `uploads` table across both MySQL and SQLite migrations.

The index covers the `protocol`, `mime_type`, and `deleted_at` columns and is designed to optimize queries that filter uploads by protocol and MIME type. This primarily benefits `ProtocolStorageStatsProvider` implementations—such as the Sia plugin's `StorageStats`—which rely on these fields to distinguish between slab pins and virtual object pins when computing storage statistics.
<!-- kody-pr-summary:end -->