### PR TITLE
feat(observability): add configurable file-watcher pprof dump

### DIFF
--- a/config/observability.go
+++ b/config/observability.go
@@ -30,6 +30,8 @@ var (
 	_ Defaults             = (*MetricsBasicAuthConfig)(nil)
 	_ ConfigSchemaProvider = (*LoggingConfig)(nil)
 	_ Defaults             = (*LoggingConfig)(nil)
+	_ ConfigSchemaProvider = (*DebugConfig)(nil)
+	_ Defaults             = (*DebugConfig)(nil)
 )
 
 type OTLPConfig struct {
@@ -79,6 +81,41 @@ type ObservabilityConfig struct {
 	Tracing     TracingConfig `config:"tracing"`
 	Metrics     MetricsConfig `config:"metrics"`
 	Logging     LoggingConfig `config:"logging"`
+	Debug       DebugConfig   `config:"debug"`
+}
+
+// DebugConfig controls the file-watcher based pprof dump feature. When
+// enabled, the process watches WatchPath for a new file named LandmarkFile
+// and, on detection, captures a full set of runtime pprof profiles and an
+// execution trace into OutputDir. It is a fallback access point for the
+// admin pprof debug tooling that bypasses the HTTP layer entirely.
+type DebugConfig struct {
+	Enabled        bool   `config:"enabled"`
+	WatchPath      string `config:"watch_path"`
+	LandmarkFile   string `config:"landmark_file"`
+	OutputDir      string `config:"output_dir"`
+	ProfileSeconds int    `config:"profile_seconds"`
+}
+
+func (d DebugConfig) Schema() z.ZogSchema {
+	return z.Struct(z.Shape{
+		"Enabled":      z.Bool(),
+		"WatchPath":    z.String(),
+		"LandmarkFile": z.String(),
+		"OutputDir":    z.String(),
+		"ProfileSeconds": z.Int().
+			GT(0, z.Message("profile_seconds must be greater than 0")),
+	})
+}
+
+func (d DebugConfig) Defaults() map[string]any {
+	return map[string]any{
+		"Enabled":        false,
+		"WatchPath":      "",
+		"LandmarkFile":   "portal.pprof",
+		"OutputDir":      "",
+		"ProfileSeconds": 30,
+	}
 }
 
 type TracingConfig struct {
@@ -200,6 +237,7 @@ func (o ObservabilityConfig) Schema() z.ZogSchema {
 		"Enabled":     z.Bool(),
 		"ServiceName": z.String(),
 		"OTLP":        o.OTLP.Schema(),
+		"Debug":       o.Debug.Schema(),
 	}).TestFunc(func(data any, ctx z.Ctx) bool {
 		c, ok := data.(*ObservabilityConfig)
 		if !ok {

--- a/core/internal/service_tests/pprof_test.go
+++ b/core/internal/service_tests/pprof_test.go
@@ -40,6 +40,26 @@ func TestPprofDebugService_DumpProfilesCreatesZip(t *testing.T) {
 	}, coreTesting.WithServiceFactory(core.PPROF_SERVICE, service.NewPprofDebugService))
 }
 
+// TestPprofDebugService_DumpProfilesCancelledNoZip verifies that a cancelled
+// context aborts the dump instead of packaging a truncated capture as success.
+func TestPprofDebugService_DumpProfilesCancelledNoZip(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[core.PprofDebugService](ctx, core.PPROF_SERVICE)
+		require.NotNil(tb, svc)
+
+		out := tb.TempDir()
+		cfg := config.DebugConfig{Enabled: true, OutputDir: out, ProfileSeconds: 1}
+
+		cancelled, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := svc.DumpProfiles(cancelled, cfg)
+		require.Error(tb, err)
+		assert.ErrorIs(tb, err, context.Canceled)
+		assert.Empty(tb, findZip(tb, out), "no zip expected when dump is cancelled")
+	}, coreTesting.WithServiceFactory(core.PPROF_SERVICE, service.NewPprofDebugService))
+}
+
 // TestPprofDebugService_WatcherTriggersDump verifies the end-to-end flow: when
 // the file watcher detects the landmark file it dumps the pprof data and
 // consumes the landmark so a new file re-arms the watcher.

