### PR TITLE
fix(cron): reconcile maintenance job schedule on boot and dedupe stale records

### DIFF
--- a/core/internal/service_tests/cron_reconcile_test.go
+++ b/core/internal/service_tests/cron_reconcile_test.go
@@ -1,0 +1,150 @@
+package service_tests
+
+import (
+	"encoding/json"
+	"testing"
+
+	gocronmocks "github.com/go-co-op/gocron/mocks/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	coreMocks "go.lumeweb.com/portal/core/testing/mocks"
+	"go.lumeweb.com/portal/db/models"
+	"go.lumeweb.com/portal/db/types"
+	"go.lumeweb.com/portal/service"
+	"go.uber.org/mock/gomock"
+	"gorm.io/datatypes"
+)
+
+// deadJobCheckJobType is the persisted job_type of the core Dead Job Check
+// maintenance job. It equals core.GetCronJobIdentifier(JobOriginCore,
+// "cron.dead_job_check"); hardcoded here because the internal constant is not
+// importable from this package.
+const deadJobCheckJobType = "core.cron.dead_job_check"
+
+// startReconcilingCronService builds a CronService backed by a mock gocron
+// scheduler and runs Start(), which exercises registerMaintenanceJobs and the
+// idempotent maintenance-job reconciliation logic.
+func startReconcilingCronService(
+	t *testing.T,
+	tb coreTesting.TB,
+	ctx coreTesting.TestContext,
+) *service.CronServiceDefault {
+	t.Helper()
+
+	gomockController := gomock.NewController(tb)
+	t.Cleanup(gomockController.Finish)
+	mockScheduler := gocronmocks.NewMockScheduler(gomockController)
+
+	mockStateMachineRegistry := coreMocks.NewMockCronJobStateMachineRegistry(tb)
+
+	cronService := service.NewTestingCronService(
+		ctx,
+		ctx.DB(),
+		nil,
+		nil,
+		nil,
+		nil,
+		service.NewDefaultCronMonitor(ctx, nil),
+	)
+
+	coordinator, err := service.NewStandaloneCoordinator(
+		ctx,
+		cronService,
+		mockStateMachineRegistry,
+		service.NewCoordinatorOptions().WithScheduler(mockScheduler),
+	)
+	require.NoError(tb, err)
+
+	cronService.(*service.CronServiceDefault).SetCoordinator(coordinator)
+
+	mockScheduler.EXPECT().Start().Return().AnyTimes()
+	mockScheduler.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+	mockScheduler.EXPECT().RemoveJob(gomock.Any()).Return(nil).AnyTimes()
+	mockScheduler.EXPECT().Jobs().Return(nil).AnyTimes()
+	mockScheduler.EXPECT().Shutdown().Return(nil).AnyTimes()
+
+	require.NoError(tb, cronService.Start(nil))
+
+	return cronService.(*service.CronServiceDefault)
+}
+
+func requireDeadJobCheckJobs(tb coreTesting.TB, ctx coreTesting.TestContext) []models.CronJob {
+	var jobs []models.CronJob
+	require.NoError(tb, ctx.DB().Where(&models.CronJob{JobType: deadJobCheckJobType}).Find(&jobs).Error)
+	return jobs
+}
+
+func TestCronServiceDefault_ReconcileDeadJobCheck_CreatesWhenMissing(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		_, cfgErr := coreTesting.WithConfig("core.cron.dead_job_check_interval_minutes", 30)(ctx)
+		require.NoError(tb, cfgErr)
+
+		startReconcilingCronService(t, tb, ctx)
+
+		jobs := requireDeadJobCheckJobs(tb, ctx)
+		require.Len(tb, jobs, 1, "a single Dead Job Check job should be created on first boot")
+
+		var sched core.CronScheduleDefinition
+		require.NoError(tb, json.Unmarshal(jobs[0].SchedDef, &sched))
+		require.Equal(t, core.CronScheduleTypeDuration, sched.Type)
+		require.Equal(t, uint(30), sched.Interval)
+	})
+}
+
+func TestCronServiceDefault_ReconcileDeadJobCheck_UpdatesDriftedScheduleAndDedupes(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		_, cfgErr := coreTesting.WithConfig("core.cron.dead_job_check_interval_minutes", 30)(ctx)
+		require.NoError(tb, cfgErr)
+
+		// Simulate a deployment that accumulated duplicate Dead Job Check jobs
+		// from earlier boots, the eldest carrying the old daily schedule.
+		canonical := uuid.New()
+		dup := uuid.New()
+		oldSched := datatypes.JSON([]byte(`{"type":"daily"}`))
+		for _, j := range []models.CronJob{
+			{UUID: types.FromUUID(canonical), JobType: deadJobCheckJobType, SchedDef: oldSched, State: models.CronJobStateQueued},
+			{UUID: types.FromUUID(dup), JobType: deadJobCheckJobType, SchedDef: oldSched, State: models.CronJobStateQueued},
+		} {
+			require.NoError(tb, ctx.DB().Create(&j).Error)
+		}
+
+		startReconcilingCronService(t, tb, ctx)
+
+		jobs := requireDeadJobCheckJobs(tb, ctx)
+		require.Len(tb, jobs, 1, "duplicate Dead Job Check jobs must be removed")
+		require.Equal(t, types.FromUUID(canonical), jobs[0].UUID,
+			"the eldest record must be kept as the canonical active job")
+
+		var sched core.CronScheduleDefinition
+		require.NoError(tb, json.Unmarshal(jobs[0].SchedDef, &sched))
+		require.Equal(t, core.CronScheduleTypeDuration, sched.Type)
+		require.Equal(t, uint(30), sched.Interval)
+	})
+}
+
+func TestCronServiceDefault_ReconcileDeadJobCheck_KeepsMatchingSchedule(t *testing.T) {
+	coreTesting.RunTestCaseWithDB(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		_, cfgErr := coreTesting.WithConfig("core.cron.dead_job_check_interval_minutes", 30)(ctx)
+		require.NoError(tb, cfgErr)
+
+		jobID := uuid.New()
+		matching := datatypes.JSON([]byte(`{"type":"duration","interval":30}`))
+		require.NoError(tb, ctx.DB().Create(&models.CronJob{
+			UUID:    types.FromUUID(jobID),
+			JobType: deadJobCheckJobType,
+			SchedDef: matching,
+			State:   models.CronJobStateQueued,
+		}).Error)
+
+		startReconcilingCronService(t, tb, ctx)
+
+		jobs := requireDeadJobCheckJobs(tb, ctx)
+		require.Len(tb, jobs, 1, "no duplicate should be created when only one exists")
+		require.Equal(t, string(matching), string(jobs[0].SchedDef),
+			"a matching schedule must be left untouched")
+	})
+}

