### PR TITLE
fix(cron): run DeadJobCheckJob every 30m + startup stuck-job recovery

### DIFF
--- a/config/cron.go
+++ b/config/cron.go
@@ -21,9 +21,10 @@ type WorkflowConfig struct {
 }
 
 type CronConfig struct {
-	Enabled  bool           `config:"enabled"`
-	MaxQueue uint           `config:"queue_limit"`
-	Workflow WorkflowConfig `config:"workflow"`
+	Enabled                     bool           `config:"enabled"`
+	MaxQueue                    uint           `config:"queue_limit"`
+	DeadJobCheckIntervalMinutes uint           `config:"dead_job_check_interval_minutes"`
+	Workflow                    WorkflowConfig `config:"workflow"`
 }
 
 func (w WorkflowConfig) Schema() z.ZogSchema {
@@ -56,13 +57,17 @@ func (c CronConfig) Schema() z.ZogSchema {
 		"MaxQueue": z.Int().
 			Default(50).
 			GT(0, z.Message("queue limit must be greater than 0")),
+		"DeadJobCheckIntervalMinutes": z.Int().
+			Default(30).
+			GT(0, z.Message("dead_job_check_interval_minutes must be greater than 0")),
 	})
 }
 
 func (c CronConfig) Defaults() map[string]any {
 	return map[string]any{
-		"Enabled":  true,
-		"MaxQueue": 50,
+		"Enabled":                     true,
+		"MaxQueue":                    50,
+		"DeadJobCheckIntervalMinutes": 30,
 		"Workflow": map[string]any{
 			"MaxRetries":         5,
 			"InitialRetryDelay":  "30s",

--- a/core/cron.go
+++ b/core/cron.go
@@ -32,6 +32,8 @@ const (
 	CronScheduleTypeCron CronScheduleType = "cron"
 	// CronScheduleTypeOnce indicates a job should run only once.
 	CronScheduleTypeOnce CronScheduleType = "once"
+	// CronScheduleTypeDuration indicates a job should run on a fixed duration interval (in minutes).
+	CronScheduleTypeDuration CronScheduleType = "duration"
 )
 
 // Cronable is an interface for entities that can register and schedule cron jobs.

--- a/core/internal/service_tests/cron_standalone_coordinator_test.go
+++ b/core/internal/service_tests/cron_standalone_coordinator_test.go
@@ -288,9 +288,9 @@ func TestStandaloneCoordinator_HandleFailedJob_RequeueFailureKeepsFailed(t *test
 
 		mockCronService.EXPECT().Monitor().Return(mockMonitor)
 		mockMonitor.EXPECT().StopHeartbeat(mock.Anything, jobID).Return().Once()
-		// Requeue happens before the Failed -> Queued transition, so if
-		// EnqueueJob fails only the Running -> Failed transition occurs.
-		mockCronService.EXPECT().StateMachine().Return(realSM).Once()
+		// Transition ordering: Running -> Failed, then Failed -> Queued,
+		// then EnqueueJob (fails), then rollback Queued -> Failed.
+		mockCronService.EXPECT().StateMachine().Return(realSM).Times(3)
 		mockCronService.EXPECT().JobFactory().Return(mockJobFactory).Maybe()
 		mockCronService.EXPECT().ScheduleRegistry().Return(mockScheduleRegistry).Maybe()
 		mockScheduleRegistry.EXPECT().Create(mock.Anything).Return(gocron.DurationJob(time.Second), nil).Once()

--- a/core/internal/service_tests/cron_standalone_coordinator_test.go
+++ b/core/internal/service_tests/cron_standalone_coordinator_test.go
@@ -190,3 +190,114 @@ func TestStandaloneCoordinator_EnqueueJob(t *testing.T) {
 		mockScheduleRegistry.AssertExpectations(t)
 	})
 }
+
+func TestStandaloneCoordinator_HandleFailedJob_ResetsToQueuedOnRetry(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		require.NotNil(tb, db)
+
+		jobID := uuid.New()
+
+		// A Running job with no retry policy. maxFailures defaults to 5, so
+		// a failure count of 1 is NOT permanent and should be requeued.
+		job := models.CronJob{
+			UUID:    types.FromUUID(jobID),
+			State:   models.CronJobStateRunning,
+			Version: 1,
+			JobType: "test-job",
+		}
+		require.NoError(tb, db.Create(&job).Error)
+
+		// Real state machine backed by the real DB so the full
+		// Running -> Failed -> Queued lifecycle is exercised.
+		realSM := service.NewCronJobStateMachine(ctx, service.NewStateMachineRegistry(ctx))
+
+		mockCronService := coreMocks.NewMockCronService(t)
+		mockMonitor := coreMocks.NewMockCronMonitor(t)
+		mockJobFactory := coreMocks.NewMockCronJobFactory(t)
+		mockScheduleRegistry := coreMocks.NewMockCronScheduleRegistry(t)
+
+		mockCronService.EXPECT().Monitor().Return(mockMonitor)
+		mockMonitor.EXPECT().StopHeartbeat(mock.Anything, jobID).Return().Once()
+		mockCronService.EXPECT().StateMachine().Return(realSM).Times(2) // Failed, then Queued
+		mockCronService.EXPECT().JobFactory().Return(mockJobFactory).Maybe()
+		mockCronService.EXPECT().ScheduleRegistry().Return(mockScheduleRegistry).Maybe()
+		mockScheduleRegistry.EXPECT().Create(mock.Anything).Return(gocron.DurationJob(time.Second), nil).Once()
+
+		// Mock the gocron scheduler so EnqueueJob doesn't really schedule.
+		gomockController := gomock.NewController(t)
+		mockScheduler := gocronmocks.NewMockScheduler(gomockController)
+		mockGocronJob := gocronmocks.NewMockJob(gomockController)
+		mockScheduler.EXPECT().Update(
+			jobID,
+			gomock.Any(), // JobDefinition
+			gomock.Any(), // Task
+			gomock.Any(), // JobOption
+		).Return(mockGocronJob, nil).Times(1)
+
+		coordinator, err := service.NewStandaloneCoordinator(
+			ctx,
+			mockCronService,
+			coreMocks.NewMockCronJobStateMachineRegistry(t),
+			service.NewCoordinatorOptions().
+				WithScheduler(mockScheduler),
+		)
+		require.NoError(t, err)
+
+		// Execute — non-permanent failure, should requeue and reset to Queued
+		err = coordinator.HandleFailedJob(nil, jobID, 1)
+		require.NoError(t, err)
+
+		// The requeued job must be back in Queued so SetupJob/CleanupJob can
+		// cycle it through Running -> Completed on the next execution.
+		var updated models.CronJob
+		require.NoError(tb, db.First(&updated, "uuid = ?", types.FromUUID(jobID)).Error)
+		assert.Equal(t, models.CronJobStateQueued, updated.State,
+			"non-permanent retry must reset the job to Queued for clean lifecycle cycling")
+	})
+}
+
+func TestStandaloneCoordinator_HandleFailedJob_PermanentFailureStaysFailed(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		require.NotNil(tb, db)
+
+		jobID := uuid.New()
+
+		job := models.CronJob{
+			UUID:    types.FromUUID(jobID),
+			State:   models.CronJobStateRunning,
+			Version: 1,
+			JobType: "test-job",
+		}
+		require.NoError(tb, db.Create(&job).Error)
+
+		realSM := service.NewCronJobStateMachine(ctx, service.NewStateMachineRegistry(ctx))
+
+		mockCronService := coreMocks.NewMockCronService(t)
+		mockMonitor := coreMocks.NewMockCronMonitor(t)
+		mockJobFactory := coreMocks.NewMockCronJobFactory(t)
+		mockCronService.EXPECT().Monitor().Return(mockMonitor)
+		mockMonitor.EXPECT().StopHeartbeat(mock.Anything, jobID).Return().Once()
+		mockCronService.EXPECT().JobFactory().Return(mockJobFactory).Maybe()
+		// Only one transition: Running -> Failed. No requeue happens.
+		mockCronService.EXPECT().StateMachine().Return(realSM).Once()
+
+		coordinator, err := service.NewStandaloneCoordinator(
+			ctx,
+			mockCronService,
+			coreMocks.NewMockCronJobStateMachineRegistry(t),
+			service.NewCoordinatorOptions(),
+		)
+		require.NoError(t, err)
+
+		// failures (5) >= maxFailures (5 default) -> permanent
+		err = coordinator.HandleFailedJob(nil, jobID, 5)
+		require.NoError(t, err)
+
+		var updated models.CronJob
+		require.NoError(tb, db.First(&updated, "uuid = ?", types.FromUUID(jobID)).Error)
+		assert.Equal(t, models.CronJobStateFailed, updated.State,
+			"permanent failure must leave the job in Failed state")
+	})
+}