--- a/core/internal/service_tests/pprof_test.go
+++ b/core/internal/service_tests/pprof_test.go
@@ -1,0 +1,127 @@
+package service_tests
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/portal/config"
+	"go.lumeweb.com/portal/core"
+	coreTesting "go.lumeweb.com/portal/core/testing"
+	"go.lumeweb.com/portal/service"
+)
+
+// TestPprofDebugService_DumpProfilesCreatesZip verifies that DumpProfiles
+// packages every pprof profile plus the trace into a single zip file.
+func TestPprofDebugService_DumpProfilesCreatesZip(t *testing.T) {
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		svc := core.GetService[core.PprofDebugService](ctx, core.PPROF_SERVICE)
+		require.NotNil(tb, svc)
+
+		out := tb.TempDir()
+		cfg := config.DebugConfig{Enabled: true, OutputDir: out, ProfileSeconds: 1}
+
+		require.NoError(tb, svc.DumpProfiles(context.Background(), cfg))
+
+		zipPath := findZip(tb, out)
+		require.NotEmpty(tb, zipPath, "expected a zip file in output dir")
+
+		entries := zipEntries(tb, zipPath)
+		for _, want := range []string{"cpu-", "trace-", "heap-", "allocs-", "goroutine-", "threadcreate-", "block-", "mutex-"} {
+			assert.True(tb, hasPrefix(entries, want), "expected zip entry with prefix %q, got %v", want, entries)
+		}
+	}, coreTesting.WithServiceFactory(core.PPROF_SERVICE, service.NewPprofDebugService))
+}
+
+// TestPprofDebugService_WatcherTriggersDump verifies the end-to-end flow: when
+// the file watcher detects the landmark file it dumps the pprof data and
+// consumes the landmark so a new file re-arms the watcher.
+func TestPprofDebugService_WatcherTriggersDump(t *testing.T) {
+	watch := t.TempDir()
+	out := t.TempDir()
+
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		marker := filepath.Join(watch, "portal.pprof")
+		require.NoError(tb, os.WriteFile(marker, []byte("trigger"), 0o644))
+
+		require.Eventually(tb, func() bool {
+			return findZip(tb, out) != ""
+		}, 20*time.Second, 200*time.Millisecond)
+
+		_, err := os.Stat(marker)
+		assert.True(tb, os.IsNotExist(err), "landmark file should be removed after dump")
+	},
+		coreTesting.WithServiceFactory(core.PPROF_SERVICE, service.NewPprofDebugService),
+		coreTesting.WithConfig("core.observability.debug.enabled", true),
+		coreTesting.WithConfig("core.observability.debug.watch_path", watch),
+		coreTesting.WithConfig("core.observability.debug.output_dir", out),
+		coreTesting.WithConfig("core.observability.debug.landmark_file", "portal.pprof"),
+		coreTesting.WithConfig("core.observability.debug.profile_seconds", 1),
+	)
+}
+
+// TestPprofDebugService_DisabledDoesNotStartWatcher verifies that with the
+// feature disabled, dropping a landmark file does not produce a dump.
+func TestPprofDebugService_DisabledDoesNotStartWatcher(t *testing.T) {
+	watch := t.TempDir()
+	out := t.TempDir()
+
+	coreTesting.RunTestCase(t, func(tb coreTesting.TB, ctx coreTesting.TestContext) {
+		marker := filepath.Join(watch, "portal.pprof")
+		require.NoError(tb, os.WriteFile(marker, []byte("trigger"), 0o644))
+
+		// Give any (incorrectly started) watcher a window to act; no dump
+		// should appear while the feature is disabled.
+		time.Sleep(2 * time.Second)
+		assert.Empty(tb, findZip(tb, out), "no dump expected when disabled")
+	},
+		coreTesting.WithServiceFactory(core.PPROF_SERVICE, service.NewPprofDebugService),
+		coreTesting.WithConfig("core.observability.debug.enabled", false),
+		coreTesting.WithConfig("core.observability.debug.watch_path", watch),
+		coreTesting.WithConfig("core.observability.debug.output_dir", out),
+		coreTesting.WithConfig("core.observability.debug.landmark_file", "portal.pprof"),
+	)
+}
+
+func findZip(tb coreTesting.TB, dir string) string {
+	tb.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.zip"))
+	require.NoError(tb, err)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[0]
+}
+
+func zipEntries(tb coreTesting.TB, zipPath string) []string {
+	tb.Helper()
+	r, err := zip.OpenReader(zipPath)
+	require.NoError(tb, err)
+	defer r.Close()
+
+	names := make([]string, 0, len(r.File))
+	for _, f := range r.File {
+		names = append(names, f.Name)
+		rc, err := f.Open()
+		require.NoError(tb, err)
+		_, _ = io.Copy(io.Discard, rc)
+		rc.Close()
+	}
+	return names
+}
+
+func hasPrefix(entries []string, prefix string) bool {
+	for _, e := range entries {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/internal/service_tests/pprof_test.go
+++ b/core/internal/service_tests/pprof_test.go
@@ -57,6 +57,11 @@ func TestPprofDebugService_DumpProfilesCancelledNoZip(t *testing.T) {
 		require.Error(tb, err)
 		assert.ErrorIs(tb, err, context.Canceled)
 		assert.Empty(tb, findZip(tb, out), "no zip expected when dump is cancelled")
+
+		// No partial staging dir should leak behind on the cancelled path.
+		leftovers, derr := filepath.Glob(filepath.Join(out, "portal-pprof-*"))
+		require.NoError(tb, derr)
+		assert.Empty(tb, leftovers, "no partial staging dir expected when dump is cancelled")
 	}, coreTesting.WithServiceFactory(core.PPROF_SERVICE, service.NewPprofDebugService))
 }
 

