### PR TITLE
chore: add debug logging for workflow and request status diagnostics

### DIFF
--- a/core/operation.go
+++ b/core/operation.go
@@ -10,6 +10,7 @@ import (
 	"github.com/knadh/koanf/v2"
 	"github.com/samber/lo"
 	"go.lumeweb.com/portal/db/models"
+	"go.uber.org/zap"
 )
 
 // Default implementation
@@ -595,6 +596,15 @@ func (h *OperationHelperDefault) GetStatusFromWorkflowData(requestID uint, req *
 		// If progress is > 0, the operation is definitely processing
 		// Preserve terminal states (Failed/Completed) regardless of progress
 		if progress.ProgressPercent > 0 && status.State != models.RequestStatusCompleted && status.State != models.RequestStatusFailed {
+			// Log status forcing — this is the mechanism that keeps operations
+			// stuck in "Processing" when CompleteRequest is never called.
+			// At debug level to avoid noise in normal operation, but
+			// invaluable for diagnosing stuck operations.
+			h.Logger().Debug("forcing status to Processing due to progress > 0",
+				zap.Uint("requestID", requestID),
+				zap.Float64("progressPercent", progress.ProgressPercent),
+				zap.String("dbStatus", string(req.Status)),
+				zap.String("forcedStatus", string(models.RequestStatusProcessing)))
 			status.State = models.RequestStatusProcessing
 		}
 	} else {

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -342,6 +342,7 @@ func (s *StandaloneCoordinator) EnqueueJob(ctx context.Context, jobID uuid.UUID)
 			zap.String("jobID", jobID.String()),
 			zap.String("jobName", jobName),
 			zap.Error(err),
+			zap.NamedError("ctxErr", jobCtx.Err()),
 		}
 
 		// Check if this error is from a recovered panic

--- a/service/request.go
+++ b/service/request.go
@@ -568,6 +568,9 @@ func (r *RequestServiceDefault) CompleteRequest(ctx context.Context, id uint) er
 
 	// Don't complete if already completed or failed
 	if req.Status == models.RequestStatusCompleted || req.Status == models.RequestStatusFailed {
+		r.Logger().Debug("CompleteRequest skipped: request already terminal",
+			zap.Uint("requestID", id),
+			zap.String("currentStatus", string(req.Status)))
 		return nil
 	}
 
@@ -620,6 +623,11 @@ func (r *RequestServiceDefault) CompleteRequest(ctx context.Context, id uint) er
 			if protocol != requestMetrics.LabelProtocolUnknown {
 				requestMetrics.RequestsByProtocol.WithLabelValues(protocol).Inc()
 			}
+
+			r.Logger().Debug("request completed successfully",
+				zap.Uint("requestID", id),
+				zap.String("protocol", protocol),
+				zap.String("operation", operation))
 
 			return nil
 		},

--- a/service/workflow_cron.go
+++ b/service/workflow_cron.go
@@ -70,6 +70,10 @@ func (j *workflowStepExecutorJob) Run(ctx core.Context, eventCtx context.Context
 		return nil
 	}
 
+	ctx.Logger().Debug("workflow step execution started",
+		zap.Uint("requestID", args),
+		zap.NamedError("ctxErr", execCtx.Err()))
+
 	// Execute the workflow step
 	err = workflowSvc.ExecuteWorkflowStep(execCtx, args)
 	if err != nil {
@@ -105,6 +109,11 @@ func (j *workflowStepExecutorJob) Run(ctx core.Context, eventCtx context.Context
 		}
 	}
 
+	ctx.Logger().Debug("workflow step execution completed",
+		zap.Uint("requestID", args),
+		zap.NamedError("execErr", err),
+		zap.NamedError("ctxErr", execCtx.Err()))
+
 	// Check if the step can still be transitioned (may have been completed by ExecuteWorkflowStep)
 	canTransition, err = workflowSvc.CanTransition(execCtx, args)
 	if err != nil {
@@ -113,6 +122,8 @@ func (j *workflowStepExecutorJob) Run(ctx core.Context, eventCtx context.Context
 
 	// Only complete the step if it's still pending and can be transitioned
 	if canTransition {
+		ctx.Logger().Debug("completing workflow step",
+			zap.Uint("requestID", args))
 		// If execution was successful (or we're continuing despite failure), advance to the next step
 		err = workflowSvc.CompleteWorkflowStep(execCtx, args)
 		if err != nil {


### PR DESCRIPTION
Add targeted debug log lines at key diagnostic points in the workflow
cron executor and request status tracking to help identify why
operations get stuck in Processing state:

- workflow_cron.go: log execution start/complete with ctxErr, and
  log before CompleteWorkflowStep
- operation.go: log when GetStatusFromWorkflowData forces status to
  Processing due to progress > 0
- request.go: log when CompleteRequest skips (already terminal) and
  on successful completion
- standalone_coordinator.go: add ctxErr to Job execution failed log

These logs target the root cause where context cancellation prevents
CompleteRequest from being called, leaving operations permanently stuck
in Processing.

---

<!-- kody-pr-summary:start -->
This pull request adds debug-level logging to diagnose issues with workflow execution and request status transitions. The changes include:

1. **Status forcing diagnostics** (`core/operation.go`): Added debug logging when the system forces a request status to "Processing" due to progress percentage being greater than zero. This helps identify why operations might get stuck in a processing state when completion is never called.

2. **Job context error tracking** (`service/internal/cron/standalone_coordinator.go`): Added the job context error (`ctxErr`) to the error log output when an enqueued job fails. This provides additional context about whether the failure was due to context cancellation or another issue.

3. **Request completion logging** (`service/request.go`): Added two debug log statements:
   - When `CompleteRequest` is skipped because the request is already in a terminal state (completed/failed), logging the current status
   - When a request is successfully completed, logging the request ID, protocol, and operation for tracking purposes

4. **Workflow step execution logging** (`service/workflow_cron.go`): Added debug logging at key points in the workflow step execution lifecycle:
   - When workflow step execution starts (including context error state)
   - When workflow step execution completes (including execution and context errors)
   - When completing a workflow step, logging the request ID

These logging additions help diagnose issues with stuck operations, workflow transitions, and request lifecycle management without affecting runtime behavior since they're all at debug level.
<!-- kody-pr-summary:end -->