--- a/core/internal/service_tests/cron_standalone_coordinator_test.go
+++ b/core/internal/service_tests/cron_standalone_coordinator_test.go
@@ -265,6 +265,67 @@ func TestStandaloneCoordinator_HandleFailedJob_ResetsToQueuedOnRetry(t *testing.
 	})
 }
 
+func TestStandaloneCoordinator_HandleFailedJob_RequeueFailureKeepsFailed(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		require.NotNil(tb, db)
+
+		jobID := uuid.New()
+		job := models.CronJob{
+			UUID:    types.FromUUID(jobID),
+			State:   models.CronJobStateRunning,
+			Version: 1,
+			JobType: "test-job",
+		}
+		require.NoError(tb, db.Create(&job).Error)
+
+		realSM := service.NewCronJobStateMachine(ctx, service.NewStateMachineRegistry(ctx))
+
+		mockCronService := coreMocks.NewMockCronService(t)
+		mockMonitor := coreMocks.NewMockCronMonitor(t)
+		mockJobFactory := coreMocks.NewMockCronJobFactory(t)
+		mockScheduleRegistry := coreMocks.NewMockCronScheduleRegistry(t)
+
+		mockCronService.EXPECT().Monitor().Return(mockMonitor)
+		mockMonitor.EXPECT().StopHeartbeat(mock.Anything, jobID).Return().Once()
+		// Requeue happens before the Failed -> Queued transition, so if
+		// EnqueueJob fails only the Running -> Failed transition occurs.
+		mockCronService.EXPECT().StateMachine().Return(realSM).Once()
+		mockCronService.EXPECT().JobFactory().Return(mockJobFactory).Maybe()
+		mockCronService.EXPECT().ScheduleRegistry().Return(mockScheduleRegistry).Maybe()
+		mockScheduleRegistry.EXPECT().Create(mock.Anything).Return(gocron.DurationJob(time.Second), nil).Once()
+
+		// Simulate a scheduler failure during requeue.
+		gomockController := gomock.NewController(t)
+		mockScheduler := gocronmocks.NewMockScheduler(gomockController)
+		mockScheduler.EXPECT().Update(
+			jobID,
+			gomock.Any(),
+			gomock.Any(),
+			gomock.Any(),
+		).Return(nil, fmt.Errorf("scheduler unavailable")).Times(1)
+
+		coordinator, err := service.NewStandaloneCoordinator(
+			ctx,
+			mockCronService,
+			coreMocks.NewMockCronJobStateMachineRegistry(t),
+			service.NewCoordinatorOptions().WithScheduler(mockScheduler),
+		)
+		require.NoError(t, err)
+
+		err = coordinator.HandleFailedJob(nil, jobID, 1)
+		require.Error(t, err)
+
+		// Requeue failed, so the job must NOT have been flipped to Queued
+		// without being registered with the scheduler. It stays Failed and can
+		// be retried later.
+		var updated models.CronJob
+		require.NoError(tb, db.First(&updated, "uuid = ?", types.FromUUID(jobID)).Error)
+		assert.Equal(t, models.CronJobStateFailed, updated.State,
+			"job must remain Failed when requeue fails, not be left stuck in Queued")
+	})
+}
+
 func TestStandaloneCoordinator_HandleFailedJob_PermanentFailureStaysFailed(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()

--- a/core/internal/service_tests/cron_standalone_coordinator_test.go
+++ b/core/internal/service_tests/cron_standalone_coordinator_test.go
@@ -254,6 +254,14 @@ func TestStandaloneCoordinator_HandleFailedJob_ResetsToQueuedOnRetry(t *testing.
 		require.NoError(tb, db.First(&updated, "uuid = ?", types.FromUUID(jobID)).Error)
 		assert.Equal(t, models.CronJobStateQueued, updated.State,
 			"non-permanent retry must reset the job to Queued for clean lifecycle cycling")
+
+		// The accumulated failure count must be preserved through the
+		// Failed -> Queued transition. RequeueStuckJobs uses the DB failures
+		// column as its source of truth, so zeroing it here would let
+		// dead-job-detected retries loop forever without ever hitting the
+		// permanent-failure threshold.
+		assert.Equal(t, uint(1), updated.Failures,
+			"retry must preserve the accumulated failure count")
 	})
 }
 