--- a/core/pprof.go
+++ b/core/pprof.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"context"
+
+	"go.lumeweb.com/portal/config"
+)
+
+// PPROF_SERVICE identifies the service that provides the file-watcher based
+// pprof dump feature described in config.ObservabilityConfig.Debug.
+const PPROF_SERVICE = "pprof"
+
+// PprofDebugService provides a fallback access point to the admin pprof debug
+// tooling that bypasses the HTTP layer. When the file watcher detects a
+// landmark file in the configured watch path, it dumps a full set of runtime
+// pprof profiles and an execution trace to a predefined output directory.
+type PprofDebugService interface {
+	Service
+
+	// DumpProfiles captures a full set of pprof profiles (CPU, heap, allocs,
+	// goroutine, threadcreate, block, mutex) plus an execution trace, packaged
+	// into a single zip file placed in cfg.OutputDir.
+	DumpProfiles(ctx context.Context, cfg config.DebugConfig) error
+}

--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/dunglas/httpsfv v1.1.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect

--- a/service/pprof.go
+++ b/service/pprof.go
@@ -1,0 +1,319 @@
+package service
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"go.lumeweb.com/portal/config"
+	"go.lumeweb.com/portal/core"
+	"go.uber.org/zap"
+)
+
+var _ core.PprofDebugService = (*PprofDebugServiceDefault)(nil)
+
+func init() {
+	core.RegisterService(core.ServiceInfo{
+		ID:      core.PPROF_SERVICE,
+		Factory: NewPprofDebugService,
+	})
+}
+
+// PprofDebugServiceDefault implements the file-watcher based pprof dump
+// feature. It watches a configured directory for a landmark file and, when
+// one appears, captures a full set of runtime pprof profiles and an execution
+// trace to a predefined output directory. It serves as a fallback access
+// point to the admin pprof debug tooling that does not depend on the HTTP
+// layer.
+type PprofDebugServiceDefault struct {
+	*core.BaseComponent
+
+	watcher *fsnotify.Watcher
+	mu      sync.Mutex
+}
+
+func NewPprofDebugService() (core.Service, []core.ContextBuilderOption, error) {
+	svc := &PprofDebugServiceDefault{}
+
+	opts := core.ContextOptions(
+		core.ContextWithStartupFunc(svc.start),
+		core.ContextWithExitFunc(func(ctx core.Context) error {
+			if svc.watcher != nil {
+				return svc.watcher.Close()
+			}
+			return nil
+		}),
+	)
+
+	return svc, opts, nil
+}
+
+func (p *PprofDebugServiceDefault) ID() string {
+	return core.PPROF_SERVICE
+}
+
+// DumpProfiles captures a full set of pprof profiles and an execution trace,
+// packaged into a single zip file in cfg.OutputDir.
+func (p *PprofDebugServiceDefault) DumpProfiles(ctx context.Context, cfg config.DebugConfig) error {
+	return dumpProfiles(p.Context(), cfg)
+}
+
+// start launches the fsnotify watcher when the debug feature is enabled.
+func (p *PprofDebugServiceDefault) start(ctx core.Context) error {
+	cfg := ctx.Config().Config().Core.Observability.Debug
+	if !cfg.Enabled {
+		return nil
+	}
+
+	watchPath := resolveWatchPath(cfg)
+	if err := os.MkdirAll(watchPath, 0o755); err != nil {
+		return err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	if err := watcher.Add(watchPath); err != nil {
+		watcher.Close()
+		return err
+	}
+	p.watcher = watcher
+
+	p.Logger().Info("pprof debug watcher started",
+		zap.String("watch_path", watchPath),
+		zap.String("landmark_file", cfg.LandmarkFile))
+
+	go p.watchLoop(cfg)
+
+	return nil
+}
+
+// watchLoop consumes filesystem events until the watcher is closed.
+func (p *PprofDebugServiceDefault) watchLoop(cfg config.DebugConfig) {
+	marker := filepath.Join(resolveWatchPath(cfg), cfg.LandmarkFile)
+
+	for {
+		select {
+		case event, ok := <-p.watcher.Events:
+			if !ok {
+				return
+			}
+			if event.Name == marker && event.Op&fsnotify.Create != 0 {
+				p.trigger(cfg)
+			}
+		case err, ok := <-p.watcher.Errors:
+			if !ok {
+				return
+			}
+			p.Logger().Error("pprof debug watcher error", zap.Error(err))
+		}
+	}
+}
+
+// trigger runs a single pprof dump, serializing concurrent triggers, then
+// removes the landmark file so a freshly dropped file re-arms the watcher.
+func (p *PprofDebugServiceDefault) trigger(cfg config.DebugConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.Logger().Info("landmark file detected, dumping pprof data",
+		zap.String("landmark_file", cfg.LandmarkFile))
+
+	if err := p.DumpProfiles(p.Context().GetContext(), cfg); err != nil {
+		p.Logger().Error("failed to dump pprof data", zap.Error(err))
+	}
+
+	// Consume the landmark so repeated dumps require a new file.
+	marker := filepath.Join(resolveWatchPath(cfg), cfg.LandmarkFile)
+	if err := os.Remove(marker); err != nil && !os.IsNotExist(err) {
+		p.Logger().Warn("failed to remove landmark file",
+			zap.String("path", marker), zap.Error(err))
+	}
+}
+
+// dumpProfiles enables full mutex/block capture ("set calls to 1"), samples
+// the CPU and execution trace for ProfileSeconds, writes the static profiles
+// to a per-dump directory, then packages everything into a single zip file
+// which is the sole artifact left in the output directory.
+func dumpProfiles(ctx core.Context, cfg config.DebugConfig) error {
+	dir := resolveOutputDir(cfg)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	createdAt := time.Now().UTC().Format("20060102-150405")
+	stagingDir := filepath.Join(dir, "portal-pprof-"+createdAt)
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		return err
+	}
+
+	// Capture all mutex and blocking events rather than a statistical sample.
+	runtime.SetMutexProfileFraction(1)
+	runtime.SetBlockProfileRate(1)
+
+	secs := cfg.ProfileSeconds
+	if secs <= 0 {
+		secs = 30
+	}
+	window := time.Duration(secs) * time.Second
+
+	// Time-windowed CPU profile and execution trace.
+	captureWindow(ctx, filepath.Join(stagingDir, fmt.Sprintf("cpu-%s.pprof", createdAt)), window,
+		func(w io.Writer) (captureStopper, error) {
+			if err := pprof.StartCPUProfile(w); err != nil {
+				return nil, err
+			}
+			return pprof.StopCPUProfile, nil
+		})
+	captureWindow(ctx, filepath.Join(stagingDir, fmt.Sprintf("trace-%s.out", createdAt)), window,
+		func(w io.Writer) (captureStopper, error) {
+			if err := trace.Start(w); err != nil {
+				return nil, err
+			}
+			return trace.Stop, nil
+		})
+
+	// Static profile snapshots.
+	for _, name := range []string{"heap", "allocs", "goroutine", "threadcreate", "block", "mutex"} {
+		writeProfile(ctx, stagingDir, name, createdAt)
+	}
+
+	// Package the staged files into a single zip and remove the loose files.
+	zipPath := filepath.Join(dir, "portal-pprof-"+createdAt+".zip")
+	if err := zipDir(stagingDir, zipPath); err != nil {
+		ctx.Logger().Error("failed to zip pprof data", zap.Error(err))
+		return err
+	}
+	if err := os.RemoveAll(stagingDir); err != nil {
+		ctx.Logger().Warn("failed to remove staging directory",
+			zap.String("path", stagingDir), zap.Error(err))
+	}
+
+	ctx.Logger().Info("pprof data dumped",
+		zap.String("zip_path", zipPath))
+	return nil
+}
+
+// captureStopper signals the end of a capture started by a CaptureStarter.
+type captureStopper func()
+
+// CaptureStarter begins a time-windowed capture writing to the given writer
+// and returns the function that stops the capture.
+type CaptureStarter func(w io.Writer) (stop captureStopper, err error)
+
+// captureWindow writes a time-windowed sample (CPU profile or execution
+// trace) to the given file. begin starts the capture and must return a stop
+// function; the capture runs for the full window before being stopped.
+func captureWindow(ctx core.Context, path string, window time.Duration, begin CaptureStarter) {
+	f, err := os.Create(path)
+	if err != nil {
+		ctx.Logger().Error("failed to create capture file",
+			zap.String("file", path), zap.Error(err))
+		return
+	}
+	defer f.Close()
+
+	stop, err := begin(f)
+	if err != nil {
+		ctx.Logger().Error("failed to start capture",
+			zap.String("file", path), zap.Error(err))
+		return
+	}
+
+	time.Sleep(window)
+	stop()
+}
+
+// writeProfile writes a single named runtime profile to a directory.
+func writeProfile(ctx core.Context, dir, name, createdAt string) {
+	profile := pprof.Lookup(name)
+	if profile == nil {
+		ctx.Logger().Debug("profile not available, skipping",
+			zap.String("profile", name))
+		return
+	}
+
+	f, err := os.Create(filepath.Join(dir, fmt.Sprintf("%s-%s.pprof", name, createdAt)))
+	if err != nil {
+		ctx.Logger().Error("failed to create profile file",
+			zap.String("profile", name), zap.Error(err))
+		return
+	}
+	defer f.Close()
+
+	if err := profile.WriteTo(f, 0); err != nil {
+		ctx.Logger().Error("failed to write profile",
+			zap.String("profile", name), zap.Error(err))
+	}
+}
+
+// zipDir archives all files in srcDir into a new zip file at zipPath.
+func zipDir(srcDir, zipPath string) error {
+	out, err := os.Create(zipPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	zw := zip.NewWriter(out)
+	defer zw.Close()
+
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = rel
+		header.Method = zip.Deflate
+
+		w, err := zw.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		_, err = io.Copy(w, f)
+		return err
+	})
+}
+
+func resolveWatchPath(cfg config.DebugConfig) string {
+	if cfg.WatchPath != "" {
+		return cfg.WatchPath
+	}
+	return os.TempDir()
+}
+
+func resolveOutputDir(cfg config.DebugConfig) string {
+	if cfg.OutputDir != "" {
+		return cfg.OutputDir
+	}
+	return filepath.Join(os.TempDir(), "portal-pprof")
+}

