### PR TITLE
fix(config): use Go property names as defaults map keys

### DIFF
--- a/config/cron.go
+++ b/config/cron.go
@@ -43,9 +43,9 @@ func (w WorkflowConfig) Schema() z.ZogSchema {
 
 func (w WorkflowConfig) Defaults() map[string]any {
 	return map[string]any{
-		"max_retries":          5,
-		"initial_retry_delay": "30s",
-		"retry_backoff_factor": 2.0,
+		"MaxRetries":         5,
+		"InitialRetryDelay":  "30s",
+		"RetryBackoffFactor": 2.0,
 	}
 }
 
@@ -61,12 +61,12 @@ func (c CronConfig) Schema() z.ZogSchema {
 
 func (c CronConfig) Defaults() map[string]any {
 	return map[string]any{
-		"enabled":   true,
-		"queue_limit": 50,
-		"workflow": map[string]any{
-			"max_retries":          5,
-			"initial_retry_delay":  "30s",
-			"retry_backoff_factor": 2.0,
+		"Enabled":  true,
+		"MaxQueue": 50,
+		"Workflow": map[string]any{
+			"MaxRetries":         5,
+			"InitialRetryDelay":  "30s",
+			"RetryBackoffFactor": 2.0,
 		},
 	}
 }


### PR DESCRIPTION
## What

PR #1802 introduced a regression: it changed the `CronConfig` / `WorkflowConfig` `Defaults()` map keys from the Go property names (`Enabled`, `MaxQueue`, `Workflow`) to the lowercase `config` tags (`enabled`, `queue_limit`, `workflow`).

Defaults are applied against the struct field names, so the lowercase keys were not resolving. This restores the capitalized Go property names in both `Defaults()` methods, matching the established pattern (e.g. `TracingConfig.Defaults()` uses `MaxQueueSize`).

## Changes

- `config/cron.go`:
  - `CronConfig.Defaults()` keys: `Enabled`, `MaxQueue`, `Workflow`
  - `WorkflowConfig.Defaults()` keys: `MaxRetries`, `InitialRetryDelay`, `RetryBackoffFactor`

Verified: `gofmt` clean, `go build ./config/...` passes.

---

<!-- kody-pr-summary:start -->
This pull request fixes configuration default values in the cron module by updating the map keys to use Go property names instead of JSON-style snake_case names.

**Changes made:**

- Updated `WorkflowConfig.Defaults()` to use Go property names:
  - Changed `"max_retries"` → `"MaxRetries"`
  - Changed `"initial_retry_delay"` → `"InitialRetryDelay"`
  - Changed `"retry_backoff_factor"` → `"RetryBackoffFactor"`

- Updated `CronConfig.Defaults()` to use Go property names:
  - Changed `"enabled"` → `"Enabled"`
  - Changed `"queue_limit"` → `"MaxQueue"`
  - Changed `"workflow"` → `"Workflow"`
  - Updated nested workflow defaults to use Go property names (`"MaxRetries"`, `"InitialRetryDelay"`, `"RetryBackoffFactor"`)

**Purpose:**
This ensures that the configuration defaults map keys align with the Go struct property names used by the configuration system, allowing proper default value application when the configuration is hydrated/merged with user-provided values. Previously, the snake_case keys would not match the struct fields, causing defaults to be ignored or not applied correctly.
<!-- kody-pr-summary:end -->