--- a/core/internal/service_tests/cron_test.go
+++ b/core/internal/service_tests/cron_test.go
@@ -374,6 +374,32 @@ func TestCronServiceDefault_StartStop(t *testing.T) {
 	})
 }
 
+func TestCronServiceDefault_StartWithCronDisabledSkipsRecoveryAndScheduler(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		_, cfgErr := coreTesting.WithConfig("core.cron.enabled", false)(ctx)
+		require.NoError(t, cfgErr)
+
+		db := ctx.DB()
+		require.NotNil(tb, db)
+
+		coord := coreMocks.NewMockCronCoordinator(tb)
+		monitor := coreMocks.NewMockCronMonitor(tb)
+
+		// Maintenance-job registration still enqueues jobs even when the
+		// scheduler is disabled, so allow EnqueueJob/Jobs.
+		coord.EXPECT().Jobs().Return(nil).Maybe()
+		coord.EXPECT().EnqueueJob(mock.Anything, mock.Anything).Return(nil).Maybe()
+		monitor.EXPECT().CleanupOrphanedJobs(mock.Anything).Return(0, nil).Maybe()
+		// coordinator.Start() and monitor.RequeueStuckJobs() must NOT be
+		// called when cron is disabled. If either is invoked, the testify mock
+		// fails the test.
+
+		cronService := service.NewTestingCronService(ctx, db, coord, nil, nil, nil, monitor)
+		err := cronService.Start(nil)
+		require.NoError(t, err)
+	})
+}
+
 func TestCronServiceDefault_Monitor(t *testing.T) {
 	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
 		db := ctx.DB()

--- a/core/internal/service_tests/cron_test.go
+++ b/core/internal/service_tests/cron_test.go
@@ -423,3 +423,30 @@ func TestCronServiceDefault_Monitor(t *testing.T) {
 		assert.Equal(t, monitor, retrievedMonitor)
 	})
 }
