### PR TITLE
fix(workflow): make ListWorkflowInstances items and total consistent

### DIFF
--- a/core/internal/service_tests/workflow_test.go
+++ b/core/internal/service_tests/workflow_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/multiformats/go-multihash"
 	"github.com/samber/lo"
@@ -1297,6 +1298,61 @@ func TestListWorkflowInstances(t *testing.T) {
 	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, service.NewRequestService),
 		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, service.NewWorkflowCoordinator),
 		withTestProtocol("test.operation.list1", "test.operation.list2"),
+	)
+}
+
+// TestListWorkflowInstances_SkipsUnregisteredWorkflow regresses the empty-items
+// + correct-total bug: a request whose metadata.workflow_name references a
+// workflow that is not registered in this coordinator is dropped by
+// buildWorkflowInstance. Such rows must be excluded from BOTH items and the
+// reported total, so items and total can never disagree.
+func TestListWorkflowInstances_SkipsUnregisteredWorkflow(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		workflowService := core.GetService[core.WorkflowService](ctx, core.WORKFLOW_SERVICE)
+		require.NotNil(tb, workflowService)
+
+		workflowName := "listInstancesSkipTestWorkflow"
+		operationName := "test.operation.listskip"
+
+		err := workflowService.RegisterWorkflow(workflowName, []core.OperationStep{
+			{Operation: operationName, Foreground: true},
+		}, false)
+		require.NoError(tb, err)
+
+		userID := uint(123)
+
+		// One valid workflow instance for this user.
+		_, err = workflowService.StartWorkflow(context.Background(), workflowName,
+			core.WithWorkflowUserID(userID),
+			core.WithWorkflowData(map[string]interface{}{"instance": 1}))
+		require.NoError(tb, err)
+
+		// A request whose workflow is NOT registered: it survives the SQL
+		// filter (workflow_name IS NOT NULL) but must be dropped from results.
+		unregisteredMeta, err := json.Marshal(service.WorkflowMetadata{
+			WorkflowName: "does.not.exist",
+			TotalSteps:   1,
+			StartedAt:    time.Now().Unix(),
+		})
+		require.NoError(tb, err)
+
+		usr := userID
+		unreg := models.Request{
+			Operation: operationName,
+			Protocol:  "test",
+			Status:    models.RequestStatusPending,
+			UserID:    &usr,
+			Metadata:  unregisteredMeta,
+		}
+		require.NoError(tb, ctx.DB().Create(&unreg).Error)
+
+		instances, totalCount, err := workflowService.ListWorkflowInstances(context.Background(), userID, nil, nil, queryutil.Pagination{})
+		assert.NoError(tb, err)
+		assert.Len(tb, instances, 1, "unregistered-workflow request must be excluded from items")
+		assert.Equal(tb, int64(1), totalCount, "total must match the returned items (exclude dropped rows)")
+	}, coreTesting.WithServiceFactory(core.REQUEST_SERVICE, service.NewRequestService),
+		coreTesting.WithServiceFactory(core.WORKFLOW_SERVICE, service.NewWorkflowCoordinator),
+		withTestProtocol("test.operation.listskip"),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -63,11 +63,11 @@ require (
 	go.opentelemetry.io/contrib/bridges/otelzap v0.19.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.70.0
 	go.opentelemetry.io/otel v1.45.0
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.21.0
+	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0
-	go.opentelemetry.io/otel/log v0.21.0
+	go.opentelemetry.io/otel/log v0.20.0
 	go.opentelemetry.io/otel/sdk v1.45.0
-	go.opentelemetry.io/otel/sdk/log v0.21.0
+	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	go.sia.tech/core v0.21.7
 	go.sia.tech/coreutils v0.24.0

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -1337,17 +1337,22 @@ func (w *WorkflowCoordinatorDefault) ListWorkflowInstances(ctx context.Context, 
 	// Apply sorts
 	sortedQuery := queryutil.ApplySort(filteredQuery, sorts)
 
-	// Apply pagination
-	paginatedQuery := queryutil.ApplyPagination(sortedQuery, pagination)
+	// NOTE: pagination is intentionally NOT applied at the SQL level here.
+	// Rows are post-filtered in Go (a row whose metadata.workflow_name names a
+	// workflow that isn't registered in this coordinator is dropped by
+	// buildWorkflowInstance), so SQL OFFSET/LIMIT would page over rows that may
+	// not survive filtering, yielding inconsistent items vs total. Instead we
+	// fetch the full sorted set, build valid instances, then paginate over the
+	// validated slice and report total as the count of valid instances.
 
-	// Execute query to get filtered, sorted, and paginated requests
+	// Execute query to get filtered and sorted requests
 	var requests []*models.Request
-	if err := paginatedQuery.Find(&requests).Error; err != nil {
+	if err := sortedQuery.Find(&requests).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to query requests: %w", err)
 	}
 
 	// Process requests to create workflow instances
-	var workflowInstances []*core.WorkflowInstance
+	workflowInstances := make([]*core.WorkflowInstance, 0, len(requests))
 	for _, req := range requests {
 		var metadata WorkflowMetadata
 		if err := json.Unmarshal(req.Metadata, &metadata); err != nil {
@@ -1373,14 +1378,32 @@ func (w *WorkflowCoordinatorDefault) ListWorkflowInstances(ctx context.Context, 
 		workflowInstances = append(workflowInstances, instance)
 	}
 
-	// Get total count for pagination
-	var totalCount int64
-	countQuery := queryutil.ApplyFilters(baseQuery, allFilters, nil)
-	if err := countQuery.Count(&totalCount).Error; err != nil {
-		return nil, 0, fmt.Errorf("failed to get total count: %w", err)
+	// total reflects the validated set, so items and total can never disagree.
+	totalCount := int64(len(workflowInstances))
+
+	// Apply pagination to the validated slice (Start inclusive, End exclusive,
+	// matching the queryutil _start/_end convention).
+	offset := pagination.Start
+	if offset < 0 {
+		offset = 0
+	}
+	limit := pagination.End - pagination.Start
+	if limit <= 0 {
+		limit = len(workflowInstances)
+	}
+	start := offset
+	if start > len(workflowInstances) {
+		start = len(workflowInstances)
+	}
+	end := offset + limit
+	if end > len(workflowInstances) {
+		end = len(workflowInstances)
+	}
+	if end < start {
+		end = start
 	}
 
-	return workflowInstances, totalCount, nil
+	return workflowInstances[start:end], totalCount, nil
 }
 
 func (w *WorkflowCoordinatorDefault) ListDistinctWorkflowFilters(ctx context.Context, userID uint, additionalFilters []queryutil.CrudFilter) (map[string][]string, error) {

--- a/service/workflow.go
+++ b/service/workflow.go
@@ -1341,13 +1341,18 @@ func (w *WorkflowCoordinatorDefault) ListWorkflowInstances(ctx context.Context, 
 	// Rows are post-filtered in Go (a row whose metadata.workflow_name names a
 	// workflow that isn't registered in this coordinator is dropped by
 	// buildWorkflowInstance), so SQL OFFSET/LIMIT would page over rows that may
-	// not survive filtering, yielding inconsistent items vs total. Instead we
-	// fetch the full sorted set, build valid instances, then paginate over the
-	// validated slice and report total as the count of valid instances.
+	// not survive filtering, yielding inconsistent items vs total. A correct
+	// total for the post-filtered set requires examining every candidate row
+	// (each triggers the per-row buildWorkflowInstance work regardless), so we
+	// fetch the full sorted candidate set — lightweight Request rows bounded by
+	// a single user's workflow history — build the valid instances, then page
+	// over the validated slice and report total as the count of valid ones.
 
-	// Execute query to get filtered and sorted requests
+	// Execute query to get filtered and sorted requests.
+	// The context is inherited from the base query's WithContext, and asserted
+	// explicitly here so the query honors request cancellation/timeouts.
 	var requests []*models.Request
-	if err := sortedQuery.Find(&requests).Error; err != nil {
+	if err := sortedQuery.WithContext(ctx).Find(&requests).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to query requests: %w", err)
 	}
 


### PR DESCRIPTION
The dashboard `operations_list` endpoint returned an **empty items array with a correct, larger `Total`** (e.g. `items: []`, `total: 197`).

## Root cause
`WorkflowCoordinatorDefault.ListWorkflowInstances` (service/workflow.go) applied **SQL-level pagination** over workflow-request rows, then **post-filtered them in Go**:
- dropped any row whose `metadata.workflow_name` names a workflow that is **not registered** in the coordinator (`buildWorkflowInstance` → `GetWorkflowStepInfo` → `GetWorkflow` returns `ErrKeyWorkflowNotFound`), and any row whose metadata fails to parse,
- while `Total` was computed **separately** as a SQL count (on the filtered-but-unpaginated query) that **includes those dropped rows**.

So `items` and `total` diverge, and a page landing entirely on dropped rows yields `items == []` with `total` still correct (`_start`/`_end` page over rows that may not survive validation).

## Fix
- Build the **validated instance set in Go first** (no SQL pagination), report `total` as the **count of valid instances**, then apply pagination to the validated slice using the queryutil `_start`/`_end` (Start inclusive, End exclusive) convention.
- `items` and `total` now always agree, and pages always contain valid instances.

## Tests
- New `TestListWorkflowInstances_SkipsUnregisteredWorkflow`: inserts a request whose `workflow_name` is unregistered and asserts it's excluded from **both** items and total.
- Existing `TestListWorkflowInstances` still passes (zero-value pagination → full validated set + total = count).

## Verified
`go build ./...` and `go test ./core/internal/service_tests/ -run TestListWorkflowInstances` pass.

---
**Note (separate commit in this branch):** the committed module graph was broken to build — `go.opentelemetry.io/otel/log v0.21.0` removed `log.KeyValue` but `otelzap v0.19.0` still imports it. Pinned the otel log packages to v0.20.0 (already in go.sum) to restore a buildable tree; required for the test to actually run.

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes an inconsistency bug in the `ListWorkflowInstances` API where the returned list of workflow instances (items) and the reported total count could disagree.

## Problem

When listing workflow instances, rows whose `metadata.workflow_name` references a workflow that is not registered in the coordinator were silently dropped during post-processing (in `buildWorkflowInstance`). However, the SQL query still included these rows for pagination (via `OFFSET`/`LIMIT`) and for the total count. This caused:
- **Items**: Fewer items than expected because invalid rows were filtered out after pagination
- **Total**: A count that included the dropped/invalid rows

This resulted in inconsistent responses where `items` and `total` did not match, breaking pagination logic for clients.

## Solution

The fix in `service/workflow.go`:

1. **Removed SQL-level pagination**: Instead of applying `OFFSET`/`LIMIT` in the database query, it now fetches the entire filtered and sorted result set.

2. **Post-processes and validates**: All rows are processed through `buildWorkflowInstance` (which drops unregistered workflow references).

3. **Pagination on validated data**: Pagination (`start`/`end`) is now applied to the validated slice of workflow instances after filtering.

4. **Consistent total**: The total count is now derived from the length of the validated instances array (`int64(len(workflowInstances))`), ensuring it always matches the actual items returned (before final pagination slicing).

## Testing

Added a regression test (`TestListWorkflowInstances_SkipsUnregisteredWorkflow`) that:
- Registers a workflow and starts one valid instance
- Creates a request with an unregistered workflow name
- Verifies that the unregistered row is excluded from both items AND total count
- Asserts `items` length is 1 and `total` is 1, confirming consistency

This ensures the fix prevents the empty-items-with-correct-total bug from recurring.
<!-- kody-pr-summary:end -->