### PR TITLE
feat: return RenterObject from SharedObject, use ErrUploadNotFound

### DIFF
--- a/core/renter.go
+++ b/core/renter.go
@@ -84,7 +84,7 @@ type RenterService interface {
 	UploadObjectMultipart(ctx context.Context, params *MultipartUploadParams) error
 	DeleteObject(ctx context.Context, bucket string, fileName string) error
 	SlabSize(ctx context.Context) (uint64, error)
-	SharedObject(ctx context.Context, bucket string, fileName string) (*SharedObject, error)
+	SharedObject(ctx context.Context, bucket string, fileName string) (*SharedObject, *models.RenterObject, error)
 
 	Service
 }

--- a/core/testing/mock_renter.go
+++ b/core/testing/mock_renter.go
@@ -205,8 +205,8 @@ func (h *MockRenterService) SlabSize(_ context.Context) (uint64, error) {
 	return uint64(4 * 1024 * 1024), nil
 }
 
-func (h *MockRenterService) SharedObject(_ context.Context, _ string, _ string) (*core.SharedObject, error) {
-	return nil, fmt.Errorf("not implemented")
+func (h *MockRenterService) SharedObject(_ context.Context, _ string, _ string) (*core.SharedObject, *models.RenterObject, error) {
+	return nil, nil, fmt.Errorf("not implemented")
 }
 
 // Config implements core.Component

--- a/core/testing/mocks/RenterService.go
+++ b/core/testing/mocks/RenterService.go
@@ -762,7 +762,7 @@ func (_c *MockRenterService_SetLogger_Call) RunAndReturn(run func(logger *core.L
 }
 
 // SharedObject provides a mock function for the type MockRenterService
-func (_mock *MockRenterService) SharedObject(ctx context.Context, bucket string, fileName string) (*core.SharedObject, error) {
+func (_mock *MockRenterService) SharedObject(ctx context.Context, bucket string, fileName string) (*core.SharedObject, *models.RenterObject, error) {
 	ret := _mock.Called(ctx, bucket, fileName)
 
 	if len(ret) == 0 {
@@ -770,8 +770,9 @@ func (_mock *MockRenterService) SharedObject(ctx context.Context, bucket string,
 	}
 
 	var r0 *core.SharedObject
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*core.SharedObject, error)); ok {
+	var r1 *models.RenterObject
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*core.SharedObject, *models.RenterObject, error)); ok {
 		return returnFunc(ctx, bucket, fileName)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *core.SharedObject); ok {
@@ -781,12 +782,19 @@ func (_mock *MockRenterService) SharedObject(ctx context.Context, bucket string,
 			r0 = ret.Get(0).(*core.SharedObject)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) *models.RenterObject); ok {
 		r1 = returnFunc(ctx, bucket, fileName)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*models.RenterObject)
+		}
 	}
-	return r0, r1
+	if returnFunc, ok := ret.Get(2).(func(context.Context, string, string) error); ok {
+		r2 = returnFunc(ctx, bucket, fileName)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
 }
 
 // MockRenterService_SharedObject_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SharedObject'
@@ -825,12 +833,12 @@ func (_c *MockRenterService_SharedObject_Call) Run(run func(ctx context.Context,
 	return _c
 }
 
-func (_c *MockRenterService_SharedObject_Call) Return(sharedObject *core.SharedObject, err error) *MockRenterService_SharedObject_Call {
-	_c.Call.Return(sharedObject, err)
+func (_c *MockRenterService_SharedObject_Call) Return(sharedObject *core.SharedObject, renterObject *models.RenterObject, err error) *MockRenterService_SharedObject_Call {
+	_c.Call.Return(sharedObject, renterObject, err)
 	return _c
 }
 
-func (_c *MockRenterService_SharedObject_Call) RunAndReturn(run func(ctx context.Context, bucket string, fileName string) (*core.SharedObject, error)) *MockRenterService_SharedObject_Call {
+func (_c *MockRenterService_SharedObject_Call) RunAndReturn(run func(ctx context.Context, bucket string, fileName string) (*core.SharedObject, *models.RenterObject, error)) *MockRenterService_SharedObject_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/service/renter.go
+++ b/service/renter.go
@@ -748,7 +748,7 @@ func (r *RenterService) SlabSize(ctx context.Context) (uint64, error) {
 // stored at (bucket, fileName). The caller can use the slab layout, sector
 // roots, and data key to retrieve and decrypt the object data directly from
 // the Sia network without contacting the indexer.
-func (r *RenterService) SharedObject(ctx context.Context, bucket string, fileName string) (*core.SharedObject, error) {
+func (r *RenterService) SharedObject(ctx context.Context, bucket string, fileName string) (*core.SharedObject, *models.RenterObject, error) {
 	_, span := core.TraceMethod(ctx, "RenterService.SharedObject")
 	defer span.End()
 	span.SetAttributes(
@@ -757,28 +757,28 @@ func (r *RenterService) SharedObject(ctx context.Context, bucket string, fileNam
 	)
 
 	if err := r.ensureSDK(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	siaObj, err := r.findSiaObject(ctx, bucket, fileName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if siaObj == nil {
-		return nil, fmt.Errorf("object not found in bucket %q: %s", bucket, fileName)
+		return nil, nil, core.ErrUploadNotFound
 	}
 	if siaObj.Status != models.RenterObjectStatusUploaded {
-		return nil, fmt.Errorf("object %q is not uploaded (status: %s)", fileName, siaObj.Status)
+		return nil, siaObj, fmt.Errorf("object %q is not uploaded (status: %s)", fileName, siaObj.Status)
 	}
 
 	var sealed sdk.SealedObject
 	if err := json.Unmarshal(siaObj.SealedData, &sealed); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal sealed object: %w", err)
+		return nil, siaObj, fmt.Errorf("failed to unmarshal sealed object: %w", err)
 	}
 
 	obj, err := r.sdk.UnsealObject(sealed)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unseal object: %w", err)
+		return nil, siaObj, fmt.Errorf("failed to unseal object: %w", err)
 	}
 
 	objSlabs := obj.Slabs()
@@ -801,7 +801,7 @@ func (r *RenterService) SharedObject(ctx context.Context, bucket string, fileNam
 		}),
 	}
 
-	return out, nil
+	return out, siaObj, nil
 }
 
 // Stop shuts down the packing loop and waits for it to exit.


### PR DESCRIPTION
Changes SharedObject signature to return (*SharedObject, *models.RenterObject, error). This eliminates the need for a separate UploadExists call, halving renter-service round trips per DAG block in the meta plugin export.

Also returns core.ErrUploadNotFound instead of raw fmt.Errorf when object is missing, enabling consistent errors.Is handling.

---

<!-- kody-pr-summary:start -->
 This PR updates the `SharedObject` method across the `RenterService` interface and its implementations to return the underlying `RenterObject` alongside the `SharedObject` result. This gives callers direct access to the stored renter object metadata when retrieving shared object data.

Additionally, the not-found case now returns the standard `core.ErrUploadNotFound` error instead of a bespoke formatted error, improving consistency in error handling for consumers of the service.
<!-- kody-pr-summary:end -->