+
+func TestCronJobStateMachine_QueuedToFailedRollback(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		db := ctx.DB()
+		require.NotNil(tb, db)
+
+		jobID := uuid.New()
+		job := models.CronJob{
+			UUID:    types.FromUUID(jobID),
+			State:   models.CronJobStateQueued,
+			Version: 1,
+			JobType: "test-job",
+		}
+		require.NoError(tb, db.Create(&job).Error)
+
+		sm := service.NewCronJobStateMachine(ctx, service.NewStateMachineRegistry(ctx))
+
+		// Queued -> Failed must succeed (rollback path in HandleFailedJob).
+		err := sm.Transition(nil, jobID, models.CronJobStateFailed, core.WithCronFailures(1))
+		require.NoError(t, err)
+
+		var updated models.CronJob
+		require.NoError(tb, db.First(&updated, "uuid = ?", types.FromUUID(jobID)).Error)
+		assert.Equal(t, models.CronJobStateFailed, updated.State)
+		assert.Equal(t, uint(1), updated.Failures)
+	})
+}

--- a/service/cron.go
+++ b/service/cron.go
@@ -234,17 +234,19 @@ func (c *CronServiceDefault) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-	}
 
-	// Recover jobs that were left in the Running state by a crash on the
-	// previous boot. loadJobsFromDB only re-registers Queued jobs, so without
-	// this sweep stuck Running jobs would sit until the next DeadJobCheckJob.
-	// Run it asynchronously so startup is not blocked on the DB sweep.
-	go func() {
-		if err := c.monitor.RequeueStuckJobs(context.Background()); err != nil {
-			c.Logger().Error("Startup stuck job recovery failed", zap.Error(err))
-		}
-	}()
+		// Recover jobs that were left in the Running state by a crash on the
+		// previous boot. loadJobsFromDB only re-registers Queued jobs, so
+		// without this sweep stuck Running jobs would sit until the next
+		// DeadJobCheckJob. Run it asynchronously so startup is not blocked on
+		// the DB sweep, and only when cron is enabled so we never mutate cron
+		// state for a disabled subsystem.
+		go func() {
+			if err := c.monitor.RequeueStuckJobs(context.Background()); err != nil {
+				c.Logger().Error("Startup stuck job recovery failed", zap.Error(err))
+			}
+		}()
+	}
 
 	return nil
 }

