### PR TITLE
fix(errors): bridge err into format verb in NewError when args empty

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -321,15 +321,21 @@ func (r *ErrorRegistry) NewError(namespace string, key ErrorType, err error, arg
 	}
 
 	message := def.Message
-	if len(args) > 0 {
+	switch {
+	case len(args) > 0:
 		message = fmt.Sprintf(def.Message, args...) // Format the message
-	} else if err != nil && countFormattedVerbs(def.Message) == 1 {
+	case err != nil && countFormattedVerbs(def.Message) == 1:
 		// Convention: callers pass the descriptive detail via err. Bridge it into
 		// the single format verb so the template reads e.g.
 		// "Invalid request parameter: a domain is required...".
 		// Only bridge when the template resolves to exactly one verb so literal
 		// percent signs and multi-verb templates are left untouched.
 		message = fmt.Sprintf(def.Message, err.Error())
+	case strings.Contains(def.Message, "%%"):
+		// Collapse escaped literal percents (%% -> %). Injecting err here is
+		// intentionally avoided: with no verb to consume it, the argument would
+		// render as a %!(EXTRA ...) marker.
+		message = strings.ReplaceAll(def.Message, "%%", "%")
 	}
 
 	return &Error{

--- a/core/errors.go
+++ b/core/errors.go
@@ -331,7 +331,7 @@ func (r *ErrorRegistry) NewError(namespace string, key ErrorType, err error, arg
 		// Only bridge when the template resolves to exactly one verb so literal
 		// percent signs and multi-verb templates are left untouched.
 		message = fmt.Sprintf(def.Message, err.Error())
-	case strings.Contains(def.Message, "%%"):
+	case countFormattedVerbs(def.Message) == 0 && strings.Contains(def.Message, "%%"):
 		// Collapse escaped literal percents (%% -> %). Injecting err here is
 		// intentionally avoided: with no verb to consume it, the argument would
 		// render as a %!(EXTRA ...) marker.

--- a/core/errors.go
+++ b/core/errors.go
@@ -323,10 +323,12 @@ func (r *ErrorRegistry) NewError(namespace string, key ErrorType, err error, arg
 	message := def.Message
 	if len(args) > 0 {
 		message = fmt.Sprintf(def.Message, args...) // Format the message
-	} else if err != nil && strings.Contains(def.Message, "%") {
+	} else if err != nil && countFormattedVerbs(def.Message) == 1 {
 		// Convention: callers pass the descriptive detail via err. Bridge it into
-		// any format verb so the template reads e.g.
+		// the single format verb so the template reads e.g.
 		// "Invalid request parameter: a domain is required...".
+		// Only bridge when the template resolves to exactly one verb so literal
+		// percent signs and multi-verb templates are left untouched.
 		message = fmt.Sprintf(def.Message, err.Error())
 	}
 
@@ -448,4 +450,51 @@ func NewError(namespace string, key ErrorType, err error, args ...any) *Error {
 	errorRegistryMu.RLock()
 	defer errorRegistryMu.RUnlock()
 	return errorRegistry.NewError(namespace, key, err, args...)
+}
+
+// countFormattedVerbs returns the number of format verbs (directives that
+// consume an argument) in s. A literal percent sign ("%%") is not a verb, and
+// malformed trailing "%" without a verb is ignored.
+func countFormattedVerbs(s string) int {
+	count := 0
+	for i := 0; i < len(s); {
+		if s[i] != '%' {
+			i++
+			continue
+		}
+		i++ // consume '%'
+		if i < len(s) && s[i] == '%' {
+			i++ // literal percent, not a verb
+			continue
+		}
+		// Skip flags.
+		for i < len(s) && strings.ContainsRune("#0+- ", rune(s[i])) {
+			i++
+		}
+		// Skip width (digits or '*').
+		for i < len(s) && (s[i] == '*' || (s[i] >= '0' && s[i] <= '9')) {
+			i++
+		}
+		// Skip precision ('.' followed by digits or '*').
+		if i < len(s) && s[i] == '.' {
+			i++
+			for i < len(s) && (s[i] == '*' || (s[i] >= '0' && s[i] <= '9')) {
+				i++
+			}
+		}
+		// Skip argument index '[n]'.
+		if i < len(s) && s[i] == '[' {
+			for i < len(s) && s[i] != ']' {
+				i++
+			}
+			if i < len(s) {
+				i++ // consume ']'
+			}
+		}
+		if i < len(s) {
+			count++
+			i++
+		}
+	}
+	return count
 }

--- a/core/errors.go
+++ b/core/errors.go
@@ -323,6 +323,11 @@ func (r *ErrorRegistry) NewError(namespace string, key ErrorType, err error, arg
 	message := def.Message
 	if len(args) > 0 {
 		message = fmt.Sprintf(def.Message, args...) // Format the message
+	} else if err != nil && strings.Contains(def.Message, "%") {
+		// Convention: callers pass the descriptive detail via err. Bridge it into
+		// any format verb so the template reads e.g.
+		// "Invalid request parameter: a domain is required...".
+		message = fmt.Sprintf(def.Message, err.Error())
 	}
 
 	return &Error{

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -136,6 +136,20 @@ func TestNewErrorFormatVerbFallback(t *testing.T) {
 		assert.Equal(t, "%s and %s", e.Message)
 	})
 
+	t.Run("escaped percent with multiple verbs is left untouched", func(t *testing.T) {
+		RegisterNamespace("pctverb")
+		MustRegisterDefaultErrorMessages("pctverb", map[ErrorType]ErrorDefinition{
+			"MIXED": {Key: "MIXED", Message: "Progress: %d%% and %s"},
+		})
+		MustRegisterErrorCodes("pctverb", map[ErrorType]int{"MIXED": 400})
+
+		e := NewError("pctverb", "MIXED", errors.New("detail"))
+		// %% must NOT collapse here because the template has consuming verbs
+		// that can't be filled — collapsing would produce "Progress: %d% and %s"
+		// which is worse than leaving the original template intact.
+		assert.Equal(t, "Progress: %d%% and %s", e.Message)
+	})
+
 	t.Run("escaped percent plus one verb bridges the single verb", func(t *testing.T) {
 		RegisterNamespace("verbpct")
 		MustRegisterDefaultErrorMessages("verbpct", map[ErrorType]ErrorDefinition{

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -111,4 +111,59 @@ func TestNewErrorFormatVerbFallback(t *testing.T) {
 		e := NewError("format", "INVALID_REQUEST", nil)
 		assert.Equal(t, "Invalid request parameter: %s", e.Message)
 	})
+
+	t.Run("literal percent is not bridged as a verb", func(t *testing.T) {
+		RegisterNamespace("pct")
+		MustRegisterDefaultErrorMessages("pct", map[ErrorType]ErrorDefinition{
+			"PROGRESS": {Key: "PROGRESS", Message: "Processing 50%% complete"},
+		})
+		MustRegisterErrorCodes("pct", map[ErrorType]int{"PROGRESS": 500})
+
+		e := NewError("pct", "PROGRESS", errors.New("any detail"))
+		assert.Equal(t, "Processing 50%% complete", e.Message)
+	})
+
+	t.Run("template with multiple verbs is not bridged", func(t *testing.T) {
+		RegisterNamespace("multi")
+		MustRegisterDefaultErrorMessages("multi", map[ErrorType]ErrorDefinition{
+			"PAIR": {Key: "PAIR", Message: "%s and %s"},
+		})
+		MustRegisterErrorCodes("multi", map[ErrorType]int{"PAIR": 400})
+
+		e := NewError("multi", "PAIR", errors.New("one detail"))
+		assert.Equal(t, "%s and %s", e.Message)
+	})
+
+	t.Run("escaped percent plus one verb bridges the single verb", func(t *testing.T) {
+		RegisterNamespace("verbpct")
+		MustRegisterDefaultErrorMessages("verbpct", map[ErrorType]ErrorDefinition{
+			"VERB_PCT": {Key: "VERB_PCT", Message: "Progress at 50%%: %s"},
+		})
+		MustRegisterErrorCodes("verbpct", map[ErrorType]int{"VERB_PCT": 400})
+
+		e := NewError("verbpct", "VERB_PCT", errors.New("done"))
+		assert.Equal(t, "Progress at 50%: done", e.Message)
+	})
+}
+
+func TestCountFormattedVerbs(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"no verbs", 0},
+		{"plain %% literal", 0},
+		{"%s", 1},
+		{"prefix %s suffix", 1},
+		{"%s and %s", 2},
+		{"Progress at 50%%: %s", 1},
+		{"%d items", 1},
+		{"%-10s", 1},
+		{"%.2f", 1},
+		{"%[2]v", 1},
+		{"trailing %", 0},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, countFormattedVerbs(c.in), "countFormattedVerbs(%q)", c.in)
+	}
 }

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -112,7 +112,7 @@ func TestNewErrorFormatVerbFallback(t *testing.T) {
 		assert.Equal(t, "Invalid request parameter: %s", e.Message)
 	})
 
-	t.Run("literal percent is not bridged as a verb", func(t *testing.T) {
+	t.Run("escaped percent collapses without injecting err", func(t *testing.T) {
 		RegisterNamespace("pct")
 		MustRegisterDefaultErrorMessages("pct", map[ErrorType]ErrorDefinition{
 			"PROGRESS": {Key: "PROGRESS", Message: "Processing 50%% complete"},
@@ -120,7 +120,9 @@ func TestNewErrorFormatVerbFallback(t *testing.T) {
 		MustRegisterErrorCodes("pct", map[ErrorType]int{"PROGRESS": 500})
 
 		e := NewError("pct", "PROGRESS", errors.New("any detail"))
-		assert.Equal(t, "Processing 50%% complete", e.Message)
+		// %% collapses to % and err is NOT injected (no verb to consume it),
+		// so no %!(EXTRA ...) marker appears.
+		assert.Equal(t, "Processing 50% complete", e.Message)
 	})
 
 	t.Run("template with multiple verbs is not bridged", func(t *testing.T) {

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,4 +71,44 @@ func TestError_MarshalJSON(t *testing.T) {
 
 func TestError_ImplementsMarshaler(t *testing.T) {
 	var _ json.Marshaler = (*Error)(nil)
+}
+
+func TestNewErrorFormatVerbFallback(t *testing.T) {
+	RegisterNamespace("format")
+	MustRegisterDefaultErrorMessages("format", map[ErrorType]ErrorDefinition{
+		"INVALID_REQUEST": {Key: "INVALID_REQUEST", Message: "Invalid request parameter: %s"},
+		"PLAIN_MESSAGE":   {Key: "PLAIN_MESSAGE", Message: "Failed to process the file."},
+		"NO_FORMAT":       {Key: "NO_FORMAT", Message: "Account creation failed"},
+	})
+	MustRegisterErrorCodes("format", map[ErrorType]int{
+		"INVALID_REQUEST": 400,
+		"PLAIN_MESSAGE":   500,
+		"NO_FORMAT":       400,
+	})
+
+	t.Run("bridges err into format verb", func(t *testing.T) {
+		e := NewError("format", "INVALID_REQUEST", errors.New("a domain is required"))
+		assert.Equal(t, "Invalid request parameter: a domain is required", e.Message)
+	})
+
+	t.Run("leaves non-verb template untouched with err", func(t *testing.T) {
+		e := NewError("format", "PLAIN_MESSAGE", errors.New("some detail"))
+		// %!(EXTRA...) corruption would appear here if the fallback were naive.
+		assert.Equal(t, "Failed to process the file.", e.Message)
+	})
+
+	t.Run("leaves message untouched when no err and no args", func(t *testing.T) {
+		e := NewError("format", "NO_FORMAT", nil)
+		assert.Equal(t, "Account creation failed", e.Message)
+	})
+
+	t.Run("explicit args take precedence over err", func(t *testing.T) {
+		e := NewError("format", "INVALID_REQUEST", errors.New("ignored"), "explicit value")
+		assert.Equal(t, "Invalid request parameter: explicit value", e.Message)
+	})
+
+	t.Run("template with verb but nil err stays unformatted", func(t *testing.T) {
+		e := NewError("format", "INVALID_REQUEST", nil)
+		assert.Equal(t, "Invalid request parameter: %s", e.Message)
+	})
 }


### PR DESCRIPTION
Bridges the descriptive detail callers pass via `err` into `%s`-templated error messages in `NewError` when no explicit args are given, so templates read e.g. `Invalid request parameter: a domain is required` instead of leaking a literal `%s` into API responses.

Non-verb templates (e.g. `Failed to process the file.`) are left untouched via a format-verb guard; explicit args still take precedence.

---

<!-- kody-pr-summary:start -->
## Summary

This pull request fixes the `NewError` function in the core error package to properly handle format verbs when no explicit arguments are provided but an error is passed.

## Changes

### Core Fix (`core/errors.go`)

Updated the `NewError` function to add a fallback formatting path. Previously, when no explicit arguments were passed to `NewError`, the error message template would remain unformatted (leaving format verbs like `%s` visible in the final message). Now, when:

- No explicit arguments are provided (`len(args) == 0`)
- An error is passed to the function
- The message template contains format verbs (contains `%`)

The error's message text is automatically bridged into the format template. This enables the pattern where callers pass descriptive error details via the `err` parameter, and they get properly formatted into the message template.

### Test Coverage (`core/errors_test.go`)

Added a comprehensive test suite (`TestNewErrorFormatVerbFallback`) that validates:

1. **Error bridging**: When an error is passed and the template has format verbs, the error message is interpolated into the template
2. **No verb corruption**: Templates without format verbs remain unchanged when an error is passed (prevents `%!(EXTRA...)` corruption)
3. **Nil error handling**: Messages without format verbs remain untouched when no error or arguments are provided
4. **Argument precedence**: Explicit arguments still take precedence over the error as the formatting source
5. **Nil error with format verbs**: Templates with format verbs but no error remain unformatted (preserving the template as-is)

## Impact

This change improves the error handling consistency by ensuring that error messages with format verbs are always rendered with meaningful content, either from explicit arguments or from the error's descriptive text, while maintaining backward compatibility for existing behavior.
<!-- kody-pr-summary:end -->