### PR TITLE
fix: use UnsafeDataKey() for siastorage Object API change

### DIFF
--- a/service/renter.go
+++ b/service/renter.go
@@ -783,7 +783,7 @@ func (r *RenterService) SharedObject(ctx context.Context, bucket string, fileNam
 
 	objSlabs := obj.Slabs()
 	out := &core.SharedObject{
-		DataKey: obj.DataKey(),
+		DataKey: obj.UnsafeDataKey(),
 		Slabs: lo.Map(objSlabs, func(s slabs.SlabSlice, _ int) core.SlabSlice {
 			return core.SlabSlice{
 				Version:       s.Version,


### PR DESCRIPTION
## Summary

`siastorage` `ca2ffd9` unexported the `Object.dataKey` field and renamed the accessor from `DataKey()` to `UnsafeDataKey()`. This updates `service/renter.go` to use the new method name.

## Changes

- `service/renter.go:786`: `obj.DataKey()` → `obj.UnsafeDataKey()`

## Context

The `go.sia.tech/siastorage` digest bump to `ca2ffd9` broke the build because `Object.DataKey()` was removed in favor of `UnsafeDataKey()`. Both return `[32]byte`, matching the `core.SharedObject.DataKey` field type.

---

<!-- kody-pr-summary:start -->
 ## Summary

Updates the renter service to use the renamed `UnsafeDataKey()` method when retrieving the data key from a siastorage object, replacing the previous `DataKey()` call.

## What changed

- In `service/renter.go`, the `SharedObject` method now calls `obj.UnsafeDataKey()` instead of `obj.DataKey()` when constructing shared object metadata.

## Why

This change adapts to an upstream API rename in the siastorage `Object` type. Using the updated method name restores compatibility and allows shared object construction to continue functioning correctly against the revised object model.
<!-- kody-pr-summary:end -->