--- a/service/cron.go
+++ b/service/cron.go
@@ -21,15 +21,15 @@ import (
 var _ core.CronService = (*CronServiceDefault)(nil)
 
 var (
-	NewJobFactory              = cron.NewJobFactory
-	NewScheduleRegistry        = cron.NewScheduleRegistry
-	NewCronJobStateMachine     = cron.NewCronJobStateMachine
-	NewStateMachineRegistry    = cron.NewStateMachineRegistry
-	NewDefaultCronMonitor      = cron.NewDefaultCronMonitor
-	NewStandaloneCoordinator   = cron.NewStandaloneCoordinator
-	NewCoordinatorOptions      = cron.NewCoordinatorOptions
-	NewCoordinatorFromContext  = cron.NewCoordinatorFromContext
-	NewJobCreator              = cron.NewJobCreator
+	NewJobFactory             = cron.NewJobFactory
+	NewScheduleRegistry       = cron.NewScheduleRegistry
+	NewCronJobStateMachine    = cron.NewCronJobStateMachine
+	NewStateMachineRegistry   = cron.NewStateMachineRegistry
+	NewDefaultCronMonitor     = cron.NewDefaultCronMonitor
+	NewStandaloneCoordinator  = cron.NewStandaloneCoordinator
+	NewCoordinatorOptions     = cron.NewCoordinatorOptions
+	NewCoordinatorFromContext = cron.NewCoordinatorFromContext
+	NewJobCreator             = cron.NewJobCreator
 
 	// ErrCronJobNotFound is returned when a cron job cannot be found.
 	ErrCronJobNotFound = cron.ErrCronJobNotFound
@@ -236,6 +236,16 @@ func (c *CronServiceDefault) Start(ctx context.Context) error {
 		}
 	}
 
+	// Recover jobs that were left in the Running state by a crash on the
+	// previous boot. loadJobsFromDB only re-registers Queued jobs, so without
+	// this sweep stuck Running jobs would sit until the next DeadJobCheckJob.
+	// Run it asynchronously so startup is not blocked on the DB sweep.
+	go func() {
+		if err := c.monitor.RequeueStuckJobs(context.Background()); err != nil {
+			c.Logger().Error("Startup stuck job recovery failed", zap.Error(err))
+		}
+	}()
+
 	return nil
 }
 