--- a/service/cron.go
+++ b/service/cron.go
@@ -256,45 +256,196 @@ func (c *CronServiceDefault) registerMaintenanceJobs(ctx context.Context) error 
 	defer span.End()
 
 	// Register dead job check job using the pre-registered schedule
-	err := c.RegisterJobType(ctx, core.GetCronJobIdentifier(core.JobOriginCore, cron.DeadJobCheckJobType), func() (core.CronJob, error) {
-		return &cron.DeadJobCheckJob{
-			BaseCronJob: core.NewBaseCronJob(
-				uuid.New(),
-				core.JobOriginCore,
-				cron.DeadJobCheckJobType,
-				"Dead Job Check",
-				nil,
-				nil,
-			),
-		}, nil
-	}, &core.CronScheduleDefinition{
-		Type:     core.CronScheduleTypeDuration,
-		Interval: c.Config().Config().Core.Cron.DeadJobCheckIntervalMinutes,
-	})
+	err := c.registerCoreMaintenanceJob(
+		ctx,
+		core.GetCronJobIdentifier(core.JobOriginCore, cron.DeadJobCheckJobType),
+		func() (core.CronJob, error) {
+			return &cron.DeadJobCheckJob{
+				BaseCronJob: core.NewBaseCronJob(
+					uuid.New(),
+					core.JobOriginCore,
+					cron.DeadJobCheckJobType,
+					"Dead Job Check",
+					nil,
+					nil,
+				),
+			}, nil
+		},
+		&core.CronScheduleDefinition{
+			Type:     core.CronScheduleTypeDuration,
+			Interval: c.Config().Config().Core.Cron.DeadJobCheckIntervalMinutes,
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to register dead job check job: %w", err)
 	}
 
 	// Register cleanup job using the pre-registered schedule
-	err = c.RegisterJobType(ctx, core.GetCronJobIdentifier(core.JobOriginCore, cron.CleanupJobType), func() (core.CronJob, error) {
-		return &cron.CleanupJob{
-			BaseCronJob: core.NewBaseCronJob(
-				uuid.New(),
-				core.JobOriginCore,
-				cron.CleanupJobType,
-				"Cleanup Job",
-				nil,
-				nil,
-			),
-		}, nil
-	}, &core.CronScheduleDefinition{
-		Type: core.CronScheduleTypeDaily,
-	})
+	err = c.registerCoreMaintenanceJob(
+		ctx,
+		core.GetCronJobIdentifier(core.JobOriginCore, cron.CleanupJobType),
+		func() (core.CronJob, error) {
+			return &cron.CleanupJob{
+				BaseCronJob: core.NewBaseCronJob(
+					uuid.New(),
+					core.JobOriginCore,
+					cron.CleanupJobType,
+					"Cleanup Job",
+					nil,
+					nil,
+				),
+			}, nil
+		},
+		&core.CronScheduleDefinition{
+			Type: core.CronScheduleTypeDaily,
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to register cleanup job: %w", err)
 	}
 
 	return nil
+}
+
+// registerCoreMaintenanceJob idempotently registers a core maintenance job
+// (e.g. DeadJobCheck, Cleanup) keyed by its job type.
+//
+// Previously maintenance jobs were registered with a fresh random UUID on every
+// boot, which accumulated duplicate DB records (all State=Queued) and scheduled
+// them all. This makes registration reconciling: it reuses the eldest persisted
+// record as the canonical "active" job, force-updates its schedule to match the
+// configured definition if it drifted, cleans up any accumulated duplicates, and
+// reschedules the canonical job through the coordinator.
+func (c *CronServiceDefault) registerCoreMaintenanceJob(
+	ctx context.Context,
+	jobType string,
+	factory core.CronJobFactoryFunc,
+	schedule *core.CronScheduleDefinition,
+) error {
+	ctx, span := core.TraceMethod(ctx, "CronServiceDefault.registerCoreMaintenanceJob")
+	defer span.End()
+
+	// Register the job factory so the job can be materialized on demand.
+	if err := c.jobFactory.RegisterFactory(ctx, jobType, factory, schedule); err != nil {
+		return fmt.Errorf("failed to register job factory for %s: %w", jobType, err)
+	}
+
+	// Find any existing persisted jobs of this type.
+	var existing []models.CronJob
+	if err := c.DB().
+		Where(&models.CronJob{JobType: jobType}).
+		Order("id asc").
+		Find(&existing).Error; err != nil {
+		return fmt.Errorf("failed to query existing %s jobs: %w", jobType, err)
+	}
+
+	if len(existing) == 0 {
+		// No persisted job yet - create one through the normal path.
+		job, err := factory()
+		if err != nil {
+			return fmt.Errorf("failed to create %s job: %w", jobType, err)
+		}
+		return c.RegisterJob(ctx, job, schedule.RetryPolicy)
+	}
+
+	// Reconcile: keep the eldest record as the canonical "active" job and update
+	// its schedule in the database if it differs from the configured one.
+	canonical := existing[0]
+	canonicalID := canonical.UUID.ToUUID()
+	changed, err := c.reconcileMaintenanceSchedule(ctx, &canonical, schedule, jobType)
+	if err != nil {
+		return err
+	}
+
+	// Remove duplicate records that accumulated from previous boots.
+	for _, dup := range existing[1:] {
+		dupID := dup.UUID.ToUUID()
+		if err := c.coordinator.RemoveJob(dupID); err != nil {
+			c.Logger().Warn("Failed to remove duplicate job from scheduler",
+				zap.String("jobType", jobType),
+				zap.String("jobID", dupID.String()),
+				zap.Error(err))
+		}
+		if err := c.DB().Where("uuid = ?", dup.UUID).Delete(&models.CronJob{}).Error; err != nil {
+			c.Logger().Warn("Failed to delete duplicate job record",
+				zap.String("jobType", jobType),
+				zap.String("jobID", dupID.String()),
+				zap.Error(err))
+		} else {
+			c.Logger().Info("Removed duplicate maintenance job",
+				zap.String("jobType", jobType),
+				zap.String("jobID", dupID.String()))
+		}
+	}
+
+	// (Re)schedule the canonical job. EnqueueJob upserts the gocron job keyed by
+	// ID and reads the latest SchedDef from the DB, so this applies the new
+	// schedule immediately.
+	if err := c.coordinator.EnqueueJob(ctx, canonicalID); err != nil {
+		return fmt.Errorf("failed to (re)schedule %s job: %w", jobType, err)
+	}
+
+	if changed {
+		c.Logger().Info("Updated cron job schedule to match configuration",
+			zap.String("jobType", jobType),
+			zap.String("jobID", canonicalID.String()))
+	}
+
+	return nil
+}
+
+// reconcileMaintenanceSchedule updates a persisted job's SchedDef to match the
+// desired configured schedule if it differs. It returns true when a change was
+// written.
+func (c *CronServiceDefault) reconcileMaintenanceSchedule(
+	ctx context.Context,
+	dbJob *models.CronJob,
+	desired *core.CronScheduleDefinition,
+	jobType string,
+) (bool, error) {
+	ctx, span := core.TraceMethod(ctx, "CronServiceDefault.reconcileMaintenanceSchedule")
+	defer span.End()
+
+	if len(dbJob.SchedDef) > 0 {
+		var current core.CronScheduleDefinition
+		if err := json.Unmarshal([]byte(dbJob.SchedDef), &current); err != nil {
+			return false, fmt.Errorf("failed to unmarshal existing schedule for %s: %w", jobType, err)
+		}
+		if cronSchedulesEqual(&current, desired) {
+			return false, nil
+		}
+	} else if desired == nil {
+		return false, nil
+	}
+
+	desiredBytes, err := json.Marshal(desired)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal desired schedule for %s: %w", jobType, err)
+	}
+
+	if err := c.DB().Model(&models.CronJob{}).
+		Where("uuid = ?", dbJob.UUID).
+		Updates(map[string]any{
+			"sched_def":     datatypes.JSON(desiredBytes),
+			"schedule_type": string(desired.Type),
+		}).Error; err != nil {
+		return false, fmt.Errorf("failed to update schedule for %s: %w", jobType, err)
+	}
+
+	return true, nil
+}
+
+// cronSchedulesEqual reports whether two schedule definitions are semantically
+// equivalent for the purposes of reconciliation.
+func cronSchedulesEqual(a, b *core.CronScheduleDefinition) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Type == b.Type &&
+		a.Interval == b.Interval &&
+		a.DayOfWeek == b.DayOfWeek &&
+		a.DayOfMonth == b.DayOfMonth &&
+		a.CronExpression == b.CronExpression
 }
 
 func (c *CronServiceDefault) Monitor() core.CronMonitor {

--- a/service/cron.go
+++ b/service/cron.go
@@ -345,7 +345,11 @@ func (c *CronServiceDefault) registerCoreMaintenanceJob(
 		if err != nil {
 			return fmt.Errorf("failed to create %s job: %w", jobType, err)
 		}
-		return c.RegisterJob(ctx, job, schedule.RetryPolicy)
+		var retryPolicy *core.RetryPolicy
+		if schedule != nil {
+			retryPolicy = schedule.RetryPolicy
+		}
+		return c.RegisterJob(ctx, job, retryPolicy)
 	}
 
 	// Reconcile: keep the eldest record as the canonical "active" job and update
@@ -443,6 +447,7 @@ func cronSchedulesEqual(a, b *core.CronScheduleDefinition) bool {
 	}
 	return a.Type == b.Type &&
 		a.Interval == b.Interval &&
+		a.AtTime.Equal(b.AtTime) &&
 		a.DayOfWeek == b.DayOfWeek &&
 		a.DayOfMonth == b.DayOfMonth &&
 		a.CronExpression == b.CronExpression


### PR DESCRIPTION
Previously each boot allocated a fresh random UUID for core maintenance jobs
(DeadJobCheck, Cleanup), accumulating duplicate DB records over time and
scheduling all of them. If the DeadJobCheck schedule drifted from the
configured interval (e.g. after the interval config was introduced), the
duplicates kept the old schedule and the configured value had no effect.

Make maintenance-job registration reconciling: reuse the eldest persisted
record as the canonical active job, force-update its schedule to the
configured definition when it differs, remove accumulated duplicate records,
and reschedule the canonical job through the coordinator. Registration is
idempotent across boots.

Adds integration tests covering create-when-missing, schedule reconciliation
with duplicate cleanup, and no-op when the schedule already matches.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes the cron job registration for maintenance jobs (Dead Job Check and Cleanup) to prevent duplicate records and ensure schedules are reconciled with configuration on every boot.

## Key Changes

### Idempotent Maintenance Job Registration (`service/cron.go`)
- Refactored `registerMaintenanceJobs` to use a new `registerCoreMaintenanceJob` helper that performs reconciling registration instead of creating fresh records on each boot.
- **Schedule Drift Correction**: On startup, the system now checks existing persisted maintenance job records and updates their schedules to match the currently configured schedule if they've drifted (e.g., when the Dead Job Check interval changes from daily to 30 minutes).
- **Duplicate Cleanup**: Previously, each boot created a new job record with a random UUID, resulting in many duplicate records accumulating over time. The new logic keeps the eldest persisted record as the canonical active job and removes all duplicates.
- **Rescheduling**: After reconciliation, the canonical job is rescheduled through the coordinator to apply any schedule changes immediately.
- Maintenance jobs now remain stable across restarts rather than being recreated with new IDs.

### Test Coverage (`core/internal/service_tests/cron_reconcile_test.go`)
Added three comprehensive tests validating the reconciliation behavior:
1. **CreatesWhenMissing**: A single job record is created on first boot with the configured schedule.
2. **UpdatesDriftedScheduleAndDedupes**: When duplicate records exist with an old schedule, the eldest is retained, duplicates are removed, and the schedule is updated to match configuration.
3. **KeepsMatchingSchedule**: Existing jobs with a matching schedule are left untouched.

## Impact
- Eliminates database clutter from repeated job registrations across deployments.
- Ensures maintenance jobs run on the intended, up-to-date schedule (particularly relevant for the Dead Job Check interval increase to 30 minutes) even if existing persisted records carry an older schedule.
<!-- kody-pr-summary:end -->