--- a/service/pprof.go
+++ b/service/pprof.go
@@ -64,7 +64,7 @@ func (p *PprofDebugServiceDefault) ID() string {
 // DumpProfiles captures a full set of pprof profiles and an execution trace,
 // packaged into a single zip file in cfg.OutputDir.
 func (p *PprofDebugServiceDefault) DumpProfiles(ctx context.Context, cfg config.DebugConfig) error {
-	return dumpProfiles(p.Context(), cfg)
+	return dumpProfiles(ctx, p.Logger(), cfg)
 }
 
 // start launches the fsnotify watcher when the debug feature is enabled.
@@ -145,7 +145,7 @@ func (p *PprofDebugServiceDefault) trigger(cfg config.DebugConfig) {
 // the CPU and execution trace for ProfileSeconds, writes the static profiles
 // to a per-dump directory, then packages everything into a single zip file
 // which is the sole artifact left in the output directory.
-func dumpProfiles(ctx core.Context, cfg config.DebugConfig) error {
+func dumpProfiles(ctx context.Context, log *core.Logger, cfg config.DebugConfig) error {
 	dir := resolveOutputDir(cfg)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
@@ -158,8 +158,12 @@ func dumpProfiles(ctx core.Context, cfg config.DebugConfig) error {
 	}
 
 	// Capture all mutex and blocking events rather than a statistical sample.
+	// These are process-global, so reset them once the dump completes so the
+	// sustained overhead is not carried for the process lifetime.
 	runtime.SetMutexProfileFraction(1)
 	runtime.SetBlockProfileRate(1)
+	defer runtime.SetMutexProfileFraction(0)
+	defer runtime.SetBlockProfileRate(0)
 
 	secs := cfg.ProfileSeconds
 	if secs <= 0 {
@@ -168,14 +172,14 @@ func dumpProfiles(ctx core.Context, cfg config.DebugConfig) error {
 	window := time.Duration(secs) * time.Second
 
 	// Time-windowed CPU profile and execution trace.
-	captureWindow(ctx, filepath.Join(stagingDir, fmt.Sprintf("cpu-%s.pprof", createdAt)), window,
+	captureWindow(ctx, log, filepath.Join(stagingDir, fmt.Sprintf("cpu-%s.pprof", createdAt)), window,
 		func(w io.Writer) (captureStopper, error) {
 			if err := pprof.StartCPUProfile(w); err != nil {
 				return nil, err
 			}
 			return pprof.StopCPUProfile, nil
 		})
-	captureWindow(ctx, filepath.Join(stagingDir, fmt.Sprintf("trace-%s.out", createdAt)), window,
+	captureWindow(ctx, log, filepath.Join(stagingDir, fmt.Sprintf("trace-%s.out", createdAt)), window,
 		func(w io.Writer) (captureStopper, error) {
 			if err := trace.Start(w); err != nil {
 				return nil, err
@@ -185,21 +189,21 @@ func dumpProfiles(ctx core.Context, cfg config.DebugConfig) error {
 
 	// Static profile snapshots.
 	for _, name := range []string{"heap", "allocs", "goroutine", "threadcreate", "block", "mutex"} {
-		writeProfile(ctx, stagingDir, name, createdAt)
+		writeProfile(log, stagingDir, name, createdAt)
 	}
 
 	// Package the staged files into a single zip and remove the loose files.
 	zipPath := filepath.Join(dir, "portal-pprof-"+createdAt+".zip")
 	if err := zipDir(stagingDir, zipPath); err != nil {
-		ctx.Logger().Error("failed to zip pprof data", zap.Error(err))
+		log.Error("failed to zip pprof data", zap.Error(err))
 		return err
 	}
 	if err := os.RemoveAll(stagingDir); err != nil {
-		ctx.Logger().Warn("failed to remove staging directory",
+		log.Warn("failed to remove staging directory",
 			zap.String("path", stagingDir), zap.Error(err))
 	}
 
-	ctx.Logger().Info("pprof data dumped",
+	log.Info("pprof data dumped",
 		zap.String("zip_path", zipPath))
 	return nil
 }
@@ -213,11 +217,12 @@ type CaptureStarter func(w io.Writer) (stop captureStopper, err error)
 
 // captureWindow writes a time-windowed sample (CPU profile or execution
 // trace) to the given file. begin starts the capture and must return a stop
-// function; the capture runs for the full window before being stopped.
-func captureWindow(ctx core.Context, path string, window time.Duration, begin CaptureStarter) {
+// function; the capture runs for the full window before being stopped, or
+// ends early if ctx is cancelled.
+func captureWindow(ctx context.Context, log *core.Logger, path string, window time.Duration, begin CaptureStarter) {
 	f, err := os.Create(path)
 	if err != nil {
-		ctx.Logger().Error("failed to create capture file",
+		log.Error("failed to create capture file",
 			zap.String("file", path), zap.Error(err))
 		return
 	}
@@ -225,34 +230,37 @@ func captureWindow(ctx core.Context, path string, window time.Duration, begin Ca
 
 	stop, err := begin(f)
 	if err != nil {
-		ctx.Logger().Error("failed to start capture",
+		log.Error("failed to start capture",
 			zap.String("file", path), zap.Error(err))
 		return
 	}
 
-	time.Sleep(window)
+	select {
+	case <-ctx.Done():
+	case <-time.After(window):
+	}
 	stop()
 }
 
 // writeProfile writes a single named runtime profile to a directory.
-func writeProfile(ctx core.Context, dir, name, createdAt string) {
+func writeProfile(log *core.Logger, dir, name, createdAt string) {
 	profile := pprof.Lookup(name)
 	if profile == nil {
-		ctx.Logger().Debug("profile not available, skipping",
+		log.Debug("profile not available, skipping",
 			zap.String("profile", name))
 		return
 	}
 
 	f, err := os.Create(filepath.Join(dir, fmt.Sprintf("%s-%s.pprof", name, createdAt)))
 	if err != nil {
-		ctx.Logger().Error("failed to create profile file",
+		log.Error("failed to create profile file",
 			zap.String("profile", name), zap.Error(err))
 		return
 	}
 	defer f.Close()
 
 	if err := profile.WriteTo(f, 0); err != nil {
-		ctx.Logger().Error("failed to write profile",
+		log.Error("failed to write profile",
 			zap.String("profile", name), zap.Error(err))
 	}
 }

--- a/service/pprof.go
+++ b/service/pprof.go
@@ -157,10 +157,16 @@ func dumpProfiles(ctx context.Context, log *core.Logger, cfg config.DebugConfig)
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return err
 	}
+	// Remove the staging dir on every return path (including a cancelled
+	// dump) so a partial capture never leaks into the output directory.
+	defer os.RemoveAll(stagingDir)
 
 	// Capture all mutex and blocking events rather than a statistical sample.
-	// These are process-global, so reset them once the dump completes so the
-	// sustained overhead is not carried for the process lifetime.
+	// These are process-global switches, so reset them once the dump completes
+	// to avoid carrying sustained overhead for the process lifetime. Note: Go
+	// exposes no reset API for the block/mutex accumulators, so consecutive
+	// dumps may carry forward previously-reported contention events; this is
+	// accepted for an opt-in debug fallback.
 	runtime.SetMutexProfileFraction(1)
 	runtime.SetBlockProfileRate(1)
 	defer runtime.SetMutexProfileFraction(0)
@@ -204,10 +210,6 @@ func dumpProfiles(ctx context.Context, log *core.Logger, cfg config.DebugConfig)
 	if err := zipDir(stagingDir, zipPath); err != nil {
 		log.Error("failed to zip pprof data", zap.Error(err))
 		return err
-	}
-	if err := os.RemoveAll(stagingDir); err != nil {
-		log.Warn("failed to remove staging directory",
-			zap.String("path", stagingDir), zap.Error(err))
 	}
 
 	log.Info("pprof data dumped",

--- a/service/pprof.go
+++ b/service/pprof.go
@@ -3,6 +3,7 @@ package service
 import (
 	"archive/zip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -171,21 +172,27 @@ func dumpProfiles(ctx context.Context, log *core.Logger, cfg config.DebugConfig)
 	}
 	window := time.Duration(secs) * time.Second
 
-	// Time-windowed CPU profile and execution trace.
-	captureWindow(ctx, log, filepath.Join(stagingDir, fmt.Sprintf("cpu-%s.pprof", createdAt)), window,
+	// Time-windowed CPU profile and execution trace. Abort the whole dump if
+	// the context is cancelled so a truncated capture is never packaged and
+	// reported as a successful full dump.
+	if err := captureWindow(ctx, log, filepath.Join(stagingDir, fmt.Sprintf("cpu-%s.pprof", createdAt)), window,
 		func(w io.Writer) (captureStopper, error) {
 			if err := pprof.StartCPUProfile(w); err != nil {
 				return nil, err
 			}
 			return pprof.StopCPUProfile, nil
-		})
-	captureWindow(ctx, log, filepath.Join(stagingDir, fmt.Sprintf("trace-%s.out", createdAt)), window,
+		}); isCancelled(err) {
+		return err
+	}
+	if err := captureWindow(ctx, log, filepath.Join(stagingDir, fmt.Sprintf("trace-%s.out", createdAt)), window,
 		func(w io.Writer) (captureStopper, error) {
 			if err := trace.Start(w); err != nil {
 				return nil, err
 			}
 			return trace.Stop, nil
-		})
+		}); isCancelled(err) {
+		return err
+	}
 
 	// Static profile snapshots.
 	for _, name := range []string{"heap", "allocs", "goroutine", "threadcreate", "block", "mutex"} {
@@ -217,14 +224,14 @@ type CaptureStarter func(w io.Writer) (stop captureStopper, err error)
 
 // captureWindow writes a time-windowed sample (CPU profile or execution
 // trace) to the given file. begin starts the capture and must return a stop
-// function; the capture runs for the full window before being stopped, or
-// ends early if ctx is cancelled.
-func captureWindow(ctx context.Context, log *core.Logger, path string, window time.Duration, begin CaptureStarter) {
+// function; the capture runs for the full window before being stopped, or is
+// cut short with ctx.Err() if ctx is cancelled.
+func captureWindow(ctx context.Context, log *core.Logger, path string, window time.Duration, begin CaptureStarter) error {
 	f, err := os.Create(path)
 	if err != nil {
 		log.Error("failed to create capture file",
 			zap.String("file", path), zap.Error(err))
-		return
+		return err
 	}
 	defer f.Close()
 
@@ -232,14 +239,23 @@ func captureWindow(ctx context.Context, log *core.Logger, path string, window ti
 	if err != nil {
 		log.Error("failed to start capture",
 			zap.String("file", path), zap.Error(err))
-		return
+		return err
 	}
 
 	select {
 	case <-ctx.Done():
+		stop()
+		return ctx.Err()
 	case <-time.After(window):
 	}
 	stop()
+	return nil
+}
+
+// isCancelled reports whether err indicates context cancellation or a
+// deadline, as opposed to a best-effort capture setup failure.
+func isCancelled(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 // writeProfile writes a single named runtime profile to a directory.


### PR DESCRIPTION
Adds a file-watcher based pprof dump service under `observability.debug`. When enabled it watches a directory for a landmark file and, on detection, captures CPU, trace, heap, allocs, goroutine, threadcreate, block, and mutex profiles into a single zip in a predefined output directory.

Provides a fallback access point to admin pprof debug tooling that bypasses the HTTP layer.

```yaml
observability:
  debug:
    enabled: true
    watch_path: /tmp/portal-pprof-watch
    landmark_file: portal.pprof
    output_dir: /tmp/portal-pprof
    profile_seconds: 30
```

---

<!-- kody-pr-summary:start -->
This pull request adds a configurable file-watcher based pprof debug workflow to the portal application. The feature provides a fallback method for capturing runtime debugging data without relying on the HTTP layer.

**Key changes:**

1. **New configuration options** in `config/observability.go`:
   - Added a `DebugConfig` structure with settings for enabling/disabling the feature, specifying the watch directory, landmark file name, output directory, and profile capture duration
   - Added validation requiring `profile_seconds` to be greater than zero
   - Set sensible defaults: feature disabled by default, landmark file "portal.pprof", and 30-second capture window
   - Integrated the debug configuration into the main observability schema

2. **New service interface** in `core/pprof.go`:
   - Defined the `PprofDebugService` interface with a `DumpProfiles` method that captures all pprof profiles packaged as a zip file

3. **Service implementation** in `service/pprof.go`:
   - Implemented a file watcher that monitors a configured directory for a landmark file
   - When the landmark file appears, automatically triggers a comprehensive debug dump
   - Captures CPU profile, execution trace, and six static runtime profiles (heap, allocs, goroutine, threadcreate, block, mutex)
   - Packages all captured data into a single zip file in the output directory
   - Removes the landmark file after processing, requiring a new file to trigger subsequent dumps
   - Handles concurrent trigger serialization and includes proper error logging

4. **Comprehensive test coverage** in `core/internal/service_tests/pprof_test.go`:
   - Verifies the zip file contains all expected profile entries
   - Tests the end-to-end watcher trigger flow with landmark file removal verification
   - Confirms the feature does not activate when disabled in configuration

This feature provides an operational fallback for debugging production issues when the HTTP-based pprof endpoint may not be accessible, allowing administrators to trigger debug dumps by placing a file in a designated location.
<!-- kody-pr-summary:end -->