@@ -256,7 +266,8 @@ func (c *CronServiceDefault) registerMaintenanceJobs(ctx context.Context) error 
 			),
 		}, nil
 	}, &core.CronScheduleDefinition{
-		Type: core.CronScheduleTypeDaily,
+		Type:     core.CronScheduleTypeDuration,
+		Interval: c.Config().Config().Core.Cron.DeadJobCheckIntervalMinutes,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to register dead job check job: %w", err)

--- a/service/internal/cron/job_state.go
+++ b/service/internal/cron/job_state.go
@@ -10,6 +10,7 @@ package cron
 //   Queued -> Running (via "run" event)
 //   Running -> Completed (via "complete" event)
 //   Running -> Failed (via "fail" event)
+//   Queued -> Failed (via "fail" event, rollback from failed requeue)
 //   Completed -> Queued (via "reset" event)
 //   Failed -> Queued (via "reset" event)
 //
@@ -65,7 +66,8 @@ var (
 			string(models.CronJobStateRunning), // Only Running can go to Completed
 		},
 		models.CronJobStateFailed: {
-			string(models.CronJobStateRunning), // Only Running can go to Failed
+			string(models.CronJobStateRunning), // Running can fail
+			string(models.CronJobStateQueued),  // Queued can be rolled back to Failed
 		},
 		models.CronJobStateQueued: {
 			string(models.CronJobStateCompleted), // Completed can reset to Queued

--- a/service/internal/cron/schedule_registry.go
+++ b/service/internal/cron/schedule_registry.go
@@ -178,6 +178,15 @@ func (r *DefaultScheduleRegistry) createHourlyJob(def core.CronScheduleDefinitio
 	return gocron.DurationJob(time.Duration(interval) * time.Hour), nil
 }
 
+// createDurationJob creates a job that runs every Interval minutes.
+func (r *DefaultScheduleRegistry) createDurationJob(def core.CronScheduleDefinition) (gocron.JobDefinition, error) {
+	interval := uint(30)
+	if def.Interval > 0 {
+		interval = def.Interval
+	}
+	return gocron.DurationJob(time.Duration(interval) * time.Minute), nil
+}
+
 func (r *DefaultScheduleRegistry) createOnceJob(def core.CronScheduleDefinition) (gocron.JobDefinition, error) {
 	if def.AtTime.IsZero() {
 		def.AtTime = time.Now().Add(10 * time.Second)
@@ -194,4 +203,5 @@ func (r *DefaultScheduleRegistry) registerBuiltinTypes() {
 	r.Register(core.CronScheduleTypeHourly, r.createHourlyJob)
 	r.Register(core.CronScheduleTypeCron, r.createCronJob)
 	r.Register(core.CronScheduleTypeOnce, r.createOnceJob)
+	r.Register(core.CronScheduleTypeDuration, r.createDurationJob)
 }

--- a/service/internal/cron/schedule_registry_test.go
+++ b/service/internal/cron/schedule_registry_test.go
@@ -67,6 +67,7 @@ func TestDefaultScheduleRegistry_GetRegisteredTypes(t *testing.T) {
 	assert.Contains(t, types, core.CronScheduleTypeMonthly)
 	assert.Contains(t, types, core.CronScheduleTypeCron)
 	assert.Contains(t, types, core.CronScheduleTypeOnce)
+	assert.Contains(t, types, core.CronScheduleTypeDuration)
 }
 
 func TestDefaultScheduleRegistry_Validate(t *testing.T) {
@@ -173,6 +174,18 @@ func TestDefaultScheduleRegistry_createOnceJob_MissingTime(t *testing.T) {
 	}
 
 	jobDefinition, err := registry.createOnceJob(def)
+	assert.NoError(t, err)
+	assert.NotNil(t, jobDefinition)
+}
+
+func TestDefaultScheduleRegistry_createDurationJob(t *testing.T) {
+	registry := NewScheduleRegistry()
+	def := core.CronScheduleDefinition{
+		Type:     core.CronScheduleTypeDuration,
+		Interval: 30,
+	}
+
+	jobDefinition, err := registry.createDurationJob(def)
 	assert.NoError(t, err)
 	assert.NotNil(t, jobDefinition)
 }

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -486,7 +486,16 @@ func (s *StandaloneCoordinator) HandleFailedJob(ctx context.Context, jobID uuid.
 		return nil
 	}
 
-	// Reset the job to Queued before requeueing. SetupJob only cycles
+	// Requeue the job for retry first so the job is registered with the
+	// scheduler before we flip its state. If EnqueueJob fails the job stays in
+	// Failed (its current state) and will be retried again later, rather than
+	// being left Queued but never registered with the scheduler (which no
+	// DeadJobCheck/RequeueStuckJobs sweep would recover).
+	if err := s.EnqueueJob(ctx, jobID); err != nil {
+		return fmt.Errorf("failed to requeue job: %w", err)
+	}
+
+	// Reset the job to Queued after scheduling. SetupJob only cycles
 	// Queued -> Running and CleanupJob only cycles Running -> Completed, so
 	// if we left the job in Failed the retry would execute business logic but
 	// never return to a completed state. Failed -> Queued is a valid FSM
@@ -498,11 +507,6 @@ func (s *StandaloneCoordinator) HandleFailedJob(ctx context.Context, jobID uuid.
 		core.WithCronFailures(int(failures)),
 	); err != nil {
 		return fmt.Errorf("failed to reset job to queued state for retry: %w", err)
-	}
-
-	// Requeue the job for retry
-	if err := s.EnqueueJob(ctx, jobID); err != nil {
-		return fmt.Errorf("failed to requeue job: %w", err)
 	}
 
 	return nil

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -486,6 +486,19 @@ func (s *StandaloneCoordinator) HandleFailedJob(ctx context.Context, jobID uuid.
 		return nil
 	}
 
+	// Reset the job to Queued before requeueing. SetupJob only cycles
+	// Queued -> Running and CleanupJob only cycles Running -> Completed, so
+	// if we left the job in Failed the retry would execute business logic but
+	// never return to a completed state. Failed -> Queued is a valid FSM
+	// transition that restores the normal lifecycle.
+	if err := s.cronService.StateMachine().Transition(
+		ctx,
+		jobID,
+		models.CronJobStateQueued,
+	); err != nil {
+		return fmt.Errorf("failed to reset job to queued state for retry: %w", err)
+	}
+
 	// Requeue the job for retry
 	if err := s.EnqueueJob(ctx, jobID); err != nil {
 		return fmt.Errorf("failed to requeue job: %w", err)

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -486,20 +486,11 @@ func (s *StandaloneCoordinator) HandleFailedJob(ctx context.Context, jobID uuid.
 		return nil
 	}
 
-	// Requeue the job for retry first so the job is registered with the
-	// scheduler before we flip its state. If EnqueueJob fails the job stays in
-	// Failed (its current state) and will be retried again later, rather than
-	// being left Queued but never registered with the scheduler (which no
-	// DeadJobCheck/RequeueStuckJobs sweep would recover).
-	if err := s.EnqueueJob(ctx, jobID); err != nil {
-		return fmt.Errorf("failed to requeue job: %w", err)
-	}
-
-	// Reset the job to Queued after scheduling. SetupJob only cycles
-	// Queued -> Running and CleanupJob only cycles Running -> Completed, so
-	// if we left the job in Failed the retry would execute business logic but
-	// never return to a completed state. Failed -> Queued is a valid FSM
-	// transition that restores the normal lifecycle.
+	// Reset the job to Queued before scheduling so that SetupJob (called by
+	// gocron's BeforeJobRuns) sees Queued and can transition to Running. If
+	// we EnqueueJob first, the scheduler can fire while the DB state is still
+	// Failed — SetupJob skips the Queued->Running transition and the job
+	// runs with stale state, never reaching Completed.
 	if err := s.cronService.StateMachine().Transition(
 		ctx,
 		jobID,
@@ -507,6 +498,20 @@ func (s *StandaloneCoordinator) HandleFailedJob(ctx context.Context, jobID uuid.
 		core.WithCronFailures(int(failures)),
 	); err != nil {
 		return fmt.Errorf("failed to reset job to queued state for retry: %w", err)
+	}
+
+	// Requeue the job for retry. If EnqueueJob fails, roll back to Failed so
+	// the job is not left Queued-but-unscheduled (which RequeueStuckJobs does
+	// not recover). loadJobsFromDB on next boot will re-register Queued jobs,
+	// and a Failed job will be picked up by the next HandleFailedJob cycle.
+	if err := s.EnqueueJob(ctx, jobID); err != nil {
+		_ = s.cronService.StateMachine().Transition(
+			ctx,
+			jobID,
+			models.CronJobStateFailed,
+			core.WithCronFailures(int(failures)),
+		)
+		return fmt.Errorf("failed to requeue job: %w", err)
 	}
 
 	return nil

--- a/service/internal/cron/standalone_coordinator.go
+++ b/service/internal/cron/standalone_coordinator.go
@@ -495,6 +495,7 @@ func (s *StandaloneCoordinator) HandleFailedJob(ctx context.Context, jobID uuid.
 		ctx,
 		jobID,
 		models.CronJobStateQueued,
+		core.WithCronFailures(int(failures)),
 	); err != nil {
 		return fmt.Errorf("failed to reset job to queued state for retry: %w", err)
 	}


### PR DESCRIPTION
## Summary

Improves recovery of cron jobs stuck in the `Running` state.

### Changes

1. **DeadJobCheckJob frequency → 30 min, configurable**
   - New `core.cron.dead_job_check_interval_minutes` config (default `30`, `> 0`).
   - New `CronScheduleTypeDuration` schedule type (interval in minutes) + `createDurationJob` factory.
   - `registerMaintenanceJobs` schedules DeadJobCheck with `CronScheduleTypeDuration` at the configured interval instead of daily.

2. **Startup stuck-job recovery sweep**
   - `CronServiceDefault.Start()` now runs an async `RequeueStuckJobs` sweep right after `coordinator.Start()`, so jobs left `Running` by a crash recover immediately instead of waiting for the next scheduled sweep.

3. **State machine gap fix**
   - `HandleFailedJob` now transitions non-permanent retries `Failed → Queued` before requeueing, so retries cycle `Queued → Running → Completed` cleanly (previously they executed business logic but stayed `Failed` in bookkeeping).

### Tests
- Duration schedule registered + `createDurationJob` covered.
- `HandleFailedJob` retry resets to `Queued`; permanent failure stays `Failed`.

### Notes / follow-up
- The maintenance job's schedule is persisted in the DB, so an already-registered DeadJobCheck job keeps its old daily schedule until migrated/rescheduled. The startup sweep recovers currently-stuck jobs regardless. A follow-up migration/upsert to update existing DeadJobCheck schedules may be warranted.

---

<!-- kody-pr-summary:start -->
This pull request modifies the cron job scheduling system to run the DeadJobCheckJob every 30 minutes instead of daily, and adds automatic recovery for jobs stuck in a "Running" state after system crashes or restarts.

Key changes include:

1. **Configurable Dead Job Check Interval**: Added a new `DeadJobCheckIntervalMinutes` configuration option (defaulting to 30 minutes) that controls how frequently the DeadJobCheckJob runs to detect and clean up stale/wedged jobs.

2. **New Duration-based Scheduling**: Introduced a new `CronScheduleTypeDuration` schedule type that allows cron jobs to run at fixed minute intervals, replacing the previous daily scheduling for the dead job check maintenance job.

3. **Startup Stuck-Job Recovery**: When the cron service starts, it now automatically scans for and requeues jobs that were left in a "Running" state from a previous session (likely due to a crash or unexpected shutdown). This recovery runs asynchronously in the background to avoid blocking system startup.

4. **Job Retry State Reset**: Fixed an issue where failed jobs being requeued for retry would remain in a "Failed" state, preventing them from completing their lifecycle properly. Jobs being retried are now reset to a "Queued" state, allowing them to cycle through normal execution states (Queued → Running → Completed) on the next attempt.

5. **Comprehensive Test Coverage**: Added tests validating that non-permanent job failures properly requeue and reset to "Queued" state, permanent failures stay in "Failed" state, and that the new duration-based scheduling works correctly.
<!-- kody-pr-summary:end -->
