### PR TITLE
fix(cron): run jobs from a bounded context

### DIFF
--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -271,8 +271,19 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 	}
 
 	// Define the task function
-	// Detach context to avoid cancellation in long-running jobs
-	jobCtx := core.DetachContext(ctx)
+	// Cron execution is a genuine asynchronous boundary. Start from a fresh,
+	// bounded context instead of the incoming request/workflow context graph.
+	// Detaching with context.WithoutCancel would carry the entire arbitrary
+	// context chain (and, on retries, grow it by one layer each attempt).
+	//
+	// ExecuteJob creates its own new root span (WithNewRoot), but SetupJob,
+	// CleanupJob and HandleFailedJob do not, so carry only the OTel span
+	// context (via W3C traceparent) to keep their traces parented while
+	// dropping every other value. context.Background() is never canceled,
+	// preserving the original intent to outlive the scheduling context.
+	jobCtx := context.Background()
+	jobCtx = core.WithTracerInfo(jobCtx, core.DefaultTracerService, "cron")
+	jobCtx = core.ContextWithTraceParent(jobCtx, core.MarshalTraceParent(ctx))
 	taskFunc := func(jobID uuid.UUID) error {
 		return s.ExecuteJob(jobCtx, jobID)
 	}


### PR DESCRIPTION
## Problem

Cron job execution starts from the scheduling context via
`context.WithoutCancel`. The full arbitrary request/workflow context value
chain is carried across the async cron boundary, and each retry adds another
layer, making context depth grow linearly with retry count.

## Fix

Start cron execution from a fresh, bounded context:
- Ground on `context.Background()` (never canceled, preserving the original
  intent to outlive the scheduling context).
- Carry only the OTel span context via W3C traceparent so non-root methods
  (`SetupJob`, `CleanupJob`, `HandleFailedJob`) keep their trace parent.

`ExecuteJob` already creates its own root span (`WithNewRoot`); only the three
setup/cleanup/failure methods need the trace parent, and only the span context
is carried — no other values.

## Verified

- gofmt clean.
- Context depth is now O(1) instead of O(retry count).

---

<!-- kody-pr-summary:start -->
## Summary

This pull request modifies the cron job scheduling logic in the `StandaloneCoordinator.EnqueueJob` function to fix how job contexts are handled during asynchronous execution.

### Key Changes

The previous implementation used `core.DetachContext(ctx)` when creating the context for cron job execution. This approach had issues: it carried the entire incoming request/workflow context chain, and on retries, it would grow the context chain by one additional layer per attempt.

The fix replaces this with a cleaner approach:

1. **New bounded context**: The job now starts from `context.Background()` — a clean, never-canceled context that preserves the original intent of outliving the scheduling context, while eliminating the problematic context chain growth on retries.

2. **Preserved tracing information**: Since `ExecuteJob` creates its own new root OpenTelemetry span, but `SetupJob`, `CleanupJob`, and `HandleFailedJob` do not, the fix carries only the OTel span context (via W3C traceparent) from the original context. This keeps traces properly parented while dropping all other unrelated values from the context chain.

3. **Cron service tagging**: The new context is tagged with the default tracer service and "cron" label to properly identify these operations in tracing telemetry.

### Impact

This change ensures cron jobs run from a clean, bounded context rather than inheriting arbitrary request/workflow context chains, preventing issues with context accumulation across multiple retry attempts while maintaining proper distributed tracing visibility.
<!-- kody-pr-summary:end -->